### PR TITLE
Fix cadence-web container to exit on SIGTERM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ENV NPM_CONFIG_PRODUCTION=true
 COPY package*.json ./
 RUN npm install --production
 
+RUN wget https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64.deb
+RUN dpkg -i dumb-init_*.deb
+
 # Bundle app source
 COPY . .
 
@@ -16,4 +19,4 @@ COPY . .
 RUN npm run build-production
 
 EXPOSE 8088
-CMD [ "node", "server.js" ]
+CMD [ "dumb-init", "node", "server.js" ]


### PR DESCRIPTION
The cadence web container was fixed so that it properly handles the
SIGTERM signal. It used to wait until a timeout occurred and then it
would be forceable killed with SIGKILL.

This was tested locally to verify that the cadence web container was
gracefully terminated with SIGTERM.