### PR TITLE
CDNC-5568 persist viewing format into localstorage

### DIFF
--- a/client/containers/workflow-history/component.vue
+++ b/client/containers/workflow-history/component.vue
@@ -124,6 +124,13 @@ export default {
     }
   },
   computed: {
+    selectedViewingFormat() {
+      return (
+        this.format ||
+        localStorage.getItem(`${this.domain}:history-viewing-format`) ||
+        'compact'
+      );
+    },
     exportFilename() {
       return `${this.workflowId.replace(/[\\~#%&*{}/:<>?|"-]/g, ' ')} - ${
         this.runId
@@ -150,7 +157,7 @@ export default {
         }, {});
     },
     isGrid() {
-      return this.format === 'grid';
+      return this.selectedViewingFormat === 'grid';
     },
     selectedTimelineEvent() {
       return this.timelineEvents.find(te => te.eventIds.includes(this.eventId));
@@ -229,6 +236,11 @@ export default {
       this.$router.replace({
         query: { ...this.$route.query, format },
       });
+
+      if (typeof format === 'string') {
+        localStorage.setItem(`${this.domain}:history-viewing-format`, format);
+      }
+
       setTimeout(() => this.scrollEventIntoView(this.eventId), 100);
     },
     setCompactDetails(compact) {
@@ -354,21 +366,21 @@ export default {
             href="#"
             class="compact"
             @click.prevent="setFormat('compact')"
-            :class="format === 'compact' ? 'active' : ''"
+            :class="selectedViewingFormat === 'compact' ? 'active' : ''"
             >Compact</a
           >
           <a
             href="#"
             class="grid"
             @click.prevent="setFormat('grid')"
-            :class="format === 'grid' ? 'active' : ''"
+            :class="selectedViewingFormat === 'grid' ? 'active' : ''"
             >Grid</a
           >
           <a
             href="#"
             class="json"
             @click.prevent="setFormat('json')"
-            :class="format === 'json' ? 'active' : ''"
+            :class="selectedViewingFormat === 'json' ? 'active' : ''"
             >JSON</a
           >
         </div>
@@ -433,7 +445,7 @@ export default {
         <section v-snapscroll class="results" ref="results">
           <div
             class="table"
-            v-if="format === 'grid' && showTable"
+            v-if="selectedViewingFormat === 'grid' && showTable"
             :class="{ compact: compactDetails }"
           >
             <div class="thead">
@@ -542,13 +554,15 @@ export default {
           <prism
             class="json"
             language="json"
-            v-if="format === 'json' && events.length < 90"
+            v-if="selectedViewingFormat === 'json' && events.length < 90"
             >{{ JSON.stringify(events, null, 2) }}</prism
           >
-          <pre class="json" v-if="format === 'json' && events.length >= 90">{{
-            JSON.stringify(events, null, 2)
-          }}</pre>
-          <div class="compact-view" v-if="format === 'compact'">
+          <pre
+            class="json"
+            v-if="selectedViewingFormat === 'json' && events.length >= 90"
+            >{{ JSON.stringify(events, null, 2) }}</pre
+          >
+          <div class="compact-view" v-if="selectedViewingFormat === 'compact'">
             <RecycleScroller
               class="scroller-compact"
               key-field="id"

--- a/client/main.js
+++ b/client/main.js
@@ -194,7 +194,7 @@ const routeOpts = {
               clusterName: params.clusterName,
               domain: params.domain,
               eventId: Number(query.eventId) || undefined,
-              format: query.format || 'compact',
+              format: query.format,
               runId: params.runId,
               showGraph: Boolean(query.showGraph) === true,
               graphView: query.graphView,

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -509,6 +509,22 @@ describe('Workflow', () => {
 
       return [historyEl, scenario];
     }
+    it('should pick default view format from localstorage if exists ', async function test() {
+      localStorage.setItem('ci-test:history-viewing-format', 'json');
+      const [historyEl] = await historyTest(this.test);
+
+      historyEl
+        .querySelector('.view-formats .json')
+        .should.have.class('active');
+    });
+    it('should set default view format to compact if no persisted selection in localstorage', async function test() {
+      localStorage.removeItem('ci-test:history-viewing-format');
+      const [historyEl] = await historyTest(this.test);
+
+      historyEl
+        .querySelector('.view-formats .compact')
+        .should.have.class('active');
+    });
 
     it('should allow the user to change the view format', async function test() {
       const [historyEl, scenario] = await historyTest(this.test);


### PR DESCRIPTION
Users have different preferences for the default viewing format. so we decided to persist the last selected viewing format for each user per domain and make it the default tab for them.

The persisted tab changes on each change of viewing format, so it would use the last value.