### PR TITLE
Check dependent PR

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,7 +2,7 @@ name: Dependent Issues
 
 on:
   pull_request_target:
-  branches:
+    branches:
       - release/4.0.0
       - master
     types:

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,44 @@
+name: Dependent Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+      # Makes sure we always add status check for PRs. Useful only if
+      # this action is required to pass before merging. Otherwise, it
+      # can be removed.
+      - synchronize
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          # (Required) The token to use to make API calls to GitHub.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+        with:
+          # (Optional) The label to use to mark dependent issues
+          label: dependent
+
+          # (Optional) A comma-separated list of keywords. Default
+          # "depends on, blocked by"
+          keywords: depends on, blocked by
+
+          # (Optional) A custom comment body. It supports `{{ dependencies }}` token.
+          comment: >
+            This PR/issue depends on:
+
+            {{ dependencies }}
+
+            PRs are only allowed to get merged after its dependecies.

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,13 +1,10 @@
 name: Dependent Issues
 
 on:
-  issues:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
   pull_request_target:
+  branches:
+      - release/4.0.0
+      - master
     types:
       - opened
       - edited


### PR DESCRIPTION
### Summary
Github action step to define PR dependencies and block the merging until the PRs it depend on is merged

test
depends on #657 

blocked by https://github.com/uber/cadence-web/pull/657