### PR TITLE
Workflow and domain page responsiveness

### DIFF
--- a/src/views/domain-page/domain-page-header-info/domain-page-header-info.styles.ts
+++ b/src/views/domain-page/domain-page-header-info/domain-page-header-info.styles.ts
@@ -3,7 +3,12 @@ import { styled as createStyled } from 'baseui';
 export const styled = {
   DomainDetailsContainer: createStyled('div', ({ $theme }) => ({
     display: 'flex',
-    flexDirection: 'row',
+    flexDirection: 'column',
+    flexWrap: 'wrap',
     columnGap: $theme.sizing.scale850,
+    rowGap: $theme.sizing.scale500,
+    [$theme.mediaQuery.medium]: {
+      flexDirection: 'row',
+    },
   })),
 };

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
@@ -24,12 +24,23 @@ const cssStylesObj = {
     display: 'flex',
     flexDirection: 'column',
   },
-  timelineEventHeader: {
+  timelineEventHeader: (theme) => ({
     display: 'flex',
     alignItems: 'center',
-    gap: '16px',
-    padding: '12px 0',
-  },
+    gap: theme.sizing.scale600,
+    padding: `${theme.sizing.scale500} 0`,
+  }),
+  timelineEventLableAndTime: (theme) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 0,
+    [theme.mediaQuery.medium]: {
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: theme.sizing.scale200,
+    },
+  }),
   timelineEventsLabel: (theme) => ({
     ...theme.typography.LabelLarge,
     whiteSpace: 'nowrap',

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
@@ -30,7 +30,7 @@ const cssStylesObj = {
     gap: theme.sizing.scale600,
     padding: `${theme.sizing.scale500} 0`,
   }),
-  timelineEventLableAndTime: (theme) => ({
+  timelineEventLabelAndTime: (theme) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: 0,

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
@@ -34,6 +34,7 @@ const cssStylesObj = {
     display: 'flex',
     flexDirection: 'column',
     gap: 0,
+    overflow: 'hidden',
     [theme.mediaQuery.medium]: {
       display: 'flex',
       flexDirection: 'row',

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
@@ -27,7 +27,7 @@ export default function WorkflowHistoryTimelineGroup({
     <div className={cls.groupContainer}>
       <div className={cls.timelineEventHeader}>
         <WorkflowHistoryEventStatusBadge status={status} size="medium" />
-        <div className={cls.timelineEventLableAndTime}>
+        <div className={cls.timelineEventLabelAndTime}>
           <div className={cls.timelineEventsLabel}>{label}</div>
           <div suppressHydrationWarning className={cls.timelineEventsTime}>
             {timeLabel}

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
@@ -27,9 +27,11 @@ export default function WorkflowHistoryTimelineGroup({
     <div className={cls.groupContainer}>
       <div className={cls.timelineEventHeader}>
         <WorkflowHistoryEventStatusBadge status={status} size="medium" />
-        <div className={cls.timelineEventsLabel}>{label}</div>
-        <div suppressHydrationWarning className={cls.timelineEventsTime}>
-          {timeLabel}
+        <div className={cls.timelineEventLableAndTime}>
+          <div className={cls.timelineEventsLabel}>{label}</div>
+          <div suppressHydrationWarning className={cls.timelineEventsTime}>
+            {timeLabel}
+          </div>
         </div>
       </div>
       <div className={cls.timelineEventCardContainer}>

--- a/src/views/workflow-history/workflow-history.styles.ts
+++ b/src/views/workflow-history/workflow-history.styles.ts
@@ -36,15 +36,15 @@ const cssStylesObj = {
   }),
   compactSection: (theme) => ({
     display: 'none',
-    flexDirection: 'column',
-    width: '362px',
-    maxHeight: `calc(100vh - ${theme.sizing.scale900})`, // fill page height excluding page bottom margin
-    overflow: 'auto',
-    position: 'sticky',
-    top: 0,
-    paddingRight: theme.sizing.scale800,
     [theme.mediaQuery.large]: {
       display: 'flex',
+      flexDirection: 'column',
+      width: '362px',
+      maxHeight: `calc(100vh - ${theme.sizing.scale900})`, // fill page height excluding page bottom margin
+      overflow: 'auto',
+      position: 'sticky',
+      top: 0,
+      paddingRight: theme.sizing.scale800,
     },
   }),
   compactCardContainer: (theme) => ({

--- a/src/views/workflow-history/workflow-history.styles.ts
+++ b/src/views/workflow-history/workflow-history.styles.ts
@@ -9,15 +9,25 @@ const cssStylesObj = {
     flexDirection: 'column',
     flex: 1,
   },
-  pageHeader: {
+  pageHeader: (theme) => ({
     display: 'flex',
-    alignItems: 'center',
+    flexDirection: 'column',
     justifyContent: 'space-between',
     flexWrap: 'wrap',
-  },
+    gap: theme.sizing.scale500,
+    [theme.mediaQuery.medium]: {
+      alignItems: 'center',
+      flexDirection: 'row',
+    },
+  }),
   headerActions: (theme) => ({
     display: 'flex',
+    flexDirection: 'column',
+    flexWrap: 'wrap',
     gap: theme.sizing.scale500,
+    [theme.mediaQuery.medium]: {
+      flexDirection: 'row',
+    },
   }),
   eventsContainer: (theme) => ({
     display: 'flex',
@@ -25,7 +35,7 @@ const cssStylesObj = {
     // gap: theme.sizing.scale400,
   }),
   compactSection: (theme) => ({
-    display: 'flex',
+    display: 'none',
     flexDirection: 'column',
     width: '362px',
     maxHeight: `calc(100vh - ${theme.sizing.scale900})`, // fill page height excluding page bottom margin
@@ -33,6 +43,9 @@ const cssStylesObj = {
     position: 'sticky',
     top: 0,
     paddingRight: theme.sizing.scale800,
+    [theme.mediaQuery.large]: {
+      display: 'flex',
+    },
   }),
   compactCardContainer: (theme) => ({
     display: 'flex',

--- a/src/views/workflow-page/workflow-page-header/workflow-page-header.styles.ts
+++ b/src/views/workflow-page/workflow-page-header/workflow-page-header.styles.ts
@@ -28,6 +28,7 @@ export const overrides = {
         alignItems: 'center',
         marginBottom: $theme.sizing.scale200,
         ...$theme.typography.LabelSmall,
+        lineHeight: $theme.typography.LabelMedium.lineHeight,
       }),
     },
   } satisfies BreadcrumbsOverrides,


### PR DESCRIPTION
## Summary
Handle workflow & domain pages responsiveness.

## Fixes
- Increase spacing in wrapped workflow breadcrumbs
- Wrap workflow history group date in small screens
- Wrap workflow history action buttons on small screens
- Hide workflow history compact list on small screens
- Wrap domain info in small screens

## Screenshots
<img width="555" alt="Screenshot 2024-11-13 at 18 49 21" src="https://github.com/user-attachments/assets/a2fdff1c-393d-45f0-9ad0-2a5f76b5df1a">
<img width="498" alt="Screenshot 2024-11-13 at 18 52 39" src="https://github.com/user-attachments/assets/cd02e147-a573-491e-93b5-55a5b9946474">
