### PR TITLE
fix overflowing stacktrace text

### DIFF
--- a/src/views/workflow-stack-trace/workflow-stack-trace.styles.ts
+++ b/src/views/workflow-stack-trace/workflow-stack-trace.styles.ts
@@ -40,6 +40,10 @@ const cssStylesObj = {
     color: theme.colors.contentSecondary,
     flex: 1,
   }),
+  stackTracePre: {
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+  },
 } satisfies StyletronCSSObject;
 
 export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =

--- a/src/views/workflow-stack-trace/workflow-stack-trace.tsx
+++ b/src/views/workflow-stack-trace/workflow-stack-trace.tsx
@@ -77,7 +77,9 @@ export default function WorkflowStackTrace(props: WorkflowPageTabContentProps) {
       )}
       {!isFetching && isSuccess && (
         <div className={cls.stackTrace}>
-          <pre>{String(data.result) || 'No stack trace...'}</pre>
+          <pre className={cls.stackTracePre}>
+            {String(data.result) || 'No stack trace...'}
+          </pre>
         </div>
       )}
     </PageSection>


### PR DESCRIPTION
### Summary
Fix overflowing text for stacktrace

###Screenshots
Before the fix:
<img width="1027" alt="Screenshot 2024-11-14 at 12 13 59" src="https://github.com/user-attachments/assets/a324dd26-8689-4996-8b1c-f2f3b48d4f34">

After the fix:
<img width="1026" alt="Screenshot 2024-11-14 at 12 12 43" src="https://github.com/user-attachments/assets/f1f7586d-9b2f-4714-90a7-931a08fcfeae">
