### PR TITLE
Replace query params by default in Page Filters

### DIFF
--- a/src/components/page-filters/hooks/use-page-filters.ts
+++ b/src/components/page-filters/hooks/use-page-filters.ts
@@ -18,7 +18,7 @@ export default function usePageFilters<P extends PageQueryParams>({
 }) {
   const [queryParams, setQueryParams] = usePageQueryParams(
     pageQueryParamsConfig,
-    { pageRerender: false }
+    { replace: true, pageRerender: false }
   );
 
   const activeFiltersCount = useMemo(() => {

--- a/src/hooks/use-page-query-params/use-page-query-params.tsx
+++ b/src/hooks/use-page-query-params/use-page-query-params.tsx
@@ -51,9 +51,9 @@ export default function usePageQueryParams<P extends PageQueryParams>(
         return;
       }
       const replace =
-        extraConfig?.replace ?? setterExtraConfig?.replace ?? false;
+        setterExtraConfig?.replace ?? extraConfig?.replace ?? false;
       const pageRerender =
-        extraConfig?.pageRerender ?? setterExtraConfig?.pageRerender ?? true;
+        setterExtraConfig?.pageRerender ?? extraConfig?.pageRerender ?? true;
 
       const updatedUrlSearch = getUpdatedUrlSearch(config, newParams, search);
       const routerNavigate = replace ? router.replace : router.push;


### PR DESCRIPTION
## Summary
- Configure usePageQueryParams in usePageFilters hook to replace query params in history by default
- Fix usePageQueryParams setter impl to honour setterExtraConfig over usePageQueryParams extra config

## Test plan
Ran locally and verified that history gets replaced