### PR TITLE
Show workflowExecution as link

### DIFF
--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -42,7 +42,8 @@ const workflowHistoryEventDetailsConfig = [
   },
   {
     name: 'WorkflowExecution as link',
-    pathRegex: '(parentWorkflowExecution|externalWorkflowExecution)$',
+    pathRegex:
+      '(parentWorkflowExecution|externalWorkflowExecution|workflowExecution)$',
     valueComponent: ({ entryValue, domain, cluster }) => {
       return createElement(WorkflowHistoryEventDetailsExecutionLink, {
         domain,


### PR DESCRIPTION
### Summary
Show `workflowExecution` as link in history event details.


### Screenshots
![Screenshot 2024-11-20 at 20 48 17](https://github.com/user-attachments/assets/f4b5055a-a7d4-4cfc-8a4f-4b70a26a86dc)
