### PR TITLE
Use format input in activity scheduled event

### DIFF
--- a/src/utils/data-formatters/__tests__/format-input-payload.test.ts
+++ b/src/utils/data-formatters/__tests__/format-input-payload.test.ts
@@ -1,35 +1,35 @@
-import formatWorkflowInputPayload from '../format-workflow-input-payload';
+import formatInputPayload from '../format-input-payload';
 
-describe('formatWorkflowInputPayload', () => {
+describe('formatInputPayload', () => {
   // empty data checks
   test('should return null if payload is null', () => {
     const input = null;
     const expected = null;
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should return null if payload is undefined', () => {
     const input = undefined;
     const expected = null;
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should return null if data is missing', () => {
     const input = {};
     const expected = null;
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should return null if data is null', () => {
     const input = { data: null };
     const expected = null;
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should return null if data is an empty string', () => {
     const input = { data: '' };
     const expected = null;
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
   // end of empty data checks
 
@@ -41,7 +41,7 @@ describe('formatWorkflowInputPayload', () => {
       { name: 'John', age: 30 },
       { name: 'Jane', age: 25 },
     ];
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should handle base64 encoded JSON with \\n within string values', () => {
@@ -54,7 +54,7 @@ describe('formatWorkflowInputPayload', () => {
       { name: 'John\nDoe', age: 30 },
       { name: 'Alice', city: 'Wonderland' },
     ];
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should handle base64 encoded malformed JSON gracefully', () => {
@@ -62,12 +62,12 @@ describe('formatWorkflowInputPayload', () => {
       data: btoa(`{"name": "John", "age": 30}\n{malformed JSON}`),
     };
     const expected = [{ name: 'John', age: 30 }];
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
   test('should handle base64 encoded mix of numbers, strings, arrays, nulls', () => {
     const input = { data: btoa(`42\n"Hello, World!"\n[1, 2, 3]\nnull`) };
     const expected = [42, 'Hello, World!', [1, 2, 3], null];
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should handle base64 encoded JSON objects with mixed types', () => {
@@ -79,7 +79,7 @@ describe('formatWorkflowInputPayload', () => {
     const expected = [
       { number: 123, string: 'test', array: [1, 'two', 3], nullValue: null },
     ];
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 
   test('should handle base64 encoded multiple mixed JSON objects', () => {
@@ -94,6 +94,6 @@ describe('formatWorkflowInputPayload', () => {
       42,
       'Hello',
     ];
-    expect(formatWorkflowInputPayload(input)).toEqual(expected);
+    expect(formatInputPayload(input)).toEqual(expected);
   });
 });

--- a/src/utils/data-formatters/format-input-payload.ts
+++ b/src/utils/data-formatters/format-input-payload.ts
@@ -1,6 +1,6 @@
 import logger from '@/utils/logger';
 
-const formatWorkflowInputPayload = (
+const formatInputPayload = (
   payload: { data?: string | null } | null | undefined
 ) => {
   const data = payload?.data;
@@ -54,4 +54,4 @@ function parseJsonLines(input: string) {
   return jsonArray;
 }
 
-export default formatWorkflowInputPayload;
+export default formatInputPayload;

--- a/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts.snapshot
+++ b/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts.snapshot
@@ -73,7 +73,7 @@ exports[`formatWorkflowHistoryEvent should format workflow activityTaskScheduled
   },
   "heartbeatTimeoutSeconds": 0,
   "input": [
-    "1725747370575409843",
+    1725747370575410000,
     "gadence-canary-xdc",
     "workflow.sanity",
   ],

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
@@ -21,7 +21,7 @@
 
 import formatDurationToSeconds from '../format-duration-to-seconds';
 import formatEnum from '../format-enum';
-import formatPayload from '../format-payload';
+import formatInputPayload from '../format-input-payload';
 import formatPayloadMap from '../format-payload-map';
 import formatRetryPolicy from '../format-retry-policy';
 
@@ -51,7 +51,7 @@ const formatActivityTaskScheduledEvent = ({
     domain: domain || null,
     header: formatPayloadMap(header, 'fields'),
     heartbeatTimeoutSeconds: formatDurationToSeconds(heartbeatTimeout),
-    input: formatPayload(input),
+    input: formatInputPayload(input),
     retryPolicy: formatRetryPolicy(retryPolicy),
     scheduleToCloseTimeoutSeconds: formatDurationToSeconds(
       scheduleToCloseTimeout

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import formatWorkflowInputPayload from '../format-workflow-input-payload';
+import formatInputPayload from '../format-input-payload';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type SignalExternalWorkflowExecutionInitiatedEvent } from './format-workflow-history-event.type';
@@ -38,7 +38,7 @@ const formatSignalExternalWorkflowExecutionInitiatedEvent = ({
     ...eventAttributes,
     control: control ? parseInt(atob(control)) : null,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
-    input: formatWorkflowInputPayload(input),
+    input: formatInputPayload(input),
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
@@ -21,9 +21,9 @@
 
 import formatDurationToSeconds from '../format-duration-to-seconds';
 import formatEnum from '../format-enum';
+import formatInputPayload from '../format-input-payload';
 import formatPayloadMap from '../format-payload-map';
 import formatRetryPolicy from '../format-retry-policy';
-import formatWorkflowInputPayload from '../format-workflow-input-payload';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type StartChildWorkflowExecutionInitiatedEvent } from './format-workflow-history-event.type';
@@ -57,7 +57,7 @@ const formatStartChildWorkflowExecutionInitiatedEvent = ({
       executionStartToCloseTimeout
     ),
     header: formatPayloadMap(header, 'fields'),
-    input: formatWorkflowInputPayload(input),
+    input: formatInputPayload(input),
     memo: formatPayloadMap(memo, 'fields'),
     parentClosePolicy: formatEnum(parentClosePolicy, 'PARENT_CLOSE_POLICY'),
     retryPolicy: formatRetryPolicy(retryPolicy),

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
@@ -22,9 +22,9 @@
 import formatDurationToSeconds from '../format-duration-to-seconds';
 import formatEnum from '../format-enum';
 import formatFailureDetails from '../format-failure-details';
+import formatInputPayload from '../format-input-payload';
 import formatPayloadMap from '../format-payload-map';
 import formatWorkflowEventId from '../format-workflow-event-id';
-import formatWorkflowInputPayload from '../format-workflow-input-payload';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type WorkflowExecutionContinuedAsNewEvent } from './format-workflow-history-event.type';
@@ -61,7 +61,7 @@ const formatWorkflowExecutionContinuedAsNewEvent = ({
     failureReason: failure?.reason || '',
     header: formatPayloadMap(header, 'fields'),
     initiator: formatEnum(initiator, 'CONTINUE_AS_NEW_INITIATOR'),
-    input: formatWorkflowInputPayload(input),
+    input: formatInputPayload(input),
     memo: formatPayloadMap(memo, 'fields'),
     searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
     taskList: {

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import formatWorkflowInputPayload from '../format-workflow-input-payload';
+import formatInputPayload from '../format-input-payload';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type WorkflowExecutionSignaledEvent } from './format-workflow-history-event.type';
@@ -31,7 +31,7 @@ const formatWorkflowExecutionSignaledEvent = ({
   return {
     ...formatWorkflowCommonEventFields(eventFields),
     ...eventAttributes,
-    input: formatWorkflowInputPayload(input),
+    input: formatInputPayload(input),
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
@@ -24,11 +24,11 @@ import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 import formatDurationToSeconds from '../format-duration-to-seconds';
 import formatEnum from '../format-enum';
 import formatFailureDetails from '../format-failure-details';
+import formatInputPayload from '../format-input-payload';
 import formatPayloadMap from '../format-payload-map';
 import formatPrevAutoResetPoints from '../format-prev-auto-reset-points';
 import formatRetryPolicy from '../format-retry-policy';
 import formatTimestampToDatetime from '../format-timestamp-to-datetime';
-import formatWorkflowInputPayload from '../format-workflow-input-payload';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type WorkflowExecutionStartedEvent } from './format-workflow-history-event.type';
@@ -68,7 +68,7 @@ const formatWorkflowExecutionStartedEvent = ({
       kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
       name: taskList?.name || null,
     },
-    input: formatWorkflowInputPayload(input),
+    input: formatInputPayload(input),
     executionStartToCloseTimeoutSeconds: formatDurationToSeconds(
       executionStartToCloseTimeout
     ),


### PR DESCRIPTION
### Summary
Use our default input parser to parse the input of the activity since it follows same multi argument input we have for workflow. This function helps parsing all activity arguments as json instead of treating json strings arguments as strings.

### Changes
- Rename the parsing function from `formatWorkflowInputPayload` to `formatInputPayload` as it no longer works for workflow only but activity also
- use the parsing function with the activity scheduled event
- update unit test snapshot to match the new parsing types (numbers where parsed as strings incorrectly)
- while updating the snapshot i notice that the new value precision is not correct... **going to address this in the next PR**

### Screenshots
Before:
![Screenshot 2024-11-21 at 13 55 38](https://github.com/user-attachments/assets/bdb7d31e-1f93-47b0-93ba-f8b96b4af139)
After:
![Screenshot 2024-11-21 at 13 59 17](https://github.com/user-attachments/assets/7c7f8635-1733-4ef5-8614-264806ff27b5)

