### PR TITLE
Table - fix typing for onSort function

### DIFF
--- a/src/components/table/__tests__/table.test.tsx
+++ b/src/components/table/__tests__/table.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@/test-utils/rtl';
 
 import Table from '../table';
+import { type TableConfig } from '../table.types';
 
 type TestDataT = {
   value: string;
@@ -16,18 +17,49 @@ const SAMPLE_ROWS: Array<TestDataT> = Array.from(
   (_, rowIndex) => ({ value: `test_${rowIndex}` })
 );
 
-const SAMPLE_COLUMNS = Array.from(
-  { length: SAMPLE_DATA_NUM_COLUMNS },
-  (_, colIndex) => ({
-    name: `Column Name ${colIndex}`,
-    id: `column_id_${colIndex}`,
+function getMockRenderCell(index: number) {
+  return ({ value }: TestDataT) => {
+    return `data_${value}_${index}`;
+  };
+}
+
+const SAMPLE_COLUMNS = [
+  {
+    name: 'Column name 0',
+    id: 'column_id_0',
     sortable: true,
-    renderCell: ({ value }: TestDataT) => {
-      return `data_${value}_${colIndex}`;
-    },
-    width: `${100 / SAMPLE_DATA_NUM_COLUMNS}%`,
-  })
-);
+    renderCell: getMockRenderCell(0),
+    width: '20%',
+  },
+  {
+    name: 'Column name 1',
+    id: 'column_id_1',
+    sortable: true,
+    renderCell: getMockRenderCell(1),
+    width: '20%',
+  },
+  {
+    name: 'Column name 2',
+    id: 'column_id_2',
+    sortable: true,
+    renderCell: getMockRenderCell(2),
+    width: '20%',
+  },
+  {
+    name: 'Column name 3',
+    id: 'column_id_3',
+    sortable: true,
+    renderCell: getMockRenderCell(3),
+    width: '20%',
+  },
+  {
+    name: 'Column name 4',
+    id: 'column_id_4',
+    sortable: true,
+    renderCell: getMockRenderCell(4),
+    width: '20%',
+  },
+] as const satisfies TableConfig<TestDataT>;
 
 describe('Table', () => {
   it('should render without error', async () => {

--- a/src/components/table/__tests__/table.test.tsx
+++ b/src/components/table/__tests__/table.test.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@/test-utils/rtl';
 
 import Table from '../table';
-import { type TableConfig } from '../table.types';
 
 type TestDataT = {
   value: string;
@@ -17,49 +16,18 @@ const SAMPLE_ROWS: Array<TestDataT> = Array.from(
   (_, rowIndex) => ({ value: `test_${rowIndex}` })
 );
 
-function getMockRenderCell(index: number) {
-  return ({ value }: TestDataT) => {
-    return `data_${value}_${index}`;
-  };
-}
-
-const SAMPLE_COLUMNS = [
-  {
-    name: 'Column name 0',
-    id: 'column_id_0',
+const SAMPLE_COLUMNS = Array.from(
+  { length: SAMPLE_DATA_NUM_COLUMNS },
+  (_, colIndex) => ({
+    name: `Column Name ${colIndex}`,
+    id: `column_id_${colIndex}`,
     sortable: true,
-    renderCell: getMockRenderCell(0),
-    width: '20%',
-  },
-  {
-    name: 'Column name 1',
-    id: 'column_id_1',
-    sortable: true,
-    renderCell: getMockRenderCell(1),
-    width: '20%',
-  },
-  {
-    name: 'Column name 2',
-    id: 'column_id_2',
-    sortable: true,
-    renderCell: getMockRenderCell(2),
-    width: '20%',
-  },
-  {
-    name: 'Column name 3',
-    id: 'column_id_3',
-    sortable: true,
-    renderCell: getMockRenderCell(3),
-    width: '20%',
-  },
-  {
-    name: 'Column name 4',
-    id: 'column_id_4',
-    sortable: true,
-    renderCell: getMockRenderCell(4),
-    width: '20%',
-  },
-] as const satisfies TableConfig<TestDataT>;
+    renderCell: ({ value }: TestDataT) => {
+      return `data_${value}_${colIndex}`;
+    },
+    width: `${100 / SAMPLE_DATA_NUM_COLUMNS}%`,
+  })
+);
 
 describe('Table', () => {
   it('should render without error', async () => {

--- a/src/components/table/table-sortable-head-cell/__tests__/table-sortable-head-cell.test.tsx
+++ b/src/components/table/table-sortable-head-cell/__tests__/table-sortable-head-cell.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type SortOrder } from '@/utils/sort-by';
+
+import TableSortableHeadCell from '../table-sortable-head-cell';
+
+describe(TableSortableHeadCell.name, () => {
+  it('should render unsorted without error', async () => {
+    setup({ sortColumn: 'column_2', sortOrder: 'DESC' });
+
+    expect(
+      await screen.findByLabelText('Column 1, not sorted')
+    ).toBeInTheDocument();
+  });
+
+  it('should call onSort when clicked', async () => {
+    const { mockOnSort, user } = setup({
+      sortColumn: 'column_2',
+      sortOrder: 'DESC',
+    });
+
+    const cell = await screen.findByLabelText('Column 1, not sorted');
+
+    await user.click(cell);
+    expect(mockOnSort).toHaveBeenCalledWith('column_1');
+  });
+
+  it('should render sorted ASC without error', async () => {
+    setup({ sortColumn: 'column_1', sortOrder: 'ASC' });
+
+    expect(
+      await screen.findByLabelText('Column 1, ascending sorting')
+    ).toBeInTheDocument();
+  });
+
+  it('should render sorted DESC without error', async () => {
+    setup({ sortColumn: 'column_1', sortOrder: 'DESC' });
+
+    expect(
+      await screen.findByLabelText('Column 1, descending sorting')
+    ).toBeInTheDocument();
+  });
+});
+
+function setup({
+  sortColumn,
+  sortOrder,
+}: {
+  sortColumn: string;
+  sortOrder: SortOrder;
+}) {
+  const user = userEvent.setup();
+  const mockOnSort = jest.fn();
+  render(
+    <TableSortableHeadCell
+      name="Column 1"
+      columnID="column_1"
+      width="20%"
+      onSort={mockOnSort}
+      sortColumn={sortColumn}
+      sortOrder={sortOrder}
+    />
+  );
+  return { mockOnSort, user };
+}

--- a/src/components/table/table-sortable-head-cell/table-sortable-head-cell.tsx
+++ b/src/components/table/table-sortable-head-cell/table-sortable-head-cell.tsx
@@ -10,7 +10,7 @@ export default function TableSortableHeadCell({
   name,
   columnID,
   width,
-  onSort = () => {},
+  onSort,
   sortColumn,
   sortOrder,
 }: Props) {

--- a/src/components/table/table-sortable-head-cell/table-sortable-head-cell.tsx
+++ b/src/components/table/table-sortable-head-cell/table-sortable-head-cell.tsx
@@ -10,7 +10,7 @@ export default function TableSortableHeadCell({
   name,
   columnID,
   width,
-  onSort,
+  onSort = () => {},
   sortColumn,
   sortOrder,
 }: Props) {

--- a/src/components/table/table-sortable-head-cell/table-sortable-head-cell.types.ts
+++ b/src/components/table/table-sortable-head-cell/table-sortable-head-cell.types.ts
@@ -1,8 +1,10 @@
+import { type SortOrder } from '@/utils/sort-by';
+
 export type Props = {
   name: string;
   columnID: string;
   width: string;
   sortColumn?: string;
-  sortOrder?: string;
+  sortOrder?: SortOrder;
   onSort: (column: string) => void;
 };

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -10,15 +10,18 @@ import {
 
 import TableSortableHeadCell from './table-sortable-head-cell/table-sortable-head-cell';
 import { styled } from './table.styles';
-import type { Props } from './table.types';
+import type { Props, TableColumn } from './table.types';
 
-export default function Table<T extends object>({
+export default function Table<
+  T extends object,
+  C extends Array<TableColumn<T>>,
+>({
   data,
   columns,
   shouldShowResults,
   endMessage,
   ...sortParams
-}: Props<T>) {
+}: Props<T, C>) {
   return (
     <styled.TableRoot>
       <StyledTable>

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -10,12 +10,9 @@ import {
 
 import TableSortableHeadCell from './table-sortable-head-cell/table-sortable-head-cell';
 import { styled } from './table.styles';
-import type { Props, TableColumn } from './table.types';
+import type { Props, TableConfig } from './table.types';
 
-export default function Table<
-  T extends object,
-  C extends Array<TableColumn<T>>,
->({
+export default function Table<T extends object, C extends TableConfig<T>>({
   data,
   columns,
   shouldShowResults,
@@ -34,6 +31,7 @@ export default function Table<
                   name={column.name}
                   columnID={column.id}
                   width={column.width}
+                  onSort={() => {}}
                   {...sortParams}
                 />
               ) : (

--- a/src/components/table/table.tsx
+++ b/src/components/table/table.tsx
@@ -17,7 +17,9 @@ export default function Table<T extends object, C extends TableConfig<T>>({
   columns,
   shouldShowResults,
   endMessage,
-  ...sortParams
+  onSort,
+  sortColumn,
+  sortOrder,
 }: Props<T, C>) {
   return (
     <styled.TableRoot>
@@ -25,14 +27,15 @@ export default function Table<T extends object, C extends TableConfig<T>>({
         <StyledTableHead>
           <StyledTableHeadRow>
             {columns.map((column) =>
-              column.sortable ? (
+              column.sortable && typeof onSort === 'function' ? (
                 <TableSortableHeadCell
                   key={column.id}
                   name={column.name}
                   columnID={column.id}
                   width={column.width}
-                  onSort={() => {}}
-                  {...sortParams}
+                  onSort={onSort}
+                  sortColumn={sortColumn}
+                  sortOrder={sortOrder}
                 />
               ) : (
                 <styled.TableHeadCell

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -8,21 +8,24 @@ export type TableColumn<T> = {
   sortable?: boolean;
 };
 
-type IsTableConfigSortable<T, C extends Array<TableColumn<T>>> = true extends {
+export type TableConfig<T> = Array<TableColumn<T>>;
+
+type AreAnyColumnsSortable<T, C extends TableConfig<T>> = true extends {
   [K in keyof C]: C[K] extends { sortable: true } ? true : false;
 }[number]
   ? true
   : false;
 
-export type Props<T, C extends Array<TableColumn<T>>> = {
+type OnSortFunctionOptional<T, C extends TableConfig<T>> =
+  AreAnyColumnsSortable<T, C> extends true
+    ? { onSort: (column: string) => void }
+    : { onSort?: (column: string) => void };
+
+export type Props<T, C extends TableConfig<T>> = {
   data: Array<T>;
   columns: C;
   shouldShowResults: boolean;
   endMessage: React.ReactNode;
-  // Sort params
-  onSort: IsTableConfigSortable<T, C> extends true
-    ? (column: string) => void
-    : never;
   sortColumn?: string;
   sortOrder?: SortOrder;
-};
+} & OnSortFunctionOptional<T, C>;

--- a/src/components/table/table.types.ts
+++ b/src/components/table/table.types.ts
@@ -8,13 +8,21 @@ export type TableColumn<T> = {
   sortable?: boolean;
 };
 
-export type Props<T> = {
+type IsTableConfigSortable<T, C extends Array<TableColumn<T>>> = true extends {
+  [K in keyof C]: C[K] extends { sortable: true } ? true : false;
+}[number]
+  ? true
+  : false;
+
+export type Props<T, C extends Array<TableColumn<T>>> = {
   data: Array<T>;
-  columns: Array<TableColumn<T>>;
+  columns: C;
   shouldShowResults: boolean;
   endMessage: React.ReactNode;
   // Sort params
-  onSort: (column: string) => void;
+  onSort: IsTableConfigSortable<T, C> extends true
+    ? (column: string) => void
+    : never;
   sortColumn?: string;
   sortOrder?: SortOrder;
 };

--- a/src/views/domain-workflows/config/domain-workflows-table.config.ts
+++ b/src/views/domain-workflows/config/domain-workflows-table.config.ts
@@ -2,7 +2,7 @@ import { createElement } from 'react';
 
 import FormattedDate from '@/components/formatted-date/formatted-date';
 import Link from '@/components/link/link';
-import { type TableColumn } from '@/components/table/table.types';
+import { type TableConfig } from '@/components/table/table.types';
 import { type DomainWorkflow } from '@/views/domain-page/domain-page.types';
 import WorkflowStatusTag from '@/views/shared/workflow-status-tag/workflow-status-tag';
 
@@ -55,6 +55,6 @@ const domainWorkflowsTableConfig = [
     width: '12.5%',
     sortable: true,
   },
-] as const satisfies Array<TableColumn<DomainWorkflow>>;
+] as const satisfies TableConfig<DomainWorkflow>;
 
 export default domainWorkflowsTableConfig;

--- a/src/views/domains-page/config/domains-table-columns.config.ts
+++ b/src/views/domains-page/config/domains-table-columns.config.ts
@@ -1,10 +1,10 @@
-import { type TableColumn } from '@/components/table/table.types';
+import { type TableConfig } from '@/components/table/table.types';
 
 import { type DomainData } from '../domains-page.types';
 import DomainsTableClusterCell from '../domains-table-cluster-cell/domains-table-cluster-cell';
 import DomainsTableDomainNameCell from '../domains-table-domain-name-cell/domains-table-domain-name-cell';
 
-const domainsTableColumnsConfig: Array<TableColumn<DomainData>> = [
+const domainsTableColumnsConfig = [
   {
     name: 'Domain Name',
     id: 'name',
@@ -18,6 +18,6 @@ const domainsTableColumnsConfig: Array<TableColumn<DomainData>> = [
     renderCell: DomainsTableClusterCell,
     width: '20%',
   },
-];
+] as const satisfies TableConfig<DomainData>;
 
 export default domainsTableColumnsConfig;

--- a/src/views/domains-page/domains-table/domains-table.types.ts
+++ b/src/views/domains-page/domains-table/domains-table.types.ts
@@ -1,4 +1,4 @@
-import type { TableColumn } from '@/components/table/table.types';
+import type { TableConfig } from '@/components/table/table.types';
 
 import type { DomainData } from '../domains-page.types';
 

--- a/src/views/domains-page/domains-table/domains-table.types.ts
+++ b/src/views/domains-page/domains-table/domains-table.types.ts
@@ -2,7 +2,7 @@ import type { TableColumn } from '@/components/table/table.types';
 
 import type { DomainData } from '../domains-page.types';
 
-export type DomainsTableColumns = Array<TableColumn<DomainData>>;
+export type DomainsTableColumns = TableConfig<DomainData>;
 
 export type Props = {
   domains: Array<DomainData>;

--- a/src/views/task-list-page/config/task-list-workers-table.config.ts
+++ b/src/views/task-list-page/config/task-list-workers-table.config.ts
@@ -40,6 +40,6 @@ const taskListWorkersTableConfig = [
       }),
     width: '10%',
   },
-] as const satisfies Array<TableColumn<Worker>>;
+] as const satisfies TableConfig<Worker>;
 
 export default taskListWorkersTableConfig;

--- a/src/views/task-list-page/config/task-list-workers-table.config.ts
+++ b/src/views/task-list-page/config/task-list-workers-table.config.ts
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 
 import FormattedDate from '@/components/formatted-date/formatted-date';
-import { type TableColumn } from '@/components/table/table.types';
+import { type TableConfig } from '@/components/table/table.types';
 import { type Worker } from '@/route-handlers/describe-task-list/describe-task-list.types';
 
 import TaskListWorkersTableHandlerIcon from '../task-list-workers-table-handler-icon/task-list-workers-table-handler-icon';


### PR DESCRIPTION
## Summary
- Make onSort required only if table config has at least 1 sortable column
- Fix Table to render unsortable cells if sortBy is not passed when sortable is true for a column
- Add helper type TableConfig<T> for readability
- Add unit tests for TableSortableHeadCell
- Mock TableSortableHeadCell out in Table test

## Test plan
Type checks succeeding locally + tested by modifying the config