### PR TITLE
Add attempts badge

### DIFF
--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -54,6 +54,12 @@ const workflowHistoryEventDetailsConfig = [
     },
   },
   {
+    name: 'Maximum retry attempts',
+    path: 'retryPolicy.maximumAttempts',
+    valueComponent: ({ entryValue }) =>
+      entryValue === 0 ? 'Unlimited' : entryValue,
+  },
+  {
     name: 'RunIds as link',
     pathRegex: '(firstExecutionRunId|originalExecutionRunId)$',
     valueComponent: ({ entryValue, domain, cluster, workflowId }) => {

--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -6,12 +6,26 @@ import WorkflowHistoryEventDetailsExecutionLink from '@/views/shared/workflow-hi
 import WorkflowHistoryEventDetailsTaskListLink from '../../shared/workflow-history-event-details-task-list-link/workflow-history-event-details-task-list-link';
 import { type WorkflowHistoryEventDetailsConfig } from '../workflow-history-event-details/workflow-history-event-details.types';
 import WorkflowHistoryEventDetailsJson from '../workflow-history-event-details-json/workflow-history-event-details-json';
+import WorkflowHistoryEventDetailsPlaceholderText from '../workflow-history-event-details-placeholder-text/workflow-history-event-details-placeholder-text';
 
 const workflowHistoryEventDetailsConfig = [
   {
     name: 'Filter empty value',
     customMatcher: ({ value }) => value === null || value === undefined,
     hide: () => true,
+  },
+  {
+    name: 'Not set placeholder',
+    customMatcher: ({ value, path }) => {
+      return (
+        value === 0 &&
+        new RegExp(
+          'retryPolicy.(maximumAttempts|expirationIntervalInSeconds)$'
+        ).test(path)
+      );
+    },
+    valueComponent: () =>
+      createElement(WorkflowHistoryEventDetailsPlaceholderText),
   },
   {
     name: 'Date object as time string',
@@ -52,12 +66,6 @@ const workflowHistoryEventDetailsConfig = [
         runId: entryValue?.runId,
       });
     },
-  },
-  {
-    name: 'Maximum retry attempts',
-    path: 'retryPolicy.maximumAttempts',
-    valueComponent: ({ entryValue }) =>
-      entryValue === 0 ? 'Unlimited' : entryValue,
   },
   {
     name: 'RunIds as link',

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -12,17 +12,25 @@ export default function getActivityGroupFromEvents(
   let label = '';
   let hasMissingEvents = false;
   const groupType = 'Activity';
+  const badges = [];
 
   const scheduleAttr = 'activityTaskScheduledEventAttributes';
+  const startAttr = 'activityTaskStartedEventAttributes';
   const scheduleEvent = events.find(
     ({ attributes }) => attributes === scheduleAttr
   );
+  const startEvent = events.find(({ attributes }) => attributes === startAttr);
   const firstEvent = events[0];
 
   if (scheduleEvent) {
     label = `Activity ${scheduleEvent[scheduleAttr]?.activityId}: ${scheduleEvent[scheduleAttr]?.activityType?.name}`;
   }
-
+  if (startEvent && startEvent[startAttr]?.attempt) {
+    const attempts = startEvent[startAttr].attempt;
+    badges.push({
+      content: `${attempts} Attempt${attempts !== 1 ? 's' : ''}`,
+    });
+  }
   if (firstEvent.attributes !== 'activityTaskScheduledEventAttributes') {
     hasMissingEvents = true;
   }
@@ -51,6 +59,7 @@ export default function getActivityGroupFromEvents(
     label,
     hasMissingEvents,
     groupType,
+    badges,
     ...getCommonHistoryGroupFields<ActivityHistoryGroup>(
       events,
       eventToStatus,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -12,11 +12,22 @@ export default function getDecisionGroupFromEvents(
   const label = 'Decision Task';
   let hasMissingEvents = false;
   const groupType = 'Decision';
+  const badges = [];
 
   const firstEvent = events[0];
-
+  const scheduleAttr = 'decisionTaskScheduledEventAttributes';
+  const scheduleEvent = events.find(
+    ({ attributes }) => attributes === scheduleAttr
+  );
   if (firstEvent.attributes !== 'decisionTaskScheduledEventAttributes') {
     hasMissingEvents = true;
+  }
+
+  if (scheduleEvent && scheduleEvent[scheduleAttr]?.attempt) {
+    const attempts = scheduleEvent[scheduleAttr].attempt;
+    badges.push({
+      content: `${attempts} Attempt${attempts !== 1 ? 's' : ''}`,
+    });
   }
   const eventToLabel: HistoryGroupEventToStringMap<DecisionHistoryGroup> = {
     decisionTaskScheduledEventAttributes: 'Scheduled',
@@ -39,6 +50,7 @@ export default function getDecisionGroupFromEvents(
     label,
     hasMissingEvents,
     groupType,
+    badges,
     ...getCommonHistoryGroupFields<DecisionHistoryGroup>(
       events,
       eventToStatus,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -30,6 +30,17 @@ export default function getSingleEventGroupFromEvents(
   const label = eventToGroupLabel[event.attributes];
   const groupType = 'Event';
   const hasMissingEvents = false;
+  const badges = [];
+
+  if (
+    event.attributes === 'workflowExecutionStartedEventAttributes' &&
+    event.workflowExecutionStartedEventAttributes?.attempt
+  ) {
+    const attempts = event.workflowExecutionStartedEventAttributes.attempt;
+    badges.push({
+      content: `${attempts} Attempt${attempts !== 1 ? 's' : ''}`,
+    });
+  }
 
   const eventToLabel: HistoryGroupEventToStringMap<SingleEventHistoryGroup> = {
     activityTaskCancelRequestedEventAttributes: 'Requested',
@@ -69,6 +80,7 @@ export default function getSingleEventGroupFromEvents(
     label,
     hasMissingEvents,
     groupType,
+    badges,
     ...getCommonHistoryGroupFields<SingleEventHistoryGroup>(
       events,
       eventToStatus,

--- a/src/views/workflow-history/workflow-history-compact-event-card/__tests__/workflow-history-compact-event-card.test.tsx
+++ b/src/views/workflow-history/workflow-history-compact-event-card/__tests__/workflow-history-compact-event-card.test.tsx
@@ -30,11 +30,13 @@ describe('WorkflowHistoryCompactEventCard', () => {
     expect(container.querySelector('[testid="loader"]')).toBeInTheDocument();
   });
 
-  it('renders secondaryLabel correctly', () => {
+  it('renders badges correctly', () => {
     setup({
-      secondaryLabel: 'date text',
+      badges: [{ content: 'test badge 1' }, { content: 'test badge 2' }],
     });
-    expect(screen.getByText('date text')).toBeInTheDocument();
+
+    expect(screen.getByText('test badge 1')).toBeInTheDocument();
+    expect(screen.getByText('test badge 2')).toBeInTheDocument();
   });
 
   it('renders with correct status', () => {

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.styles.ts
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.styles.ts
@@ -1,4 +1,5 @@
 import { type Theme } from 'baseui';
+import { type BadgeOverrides } from 'baseui/badge';
 import { type TileOverrides } from 'baseui/tile';
 import { type StyleObject } from 'styletron-react';
 
@@ -8,7 +9,7 @@ import type {
 } from '@/hooks/use-styletron-classes';
 
 export const overrides = {
-  Tile: {
+  title: {
     Root: {
       style: ({ $theme }: { $theme: Theme }): StyleObject => ({
         padding: $theme.sizing.scale550,
@@ -23,13 +24,23 @@ export const overrides = {
       }),
     },
   } satisfies TileOverrides,
+  badge: {
+    Badge: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        backgroundColor: $theme.colors.backgroundSecondary,
+        color: $theme.colors.contentSecondary,
+        ...$theme.typography.LabelXSmall,
+        whiteSpace: 'nowrap',
+      }),
+    },
+  } satisfies BadgeOverrides,
 };
 
 const cssStylesObj = {
   textContainer: ($theme: Theme) => ({
     display: 'flex',
-    flexDirection: 'column',
-    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+    alignItems: 'center',
     gap: $theme.sizing.scale200,
     textAlign: 'start',
     wordBreak: 'break-word',

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.tsx
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React from 'react';
 
+import { Badge } from 'baseui/badge';
 import { Skeleton } from 'baseui/skeleton';
 import { ALIGNMENT, TILE_KIND, Tile } from 'baseui/tile';
 
@@ -17,15 +18,16 @@ import { type Props } from './workflow-history-compact-event-card.types';
 export default function WorkflowHistoryCompactEventCard({
   status,
   label,
-  secondaryLabel,
+  badges,
   showLabelPlaceholder,
   onClick,
 }: Props) {
   const { cls, theme } = useStyletronClasses(cssStyles);
+  const hasBadges = badges !== undefined && badges.length > 0;
 
   return (
     <Tile
-      overrides={overrides.Tile}
+      overrides={overrides.title}
       tileKind={TILE_KIND.selection}
       headerAlignment={ALIGNMENT.right}
       bodyAlignment={ALIGNMENT.left}
@@ -34,21 +36,34 @@ export default function WorkflowHistoryCompactEventCard({
       <WorkflowHistoryEventStatusBadge status={status} size="small" />
       <div className={cls.textContainer}>
         {label && !showLabelPlaceholder && (
-          <div className={cls.label}>{label}</div>
-        )}
-        {showLabelPlaceholder && (
           <div className={cls.label}>
-            <Skeleton
-              rows={0}
-              width="100px"
-              height={theme.typography.LabelSmall.lineHeight.toString()}
-            />
+            {label}
+            {hasBadges &&
+              badges.map((badge) => (
+                <>
+                  {' '}
+                  <Badge
+                    key={badge.content}
+                    overrides={overrides.badge}
+                    content={badge.content}
+                    shape="rectangle"
+                    color="primary"
+                  />
+                </>
+              ))}
           </div>
         )}
-        <div suppressHydrationWarning className={cls.secondaryLabel}>
-          {secondaryLabel}
-        </div>
       </div>
+
+      {showLabelPlaceholder && (
+        <div className={cls.label}>
+          <Skeleton
+            rows={0}
+            width="100px"
+            height={theme.typography.LabelSmall.lineHeight.toString()}
+          />
+        </div>
+      )}
     </Tile>
   );
 }

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.types.ts
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.types.ts
@@ -1,11 +1,13 @@
 import { type TileProps } from 'baseui/tile';
 
 import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+import { type HistoryGroupBadge } from '../workflow-history.types';
 
 export type Props = {
   status: WorkflowEventStatus;
   label: string;
   secondaryLabel: string;
   showLabelPlaceholder?: boolean;
+  badges?: HistoryGroupBadge[];
   onClick: TileProps['onClick'];
 };

--- a/src/views/workflow-history/workflow-history-event-details-json/__tests__/workflow-history-event-details-json.test.tsx
+++ b/src/views/workflow-history/workflow-history-event-details-json/__tests__/workflow-history-event-details-json.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@/components/pretty-json/pretty-json', () =>
   jest.fn(() => <div>PrettyJson Mock</div>)
 );
 
-describe('WorkflowSummaryTabJsonView Component', () => {
+describe('WorkflowHistoryEventDetailsJson', () => {
   const losslessInputJson = {
     input: 'inputJson',
     long: BigInt('9007199254740991345435'),

--- a/src/views/workflow-history/workflow-history-event-details-placeholder-text/__tests__/workflow-history-event-details-placeholder-text.test.tsx
+++ b/src/views/workflow-history/workflow-history-event-details-placeholder-text/__tests__/workflow-history-event-details-placeholder-text.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { render } from '@/test-utils/rtl';
+
+import WorkflowHistoryEventDetailsPlaceholderText from '../workflow-history-event-details-placeholder-text';
+
+describe('WorkflowHistoryEventDetailsPlaceholderText', () => {
+  it('renders not set by default', () => {
+    const { getByText } = render(
+      <WorkflowHistoryEventDetailsPlaceholderText />
+    );
+
+    expect(getByText('Not set')).toBeInTheDocument();
+  });
+
+  it('renders passed placeholder text', () => {
+    const { getByText } = render(
+      <WorkflowHistoryEventDetailsPlaceholderText placeholderText="placeholder test" />
+    );
+
+    expect(getByText('placeholder test')).toBeInTheDocument();
+  });
+});

--- a/src/views/workflow-history/workflow-history-event-details-placeholder-text/workflow-history-event-details-placeholder-text.styles.ts
+++ b/src/views/workflow-history/workflow-history-event-details-placeholder-text/workflow-history-event-details-placeholder-text.styles.ts
@@ -1,0 +1,15 @@
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  placeholderText: (theme) => ({
+    display: 'contents',
+    color: theme.colors.contentTertiary,
+    fontStyle: 'italic',
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =
+  cssStylesObj;

--- a/src/views/workflow-history/workflow-history-event-details-placeholder-text/workflow-history-event-details-placeholder-text.tsx
+++ b/src/views/workflow-history/workflow-history-event-details-placeholder-text/workflow-history-event-details-placeholder-text.tsx
@@ -1,0 +1,14 @@
+'use client';
+import React from 'react';
+
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import { cssStyles } from './workflow-history-event-details-placeholder-text.styles';
+import type { Props } from './workflow-history-event-details-placeholder-text.types';
+
+export default function WorkflowHistoryEventDetailsPlaceholderText({
+  placeholderText = 'Not set',
+}: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+  return <div className={cls.placeholderText}>{placeholderText}</div>;
+}

--- a/src/views/workflow-history/workflow-history-event-details-placeholder-text/workflow-history-event-details-placeholder-text.types.ts
+++ b/src/views/workflow-history/workflow-history-event-details-placeholder-text/workflow-history-event-details-placeholder-text.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  placeholderText?: string;
+};

--- a/src/views/workflow-history/workflow-history-timeline-group/__tests__/workflow-history-timeline-group.test.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-group/__tests__/workflow-history-timeline-group.test.tsx
@@ -45,6 +45,14 @@ describe('WorkflowHistoryTimelineGroup', () => {
     expect(screen.getByText('CANCELED')).toBeInTheDocument();
   });
 
+  it('renders badges correctly', () => {
+    setup({
+      badges: [{ content: 'test badge 1' }, { content: 'test badge 2' }],
+    });
+    expect(screen.getByText('test badge 1')).toBeInTheDocument();
+    expect(screen.getByText('test badge 2')).toBeInTheDocument();
+  });
+
   it('renders group timeLabel correctly', () => {
     setup({ timeLabel: 'Started at 19 Sep, 11:37:12 GMT+2' });
 
@@ -92,6 +100,7 @@ function setup({
     runId: 'testRunId',
     workflowTab: 'history',
   },
+  badges,
 }: Partial<Props>) {
   return render(
     <WorkflowHistoryTimelineGroup
@@ -105,6 +114,7 @@ function setup({
       decodedPageUrlParams={decodedPageUrlParams}
       getIsEventExpanded={jest.fn()}
       onEventToggle={jest.fn()}
+      badges={badges}
     />
   );
 }

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.styles.ts
@@ -1,9 +1,30 @@
 import { styled as createStyled, type Theme } from 'baseui';
+import { type BadgeOverrides } from 'baseui/badge';
+import { type StyleObject } from 'styletron-react';
 
 import type {
   StyletronCSSObject,
   StyletronCSSObjectOf,
 } from '@/hooks/use-styletron-classes';
+
+export const overrides = {
+  headerBadge: {
+    Badge: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        backgroundColor: $theme.colors.backgroundSecondary,
+        color: $theme.colors.contentSecondary,
+        ...$theme.typography.LabelXSmall,
+        whiteSpace: 'nowrap',
+        marginTop: $theme.sizing.scale100,
+        marginBottom: $theme.sizing.scale100,
+        [$theme.mediaQuery.medium]: {
+          marginTop: 0,
+          marginBottom: 0,
+        },
+      }),
+    },
+  } satisfies BadgeOverrides,
+};
 
 export const styled = {
   VerticalDivider: createStyled<'div', { $hidden?: boolean }>(

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
@@ -1,12 +1,18 @@
 'use client';
 import React from 'react';
 
+import { Badge } from 'baseui/badge';
+
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 
 import WorkflowHistoryEventStatusBadge from '../workflow-history-event-status-badge/workflow-history-event-status-badge';
 import WorkflowHistoryEventsCard from '../workflow-history-events-card/workflow-history-events-card';
 
-import { cssStyles, styled } from './workflow-history-timeline-group.styles';
+import {
+  cssStyles,
+  overrides,
+  styled,
+} from './workflow-history-timeline-group.styles';
 import { type Props } from './workflow-history-timeline-group.types';
 
 export default function WorkflowHistoryTimelineGroup({
@@ -18,17 +24,31 @@ export default function WorkflowHistoryTimelineGroup({
   eventsMetadata,
   hasMissingEvents,
   decodedPageUrlParams,
+  badges,
   getIsEventExpanded,
   onEventToggle,
 }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
-
+  const hasBadges = badges !== undefined && badges.length > 0;
   return (
     <div className={cls.groupContainer}>
       <div className={cls.timelineEventHeader}>
         <WorkflowHistoryEventStatusBadge status={status} size="medium" />
         <div className={cls.timelineEventLabelAndTime}>
           <div className={cls.timelineEventsLabel}>{label}</div>
+          {hasBadges && (
+            <div>
+              {badges.map((badge) => (
+                <Badge
+                  key={badge.content}
+                  overrides={overrides.headerBadge}
+                  content={badge.content}
+                  shape="rectangle"
+                  color="primary"
+                />
+              ))}
+            </div>
+          )}
           <div suppressHydrationWarning className={cls.timelineEventsTime}>
             {timeLabel}
           </div>

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.types.ts
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.types.ts
@@ -15,6 +15,7 @@ export type Props = Pick<
   | 'label'
   | 'hasMissingEvents'
   | 'status'
+  | 'badges'
 > & {
   isLastEvent: boolean;
   decodedPageUrlParams: WorkflowHistoryProps['params'];

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -149,7 +149,10 @@ export default function WorkflowHistory({ params }: Props) {
           <div role="list" className={cls.compactSection}>
             <Virtuoso
               data={filteredGroupedHistoryEventsEntries}
-              itemContent={(index, [groupId, { label, status, timeLabel }]) => (
+              itemContent={(
+                index,
+                [groupId, { label, status, timeLabel, badges }]
+              ) => (
                 <div role="listitem" className={cls.compactCardContainer}>
                   <WorkflowHistoryCompactEventCard
                     key={groupId}
@@ -157,6 +160,7 @@ export default function WorkflowHistory({ params }: Props) {
                     label={label}
                     secondaryLabel={timeLabel}
                     showLabelPlaceholder={!label}
+                    badges={badges}
                     onClick={() => {
                       timelineSectionListRef.current?.scrollToIndex({
                         index,
@@ -185,6 +189,7 @@ export default function WorkflowHistory({ params }: Props) {
                   timeLabel={group.timeLabel}
                   events={group.events}
                   eventsMetadata={group.eventsMetadata}
+                  badges={group.badges}
                   hasMissingEvents={group.hasMissingEvents}
                   isLastEvent={
                     index === filteredGroupedHistoryEventsEntries.length - 1

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -23,6 +23,10 @@ export type HistoryGroupEventMetadata = {
   timeLabel: string;
 };
 
+export type HistoryGroupBadge = {
+  content: string;
+};
+
 export type HistoryGroupEventToStatusMap<GroupT extends HistoryEventsGroup> =
   Record<
     GroupT['events'][number]['attributes'],
@@ -44,6 +48,7 @@ type BaseHistoryGroup = {
   hasMissingEvents: boolean;
   timeMs: number | null;
   timeLabel: string;
+  badges?: HistoryGroupBadge[];
 };
 
 export type ActivityHistoryGroup = BaseHistoryGroup & {


### PR DESCRIPTION
### Summary
Lifting up the attempts count in the history timeline so it is easier for users to find retrying events. 

### Changes
- Add attempt count badge in both compact and expandable timeline.
- Remove timestamp from the compact view to save space for more useful information.
- Showing  `(maximumAttempts | expirationIntervalInSeconds) ===0` as `Not set`

### Screenshots
Attempts badge
![Screenshot 2024-11-29 at 11 24 48](https://github.com/user-attachments/assets/5c571551-fc9a-4e98-a875-ef8e2c8f39c3)

Showing `0` expirationIntervalInSeconds as `not set`
![Screenshot 2024-11-29 at 12 02 30](https://github.com/user-attachments/assets/c2219985-3194-4a83-a3a1-6fa6e9e809f9)

