### PR TITLE
Misc changes to error handling and useMergedInfiniteQueries

### DIFF
--- a/src/hooks/use-merged-infinite-queries/__tests__/use-merged-infinite-queries.test.ts
+++ b/src/hooks/use-merged-infinite-queries/__tests__/use-merged-infinite-queries.test.ts
@@ -3,6 +3,7 @@ import { act } from 'react-dom/test-utils';
 import { renderHook, waitFor } from '@/test-utils/rtl';
 
 import useMergedInfiniteQueries from '../use-merged-infinite-queries';
+import { UseMergedInfiniteQueriesError } from '../use-merged-infinite-queries-error';
 import { type SingleInfiniteQueryOptions } from '../use-merged-infinite-queries.types';
 
 type MockAPIResponse = {
@@ -105,6 +106,7 @@ describe(useMergedInfiniteQueries.name, () => {
       const [mergedResult] = result.current;
       expect(mergedResult.data).toStrictEqual([0, 2, 4, 6, 8]);
       expect(mergedResult.status).toStrictEqual('error');
+      expect(mergedResult.error).toBeInstanceOf(UseMergedInfiniteQueriesError);
     });
   });
 

--- a/src/hooks/use-merged-infinite-queries/use-merged-infinite-queries-error.ts
+++ b/src/hooks/use-merged-infinite-queries/use-merged-infinite-queries-error.ts
@@ -1,0 +1,8 @@
+export class UseMergedInfiniteQueriesError extends Error {
+  errors: Array<Error>;
+  constructor(message: string, errors: Array<Error>, options?: ErrorOptions) {
+    super(message, options);
+    this.errors = errors;
+    this.name = 'UseMergedInfiniteQueriesError';
+  }
+}

--- a/src/hooks/use-merged-infinite-queries/use-merged-infinite-queries.ts
+++ b/src/hooks/use-merged-infinite-queries/use-merged-infinite-queries.ts
@@ -111,7 +111,12 @@ export default function useMergedInfiniteQueries<TData, TResponse, TPageParam>({
     error: queryResults.some((qr) => qr.isError)
       ? new UseMergedInfiniteQueriesError(
           'One or more infinite queries failed',
-          queryResults.filter((qr) => qr.isError).map((qr) => qr.error)
+          queryResults.reduce((errors: Array<Error>, qr) => {
+            if (qr.isError) {
+              errors.push(qr.error);
+            }
+            return errors;
+          }, [])
         )
       : null,
     refetch: refetchQueriesWithError,

--- a/src/hooks/use-merged-infinite-queries/use-merged-infinite-queries.types.ts
+++ b/src/hooks/use-merged-infinite-queries/use-merged-infinite-queries.types.ts
@@ -5,6 +5,8 @@ import {
   type useInfiniteQuery,
 } from '@tanstack/react-query';
 
+import { type UseMergedInfiniteQueriesError } from './use-merged-infinite-queries-error';
+
 export type MergedQueryStatus = 'idle' | 'loading' | 'success' | 'error';
 
 export type MergedQueriesResults<TData> = {
@@ -15,6 +17,8 @@ export type MergedQueriesResults<TData> = {
   isFetchingNextPage: boolean;
   hasNextPage: boolean;
   fetchNextPage: () => void;
+  error: UseMergedInfiniteQueriesError | null;
+  refetch: () => void;
 };
 
 export type SingleInfiniteQueryOptions<TResponse, TPageParam> =

--- a/src/utils/request/request-error.ts
+++ b/src/utils/request/request-error.ts
@@ -1,8 +1,19 @@
+import { type ZodIssue } from 'zod';
+
 export class RequestError extends Error {
   status: number;
-  constructor(message: string, status: number, options?: ErrorOptions) {
+  validationErrors: Array<ZodIssue> | undefined;
+  constructor(
+    message: string,
+    status: number,
+    validationErrors?: Array<ZodIssue>,
+    options?: ErrorOptions
+  ) {
     super(message, options);
     this.status = status;
+    if (validationErrors?.length) {
+      this.validationErrors = validationErrors;
+    }
     this.name = 'RequestError';
   }
 }

--- a/src/utils/request/request.ts
+++ b/src/utils/request/request.ts
@@ -14,9 +14,14 @@ export default function request(
     async (res) => {
       if (!res.ok) {
         const error = await res.json();
-        throw new RequestError(error.message, res.status, {
-          cause: error.cause,
-        });
+        throw new RequestError(
+          error.message,
+          res.status,
+          error.validationErrors,
+          {
+            cause: error.cause,
+          }
+        );
       }
       return res;
     }


### PR DESCRIPTION
## Summary
- UseMergedInfiniteQueries: Return a merged error object
- utils/request: Add Zod validation errors to RequestError
- Misc: Add a refetch function to refetch queries which errored out
- Misc: fix docstrings in useMergedInfiniteQueries and mergeSortedArrays

## Test plan
Unit tests.