### PR TITLE
Fix loading tasklists with forward slashes

### DIFF
--- a/src/views/task-list-page/task-list-loader/task-list-loader.tsx
+++ b/src/views/task-list-page/task-list-loader/task-list-loader.tsx
@@ -24,7 +24,7 @@ export default function TaskListLoader(props: Props) {
     queryKey: ['describeTaskList', props],
     queryFn: () =>
       request(
-        `/api/domains/${props.domain}/${props.cluster}/task-list/${props.taskListName}`
+        `/api/domains/${encodeURIComponent(props.domain)}/${encodeURIComponent(props.cluster)}/task-list/${encodeURIComponent(props.taskListName)}`
       ).then((res) => res.json()),
     refetchInterval: TASK_LIST_REFETCH_INTERVAL_MS,
   });


### PR DESCRIPTION
## Summary
Encode URI components when making a call to describeTasklist, to fix an issue where tasklists with forward slashes do not load correctly.

## Test plan
Ran locally.