### PR TITLE
Add +1 to attempts, to reflect actual number of times a task was attempted

### DIFF
--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -27,8 +27,9 @@ export default function getActivityGroupFromEvents(
   }
   if (startEvent && startEvent[startAttr]?.attempt) {
     const attempts = startEvent[startAttr].attempt;
+
     badges.push({
-      content: `${attempts} Attempt${attempts !== 1 ? 's' : ''}`,
+      content: `${attempts + 1} Attempts`,
     });
   }
   if (firstEvent.attributes !== 'activityTaskScheduledEventAttributes') {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -26,7 +26,7 @@ export default function getDecisionGroupFromEvents(
   if (scheduleEvent && scheduleEvent[scheduleAttr]?.attempt) {
     const attempts = scheduleEvent[scheduleAttr].attempt;
     badges.push({
-      content: `${attempts} Attempt${attempts !== 1 ? 's' : ''}`,
+      content: `${attempts + 1} Attempts`,
     });
   }
   const eventToLabel: HistoryGroupEventToStringMap<DecisionHistoryGroup> = {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -38,7 +38,7 @@ export default function getSingleEventGroupFromEvents(
   ) {
     const attempts = event.workflowExecutionStartedEventAttributes.attempt;
     badges.push({
-      content: `${attempts} Attempt${attempts !== 1 ? 's' : ''}`,
+      content: `${attempts + 1} Attempts`,
     });
   }
 


### PR DESCRIPTION
## Summary
Since "attempts" is zero-indexed, we need to add 1 to the Attempts badge for tasks that have retried.

## Test plan
Ran locally.
<img width="1075" alt="Screenshot 2024-12-13 at 11 14 30 AM" src="https://github.com/user-attachments/assets/1f2d546c-bb16-4876-8c6a-b48bdda78f48" />
