### PR TITLE
Move fixture from domain-workflows to domain-page

### DIFF
--- a/src/views/domain-page/__fixtures__/domain-page-query-params.ts
+++ b/src/views/domain-page/__fixtures__/domain-page-query-params.ts
@@ -1,7 +1,7 @@
 import { type PageQueryParamValues } from '@/hooks/use-page-query-params/use-page-query-params.types';
 import type domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-query-params.config';
 
-export const mockDomainWorkflowsQueryParamsValues: PageQueryParamValues<
+export const mockDomainPageQueryParamsValues: PageQueryParamValues<
   typeof domainPageQueryParamsConfig
 > = {
   inputType: 'search',

--- a/src/views/domain-workflows-basic/domain-workflows-basic-filters-status/__tests__/domain-workflows-basic-filters-status.test.tsx
+++ b/src/views/domain-workflows-basic/domain-workflows-basic-filters-status/__tests__/domain-workflows-basic-filters-status.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { render, screen, fireEvent, act } from '@/test-utils/rtl';
 
-import { mockDomainWorkflowsQueryParamsValues } from '@/views/domain-workflows/__fixtures__/domain-workflows-query-params';
+import { mockDomainPageQueryParamsValues } from '@/views/domain-page/__fixtures__/domain-page-query-params';
 
 import DomainWorkflowsBasicFiltersStatus from '../domain-workflows-basic-filters-status';
 import { WORKFLOW_STATUS_NAMES_BASIC_VISIBILITY } from '../domain-workflows-basic-filters-status.constants';
@@ -63,7 +63,7 @@ function setup({
   render(
     <DomainWorkflowsBasicFiltersStatus
       value={{
-        statusBasic: mockDomainWorkflowsQueryParamsValues.statusBasic,
+        statusBasic: mockDomainPageQueryParamsValues.statusBasic,
         ...overrides,
       }}
       setValue={mockSetValue}

--- a/src/views/domain-workflows-basic/domain-workflows-basic-filters/__tests__/domain-workflows-basic-filters.test.tsx
+++ b/src/views/domain-workflows-basic/domain-workflows-basic-filters/__tests__/domain-workflows-basic-filters.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import { type Props as PageFiltersToggleProps } from '@/components/page-filters/page-filters-toggle/page-filters-toggle.types';
-import { mockDomainWorkflowsQueryParamsValues } from '@/views/domain-workflows/__fixtures__/domain-workflows-query-params';
+import { mockDomainPageQueryParamsValues } from '@/views/domain-page/__fixtures__/domain-page-query-params';
 
 import DomainWorkflowsBasicFilters from '../domain-workflows-basic-filters';
 
@@ -33,7 +33,7 @@ jest.mock('@/components/page-filters/hooks/use-page-filters', () =>
   jest.fn(() => ({
     resetAllFilters: mockResetAllFilters,
     activeFiltersCount: mockActiveFiltersCount,
-    queryParams: mockDomainWorkflowsQueryParamsValues,
+    queryParams: mockDomainPageQueryParamsValues,
     setQueryParams: mockSetQueryParams,
   }))
 );

--- a/src/views/domain-workflows-basic/domain-workflows-basic-table/__tests__/domain-workflows-basic-table.test.tsx
+++ b/src/views/domain-workflows-basic/domain-workflows-basic-table/__tests__/domain-workflows-basic-table.test.tsx
@@ -6,7 +6,7 @@ import { type Props as LoaderProps } from '@/components/table/table-infinite-scr
 import * as usePageQueryParamsModule from '@/hooks/use-page-query-params/use-page-query-params';
 import { type ListWorkflowsResponse } from '@/route-handlers/list-workflows/list-workflows.types';
 import type { Props as MSWMocksHandlersProps } from '@/test-utils/msw-mock-handlers/msw-mock-handlers.types';
-import { mockDomainWorkflowsQueryParamsValues } from '@/views/domain-workflows/__fixtures__/domain-workflows-query-params';
+import { mockDomainPageQueryParamsValues } from '@/views/domain-page/__fixtures__/domain-page-query-params';
 
 import DomainWorkflowsBasicTable from '../domain-workflows-basic-table';
 
@@ -41,7 +41,7 @@ jest.mock('query-string', () => ({
 
 const mockSetQueryParams = jest.fn();
 jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
-  jest.fn(() => [mockDomainWorkflowsQueryParamsValues, mockSetQueryParams])
+  jest.fn(() => [mockDomainPageQueryParamsValues, mockSetQueryParams])
 );
 
 describe(DomainWorkflowsBasicTable.name, () => {
@@ -133,7 +133,7 @@ describe(DomainWorkflowsBasicTable.name, () => {
   it('calls only listOpen if Running status is selected', async () => {
     jest.spyOn(usePageQueryParamsModule, 'default').mockReturnValue([
       {
-        ...mockDomainWorkflowsQueryParamsValues,
+        ...mockDomainPageQueryParamsValues,
         statusBasic: 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID',
       },
       mockSetQueryParams,
@@ -157,7 +157,7 @@ describe(DomainWorkflowsBasicTable.name, () => {
   it('calls only listClosed if a close status is selected', async () => {
     jest.spyOn(usePageQueryParamsModule, 'default').mockReturnValue([
       {
-        ...mockDomainWorkflowsQueryParamsValues,
+        ...mockDomainPageQueryParamsValues,
         statusBasic: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
       },
       mockSetQueryParams,

--- a/src/views/domain-workflows/domain-workflows-filters-dates/__tests__/domain-workflows-filters-dates.test.tsx
+++ b/src/views/domain-workflows/domain-workflows-filters-dates/__tests__/domain-workflows-filters-dates.test.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { render, screen, act, fireEvent } from '@/test-utils/rtl';
 
 import {
-  mockDomainWorkflowsQueryParamsValues,
+  mockDomainPageQueryParamsValues,
   mockDateOverrides,
-} from '../../__fixtures__/domain-workflows-query-params';
+} from '../../../domain-page/__fixtures__/domain-page-query-params';
 import DomainWorkflowsFiltersDates from '../domain-workflows-filters-dates';
 import { type DomainWorkflowsFiltersDatesValue } from '../domain-workflows-filters-dates.types';
 
@@ -136,8 +136,8 @@ function setup({
   render(
     <DomainWorkflowsFiltersDates
       value={{
-        timeRangeStart: mockDomainWorkflowsQueryParamsValues.timeRangeStart,
-        timeRangeEnd: mockDomainWorkflowsQueryParamsValues.timeRangeEnd,
+        timeRangeStart: mockDomainPageQueryParamsValues.timeRangeStart,
+        timeRangeEnd: mockDomainPageQueryParamsValues.timeRangeEnd,
         ...overrides,
       }}
       setValue={mockSetValue}

--- a/src/views/domain-workflows/domain-workflows-filters-status/__tests__/domain-workflows-filters-status.test.tsx
+++ b/src/views/domain-workflows/domain-workflows-filters-status/__tests__/domain-workflows-filters-status.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, act } from '@/test-utils/rtl';
 
 import { WORKFLOW_STATUS_NAMES } from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
 
-import { mockDomainWorkflowsQueryParamsValues } from '../../__fixtures__/domain-workflows-query-params';
+import { mockDomainPageQueryParamsValues } from '../../../domain-page/__fixtures__/domain-page-query-params';
 import DomainWorkflowsFiltersStatus from '../domain-workflows-filters-status';
 import { type DomainWorkflowsFiltersStatusValue } from '../domain-workflows-filters-status.types';
 
@@ -63,7 +63,7 @@ function setup({
   render(
     <DomainWorkflowsFiltersStatus
       value={{
-        status: mockDomainWorkflowsQueryParamsValues.status,
+        status: mockDomainPageQueryParamsValues.status,
         ...overrides,
       }}
       setValue={mockSetValue}

--- a/src/views/domain-workflows/domain-workflows-header/__tests__/domain-workflows-header.test.tsx
+++ b/src/views/domain-workflows/domain-workflows-header/__tests__/domain-workflows-header.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, userEvent } from '@/test-utils/rtl';
 import * as usePageFiltersModule from '@/components/page-filters/hooks/use-page-filters';
 import { type Props as PageFiltersToggleProps } from '@/components/page-filters/page-filters-toggle/page-filters-toggle.types';
 
-import { mockDomainWorkflowsQueryParamsValues } from '../../__fixtures__/domain-workflows-query-params';
+import { mockDomainPageQueryParamsValues } from '../../../domain-page/__fixtures__/domain-page-query-params';
 import DomainWorkflowsHeader from '../domain-workflows-header';
 
 jest.mock(
@@ -36,7 +36,7 @@ jest.mock('@/components/page-filters/hooks/use-page-filters', () =>
   jest.fn(() => ({
     resetAllFilters: mockResetAllFilters,
     activeFiltersCount: mockActiveFiltersCount,
-    queryParams: mockDomainWorkflowsQueryParamsValues,
+    queryParams: mockDomainPageQueryParamsValues,
     setQueryParams: mockSetQueryParams,
   }))
 );
@@ -83,7 +83,7 @@ describe(DomainWorkflowsHeader.name, () => {
       resetAllFilters: mockResetAllFilters,
       activeFiltersCount: mockActiveFiltersCount,
       queryParams: {
-        ...mockDomainWorkflowsQueryParamsValues,
+        ...mockDomainPageQueryParamsValues,
         inputType: 'query',
       },
       setQueryParams: mockSetQueryParams,

--- a/src/views/domain-workflows/domain-workflows-table/__tests__/domain-workflows-table.test.tsx
+++ b/src/views/domain-workflows/domain-workflows-table/__tests__/domain-workflows-table.test.tsx
@@ -7,7 +7,7 @@ import * as usePageQueryParamsModule from '@/hooks/use-page-query-params/use-pag
 import { type ListWorkflowsResponse } from '@/route-handlers/list-workflows/list-workflows.types';
 
 import type { Props as MSWMocksHandlersProps } from '../../../../test-utils/msw-mock-handlers/msw-mock-handlers.types';
-import { mockDomainWorkflowsQueryParamsValues } from '../../__fixtures__/domain-workflows-query-params';
+import { mockDomainPageQueryParamsValues } from '../../../domain-page/__fixtures__/domain-page-query-params';
 import { type DomainWorkflowsHeaderInputType } from '../../domain-workflows-header/domain-workflows-header.types';
 import DomainWorkflowsTable from '../domain-workflows-table';
 
@@ -56,7 +56,7 @@ jest.mock('query-string', () => ({
 
 const mockSetQueryParams = jest.fn();
 jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
-  jest.fn(() => [mockDomainWorkflowsQueryParamsValues, mockSetQueryParams])
+  jest.fn(() => [mockDomainPageQueryParamsValues, mockSetQueryParams])
 );
 
 describe(DomainWorkflowsTable.name, () => {
@@ -102,7 +102,7 @@ describe(DomainWorkflowsTable.name, () => {
     jest
       .spyOn(usePageQueryParamsModule, 'default')
       .mockReturnValue([
-        { ...mockDomainWorkflowsQueryParamsValues, inputType: 'query' },
+        { ...mockDomainPageQueryParamsValues, inputType: 'query' },
         mockSetQueryParams,
       ]);
 


### PR DESCRIPTION
Move fixture domainWorkflowsQueryParamsValues to domainPageQueryParamsValues since the fixture pertains to all usages of domain page query params