### PR TITLE
fix tests failing due to new year

### DIFF
--- a/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
+++ b/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
@@ -11,6 +11,8 @@ import type {
 } from '../../workflow-history.types';
 import getCommonHistoryGroupFields from '../get-common-history-group-fields';
 
+jest.useFakeTimers().setSystemTime(new Date('2024-05-25'));
+
 describe('getCommonHistoryGroupFields', () => {
   it('should return group eventsMetadata with correct labels', () => {
     const group = setup({});

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -10,6 +10,8 @@ import {
 import type { ActivityHistoryEvent } from '../../../workflow-history.types';
 import getActivityGroupFromEvents from '../get-activity-group-from-events';
 
+jest.useFakeTimers().setSystemTime(new Date('2024-05-25'));
+
 describe('getActivityGroupFromEvents', () => {
   it('should return a group with a proper label when scheduled event exists', () => {
     const events: ActivityHistoryEvent[] = [scheduleActivityTaskEvent];

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -11,6 +11,8 @@ import {
 import type { ChildWorkflowExecutionHistoryEvent } from '../../../workflow-history.types';
 import getChildWorkflowExecutionGroupFromEvents from '../get-child-workflow-execution-group-from-events';
 
+jest.useFakeTimers().setSystemTime(new Date('2024-05-25'));
+
 describe('getChildWorkflowExecutionGroupFromEvents', () => {
   it('should return a group with a proper label', () => {
     const events: ChildWorkflowExecutionHistoryEvent[] = [

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -9,6 +9,8 @@ import {
 import type { DecisionHistoryEvent } from '../../../workflow-history.types';
 import getDecisionGroupFromEvents from '../get-decision-group-from-events';
 
+jest.useFakeTimers().setSystemTime(new Date('2024-05-25'));
+
 describe('getDecisionGroupFromEvents', () => {
   it('should return a group with a proper label when scheduled event exists', () => {
     const events: DecisionHistoryEvent[] = [scheduleDecisionTaskEvent];

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
@@ -6,6 +6,8 @@ import {
 import type { RequestCancelExternalWorkflowExecutionHistoryEvent } from '../../../workflow-history.types';
 import getRequestCancelExternalWorkflowExecutionGroupFromEvents from '../get-request-cancel-external-workflow-execution-group-from-events';
 
+jest.useFakeTimers().setSystemTime(new Date('2024-05-25'));
+
 describe('getRequestCancelExternalWorkflowExecutionGroupFromEvents', () => {
   it('should return a group with a correct label', () => {
     const events: RequestCancelExternalWorkflowExecutionHistoryEvent[] = [

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -7,6 +7,8 @@ import {
 import type { SignalExternalWorkflowExecutionHistoryEvent } from '../../../workflow-history.types';
 import getSignalExternalWorkflowExecutionGroupFromEvents from '../get-signal-external-workflow-execution-group-from-events';
 
+jest.useFakeTimers().setSystemTime(new Date('2024-05-25'));
+
 describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
   it('should return a group with a correct label', () => {
     const events: SignalExternalWorkflowExecutionHistoryEvent[] = [

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -7,6 +7,8 @@ import {
 import type { TimerHistoryEvent } from '../../../workflow-history.types';
 import getTimerGroupFromEvents from '../get-timer-group-from-events';
 
+jest.useFakeTimers().setSystemTime(new Date('2024-05-25'));
+
 describe('getTimerGroupFromEvents', () => {
   it('should return a group with a correct label', () => {
     const events: TimerHistoryEvent[] = [startTimerTaskEvent];


### PR DESCRIPTION
### Summary
Fix unit tests that depends on the current time to format dates. issue solved by faking system time for those test cases.