### PR TITLE
Add panel for domains with archival disabled

### DIFF
--- a/src/components/panel-section/panel-section.styles.ts
+++ b/src/components/panel-section/panel-section.styles.ts
@@ -1,18 +1,21 @@
 import { styled as createStyled, type Theme } from 'baseui';
 
 export const styled = {
-  PanelContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'column',
-    gap: $theme.sizing.scale600,
-    padding: `${$theme.sizing.scale900} ${$theme.sizing.scale600}`,
-  })),
-  Spacer: createStyled<'div', { $heightPercent: number }>(
-    'div',
-    ({ $heightPercent }) => ({
-      flex: `1 1 ${$heightPercent}%`,
+  PanelSectionContainer: createStyled(
+    'section',
+    ({ $theme }: { $theme: Theme }) => ({
+      display: 'flex',
+      alignItems: 'center',
+      flex: 1,
+      flexDirection: 'column',
+      gap: $theme.sizing.scale600,
+      paddingTop: $theme.sizing.scale900,
+      paddingBottom: $theme.sizing.scale1200,
+      paddingLeft: $theme.sizing.scale600,
+      paddingRight: $theme.sizing.scale600,
     })
   ),
+  Spacer: createStyled<'div', { $height: string }>('div', ({ $height }) => ({
+    flex: `1 1 ${$height}`,
+  })),
 };

--- a/src/components/panel-section/panel-section.styles.ts
+++ b/src/components/panel-section/panel-section.styles.ts
@@ -1,0 +1,18 @@
+import { styled as createStyled, type Theme } from 'baseui';
+
+export const styled = {
+  PanelContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'column',
+    gap: $theme.sizing.scale600,
+    padding: `${$theme.sizing.scale900} ${$theme.sizing.scale600}`,
+  })),
+  Spacer: createStyled<'div', { $heightPercent: number }>(
+    'div',
+    ({ $heightPercent }) => ({
+      flex: `1 1 ${$heightPercent}%`,
+    })
+  ),
+};

--- a/src/components/panel-section/panel-section.tsx
+++ b/src/components/panel-section/panel-section.tsx
@@ -1,0 +1,12 @@
+import { styled } from './panel-section.styles';
+import { type Props } from './panel-section.types';
+
+export default function PanelSection({ children, heightPercent }: Props) {
+  return (
+    <styled.PanelContainer>
+      <styled.Spacer $heightPercent={heightPercent} />
+      {children}
+      <styled.Spacer $heightPercent={100 - heightPercent} />
+    </styled.PanelContainer>
+  );
+}

--- a/src/components/panel-section/panel-section.tsx
+++ b/src/components/panel-section/panel-section.tsx
@@ -1,12 +1,12 @@
 import { styled } from './panel-section.styles';
 import { type Props } from './panel-section.types';
 
-export default function PanelSection({ children, heightPercent }: Props) {
+export default function PanelSection({ children }: Props) {
   return (
-    <styled.PanelContainer>
-      <styled.Spacer $heightPercent={heightPercent} />
+    <styled.PanelSectionContainer>
+      <styled.Spacer $height="40%" />
       {children}
-      <styled.Spacer $heightPercent={100 - heightPercent} />
-    </styled.PanelContainer>
+      <styled.Spacer $height="60%" />
+    </styled.PanelSectionContainer>
   );
 }

--- a/src/components/panel-section/panel-section.types.ts
+++ b/src/components/panel-section/panel-section.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  children: React.ReactNode;
+  heightPercent: number;
+};

--- a/src/components/panel-section/panel-section.types.ts
+++ b/src/components/panel-section/panel-section.types.ts
@@ -1,4 +1,3 @@
 export type Props = {
   children: React.ReactNode;
-  heightPercent: number;
 };

--- a/src/views/domain-workflows-archival/__tests__/domain-workflows-archival.test.tsx
+++ b/src/views/domain-workflows-archival/__tests__/domain-workflows-archival.test.tsx
@@ -14,11 +14,18 @@ jest.mock(
   () => jest.fn(() => <div>Mock archival header</div>)
 );
 
+jest.mock(
+  '../domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel',
+  () => jest.fn(() => <div>Mock archival disabled panel</div>)
+);
+
 describe(DomainWorkflowsArchival.name, () => {
   it('renders without error and shows archival disabled page', async () => {
     await setup({});
 
-    expect(await screen.findByText('Archival disabled')).toBeInTheDocument();
+    expect(
+      await screen.findByText('Mock archival disabled panel')
+    ).toBeInTheDocument();
   });
 
   it('renders without error and shows archival content', async () => {

--- a/src/views/domain-workflows-archival/config/domain-workflows-archival-disabled-panel.config.ts
+++ b/src/views/domain-workflows-archival/config/domain-workflows-archival-disabled-panel.config.ts
@@ -1,0 +1,16 @@
+import { type ArchivalDisabledPanelConfig } from '../domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.types';
+
+const domainWorkflowsArchivalDisabledPanelConfig = {
+  title: 'Archival not enabled for domain',
+  details: [
+    'This domain currently does not have history archival and/or visibility archival enabled.',
+  ],
+  links: [
+    {
+      text: 'Check out the docs',
+      href: 'https://cadenceworkflow.io/docs/concepts/archival',
+    },
+  ],
+} as const satisfies ArchivalDisabledPanelConfig;
+
+export default domainWorkflowsArchivalDisabledPanelConfig;

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/__tests__/domain-workflows-archival-disabled-panel.test.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/__tests__/domain-workflows-archival-disabled-panel.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import DomainWorkflowsArchivalDisabledPanel from '../domain-workflows-archival-disabled-panel';
+import { type ArchivalDisabledPanelConfig } from '../domain-workflows-archival-disabled-panel.types';
+
+jest.mock(
+  '../../config/domain-workflows-archival-disabled-panel.config',
+  () =>
+    ({
+      title: 'Mock archival disabled title',
+      details: [
+        'Mock archival disabled detail 1',
+        'Mock archival disabled detail 2',
+      ],
+      links: [
+        {
+          text: 'Mock docs CTA',
+          href: 'https://mock.docs.link',
+        },
+      ],
+    }) satisfies ArchivalDisabledPanelConfig
+);
+
+describe(DomainWorkflowsArchivalDisabledPanel.name, () => {
+  it('renders panel correctly', async () => {
+    render(<DomainWorkflowsArchivalDisabledPanel />);
+
+    expect(
+      screen.getByText('Mock archival disabled title')
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText('Mock archival disabled detail 1')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Mock archival disabled detail 2')
+    ).toBeInTheDocument();
+
+    const docsLink = await screen.findByText('Mock docs CTA');
+    expect(docsLink).toBeInTheDocument();
+    expect(docsLink).toHaveAttribute('href', 'https://mock.docs.link');
+  });
+});

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.styles.ts
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.styles.ts
@@ -1,20 +1,6 @@
 import { styled as createStyled, type Theme } from 'baseui';
 
 export const styled = {
-  PanelContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    flex: 1,
-    flexDirection: 'column',
-    gap: $theme.sizing.scale600,
-    padding: `${$theme.sizing.scale900} ${$theme.sizing.scale600}`,
-  })),
-  TopSpacer: createStyled('div', {
-    flex: '1 1 35%',
-  }),
-  BottomSpacer: createStyled('div', {
-    flex: '1 1 65%',
-  }),
   Title: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
     ...$theme.typography.HeadingXSmall,
   })),
@@ -22,9 +8,21 @@ export const styled = {
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
+    textAlign: 'center',
   }),
-  Subtitle: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+  Detail: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
     ...$theme.typography.ParagraphLarge,
     color: $theme.colors.contentSecondary,
+  })),
+  LinksContainer: createStyled('div', {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  }),
+  LinkContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.ParagraphLarge,
+    display: 'flex',
+    alignItems: 'center',
+    gap: $theme.sizing.scale200,
   })),
 };

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.styles.ts
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.styles.ts
@@ -1,0 +1,30 @@
+import { styled as createStyled, type Theme } from 'baseui';
+
+export const styled = {
+  PanelContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    flex: 1,
+    flexDirection: 'column',
+    gap: $theme.sizing.scale600,
+    padding: `${$theme.sizing.scale900} ${$theme.sizing.scale600}`,
+  })),
+  TopSpacer: createStyled('div', {
+    flex: '1 1 35%',
+  }),
+  BottomSpacer: createStyled('div', {
+    flex: '1 1 65%',
+  }),
+  Title: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.HeadingXSmall,
+  })),
+  Content: createStyled('div', {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  }),
+  Subtitle: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.ParagraphLarge,
+    color: $theme.colors.contentSecondary,
+  })),
+};

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.tsx
@@ -1,0 +1,26 @@
+import Image from 'next/image';
+
+import errorIcon from '@/assets/error-icon.svg';
+
+import { styled } from './domain-workflows-archival-disabled-panel.styles';
+
+export default function DomainWorkflowsArchivalDisabledPanel() {
+  return (
+    <styled.PanelContainer>
+      <styled.TopSpacer />
+      <Image width={64} height={64} alt="Error" src={errorIcon} />
+      <styled.Title>Archival not enabled for domain</styled.Title>
+      <styled.Content>
+        <styled.Subtitle>
+          This domain currently does not have history archival and/or visibility
+          archival enabled.
+        </styled.Subtitle>
+        <styled.Subtitle>
+          To enable the Cadence UI archival screen you will need to enable both
+          history archival and visibility archival.
+        </styled.Subtitle>
+      </styled.Content>
+      <styled.BottomSpacer />
+    </styled.PanelContainer>
+  );
+}

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.tsx
@@ -1,26 +1,40 @@
 import Image from 'next/image';
+import { MdOpenInNew } from 'react-icons/md';
 
 import errorIcon from '@/assets/error-icon.svg';
+import Link from '@/components/link/link';
+import PanelSection from '@/components/panel-section/panel-section';
+
+import domainWorkflowsArchivalDisabledPanelConfig from '../config/domain-workflows-archival-disabled-panel.config';
 
 import { styled } from './domain-workflows-archival-disabled-panel.styles';
 
 export default function DomainWorkflowsArchivalDisabledPanel() {
   return (
-    <styled.PanelContainer>
-      <styled.TopSpacer />
+    <PanelSection heightPercent={35}>
       <Image width={64} height={64} alt="Error" src={errorIcon} />
-      <styled.Title>Archival not enabled for domain</styled.Title>
+      <styled.Title>
+        {domainWorkflowsArchivalDisabledPanelConfig.title}
+      </styled.Title>
       <styled.Content>
-        <styled.Subtitle>
-          This domain currently does not have history archival and/or visibility
-          archival enabled.
-        </styled.Subtitle>
-        <styled.Subtitle>
-          To enable the Cadence UI archival screen you will need to enable both
-          history archival and visibility archival.
-        </styled.Subtitle>
+        {domainWorkflowsArchivalDisabledPanelConfig.details.map(
+          (detail, index) => (
+            <styled.Detail key={`details-${index}`}>{detail}</styled.Detail>
+          )
+        )}
       </styled.Content>
-      <styled.BottomSpacer />
-    </styled.PanelContainer>
+      <styled.LinksContainer>
+        {domainWorkflowsArchivalDisabledPanelConfig.links.map(
+          ({ text, href }) => (
+            <styled.LinkContainer key={`link-${href}`}>
+              <Link href={href} target="_blank" rel="noreferrer">
+                {text}
+              </Link>
+              <MdOpenInNew />
+            </styled.LinkContainer>
+          )
+        )}
+      </styled.LinksContainer>
+    </PanelSection>
   );
 }

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.tsx
@@ -11,8 +11,8 @@ import { styled } from './domain-workflows-archival-disabled-panel.styles';
 
 export default function DomainWorkflowsArchivalDisabledPanel() {
   return (
-    <PanelSection heightPercent={35}>
-      <Image width={64} height={64} alt="Error" src={errorIcon} />
+    <PanelSection>
+      <Image width={64} alt="Error" src={errorIcon} />
       <styled.Title>
         {domainWorkflowsArchivalDisabledPanelConfig.title}
       </styled.Title>

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.types.ts
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  isHistoryArchivalEnabled: boolean;
+  isVisibilityArchivalEnabled: boolean;
+};

--- a/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.types.ts
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel.types.ts
@@ -2,3 +2,12 @@ export type Props = {
   isHistoryArchivalEnabled: boolean;
   isVisibilityArchivalEnabled: boolean;
 };
+
+export type ArchivalDisabledPanelConfig = {
+  title: string;
+  details: Array<string>;
+  links: Array<{
+    href: string;
+    text: string;
+  }>;
+};

--- a/src/views/domain-workflows-archival/domain-workflows-archival.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival.tsx
@@ -7,6 +7,7 @@ import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-
 
 import { type DomainInfo } from '../domain-page/domain-page.types';
 
+import DomainWorkflowsArchivalDisabledPanel from './domain-workflows-archival-disabled-panel/domain-workflows-archival-disabled-panel';
 import DomainWorkflowsArchivalHeader from './domain-workflows-archival-header/domain-workflows-archival-header';
 
 export default function DomainWorkflowsArchival(
@@ -26,8 +27,7 @@ export default function DomainWorkflowsArchival(
     historyArchivalStatus !== 'ARCHIVAL_STATUS_ENABLED' ||
     visibilityArchivalStatus !== 'ARCHIVAL_STATUS_ENABLED'
   ) {
-    // TODO: archival landing page
-    return <div>Archival disabled</div>;
+    return <DomainWorkflowsArchivalDisabledPanel />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- Add PanelSection shared component to allow wrapping panels while keeping them slightly off-center vertically
- Add short descriptive panel for domains with archival disabled

## Test plan
Unit tests + ran locally.

<img width="1616" alt="Screenshot 2025-01-03 at 3 17 15 PM" src="https://github.com/user-attachments/assets/9519edd2-5ef6-4345-b0e1-3a29e6737368" />
<img width="1664" alt="Screenshot 2025-01-03 at 3 17 27 PM" src="https://github.com/user-attachments/assets/ff7ae12a-e368-49c7-a1df-1a93644421af" />

