### PR TITLE
Fix attempts badge and history event detail

### DIFF
--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -79,6 +79,11 @@ const workflowHistoryEventDetailsConfig = [
       });
     },
   },
+  {
+    name: 'Retry config attempt as retryAttempt',
+    key: 'attempt',
+    getLabel: () => 'retryAttempt',
+  },
 ] as const satisfies WorkflowHistoryEventDetailsConfig[];
 
 export default workflowHistoryEventDetailsConfig;

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -26,10 +26,13 @@ export default function getActivityGroupFromEvents(
     label = `Activity ${scheduleEvent[scheduleAttr]?.activityId}: ${scheduleEvent[scheduleAttr]?.activityType?.name}`;
   }
   if (startEvent && startEvent[startAttr]?.attempt) {
-    const attempts = startEvent[startAttr].attempt;
+    const currentAttemptNumber = startEvent[startAttr].attempt;
 
     badges.push({
-      content: `${attempts + 1} Attempts`,
+      content:
+        currentAttemptNumber === 1
+          ? '1 Retry'
+          : `${currentAttemptNumber} Retries`,
     });
   }
   if (firstEvent.attributes !== 'activityTaskScheduledEventAttributes') {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -26,13 +26,11 @@ export default function getActivityGroupFromEvents(
     label = `Activity ${scheduleEvent[scheduleAttr]?.activityId}: ${scheduleEvent[scheduleAttr]?.activityType?.name}`;
   }
   if (startEvent && startEvent[startAttr]?.attempt) {
-    const currentAttemptNumber = startEvent[startAttr].attempt;
+    const retryAttemptNumber = startEvent[startAttr].attempt;
 
     badges.push({
       content:
-        currentAttemptNumber === 1
-          ? '1 Retry'
-          : `${currentAttemptNumber} Retries`,
+        retryAttemptNumber === 1 ? '1 Retry' : `${retryAttemptNumber} Retries`,
     });
   }
   if (firstEvent.attributes !== 'activityTaskScheduledEventAttributes') {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -24,13 +24,11 @@ export default function getDecisionGroupFromEvents(
   }
 
   if (scheduleEvent && scheduleEvent[scheduleAttr]?.attempt) {
-    const currentAttemptNumber = scheduleEvent[scheduleAttr].attempt;
+    const retryAttemptNumber = scheduleEvent[scheduleAttr].attempt;
 
     badges.push({
       content:
-        currentAttemptNumber === 1
-          ? '1 Retry'
-          : `${currentAttemptNumber} Retries`,
+        retryAttemptNumber === 1 ? '1 Retry' : `${retryAttemptNumber} Retries`,
     });
   }
   const eventToLabel: HistoryGroupEventToStringMap<DecisionHistoryGroup> = {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -24,9 +24,13 @@ export default function getDecisionGroupFromEvents(
   }
 
   if (scheduleEvent && scheduleEvent[scheduleAttr]?.attempt) {
-    const attempts = scheduleEvent[scheduleAttr].attempt;
+    const currentAttemptNumber = scheduleEvent[scheduleAttr].attempt;
+
     badges.push({
-      content: `${attempts + 1} Attempts`,
+      content:
+        currentAttemptNumber === 1
+          ? '1 Retry'
+          : `${currentAttemptNumber} Retries`,
     });
   }
   const eventToLabel: HistoryGroupEventToStringMap<DecisionHistoryGroup> = {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -36,9 +36,14 @@ export default function getSingleEventGroupFromEvents(
     event.attributes === 'workflowExecutionStartedEventAttributes' &&
     event.workflowExecutionStartedEventAttributes?.attempt
   ) {
-    const attempts = event.workflowExecutionStartedEventAttributes.attempt;
+    const currentAttemptNumber =
+      event.workflowExecutionStartedEventAttributes.attempt;
+
     badges.push({
-      content: `${attempts + 1} Attempts`,
+      content:
+        currentAttemptNumber === 1
+          ? '1 Retry'
+          : `${currentAttemptNumber} Retries`,
     });
   }
 

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -36,14 +36,12 @@ export default function getSingleEventGroupFromEvents(
     event.attributes === 'workflowExecutionStartedEventAttributes' &&
     event.workflowExecutionStartedEventAttributes?.attempt
   ) {
-    const currentAttemptNumber =
+    const retryAttemptNumber =
       event.workflowExecutionStartedEventAttributes.attempt;
 
     badges.push({
       content:
-        currentAttemptNumber === 1
-          ? '1 Retry'
-          : `${currentAttemptNumber} Retries`,
+        retryAttemptNumber === 1 ? '1 Retry' : `${retryAttemptNumber} Retries`,
     });
   }
 


### PR DESCRIPTION
## Summary
- Rename "Attempts" in badge to "Retries" and make it 0-indexed
- Label "attempt" field in history event details as "retryAttempt"

## Test plan
Ran locally.

<img width="604" alt="Screenshot 2025-01-03 at 1 05 25 PM" src="https://github.com/user-attachments/assets/a0565dfb-b7a1-40dc-951d-f155a1ea2582" />
<img width="1252" alt="Screenshot 2025-01-03 at 1 04 28 PM" src="https://github.com/user-attachments/assets/580186d1-c6b4-4c87-9008-e1fffa1ae990" />
 