### PR TITLE
fix formatting decisions file names issue

### DIFF
--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
@@ -19,18 +19,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
-import { type DecisionTaskStartedEvent } from './format-workflow-history-event.type';
+import formatDurationToSeconds from '../format-duration-to-seconds';
+import formatEnum from '../format-enum';
 
-const formatDecisionTaskStartedEvent = ({
-  decisionTaskStartedEventAttributes: { scheduledEventId, ...eventAttributes },
+import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
+import { type DecisionTaskScheduledEvent } from './format-workflow-history-event.type';
+
+const formatDecisionTaskScheduledEvent = ({
+  decisionTaskScheduledEventAttributes: {
+    startToCloseTimeout,
+    taskList,
+    ...eventAttributes
+  },
   ...eventFields
-}: DecisionTaskStartedEvent) => {
+}: DecisionTaskScheduledEvent) => {
   return {
     ...formatWorkflowCommonEventFields(eventFields),
     ...eventAttributes,
-    scheduledEventId: parseInt(scheduledEventId),
+    taskList: {
+      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
+      name: taskList?.name || null,
+    },
+    startToCloseTimeoutSeconds: formatDurationToSeconds(startToCloseTimeout),
   };
 };
 
-export default formatDecisionTaskStartedEvent;
+export default formatDecisionTaskScheduledEvent;

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
@@ -19,29 +19,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import formatDurationToSeconds from '../format-duration-to-seconds';
-import formatEnum from '../format-enum';
-
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
-import { type DecisionTaskScheduledEvent } from './format-workflow-history-event.type';
+import { type DecisionTaskStartedEvent } from './format-workflow-history-event.type';
 
-const formatDecisionTaskScheduledEvent = ({
-  decisionTaskScheduledEventAttributes: {
-    startToCloseTimeout,
-    taskList,
-    ...eventAttributes
-  },
+const formatDecisionTaskStartedEvent = ({
+  decisionTaskStartedEventAttributes: { scheduledEventId, ...eventAttributes },
   ...eventFields
-}: DecisionTaskScheduledEvent) => {
+}: DecisionTaskStartedEvent) => {
   return {
     ...formatWorkflowCommonEventFields(eventFields),
     ...eventAttributes,
-    taskList: {
-      kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
-      name: taskList?.name || null,
-    },
-    startToCloseTimeoutSeconds: formatDurationToSeconds(startToCloseTimeout),
+    scheduledEventId: parseInt(scheduledEventId),
   };
 };
 
-export default formatDecisionTaskScheduledEvent;
+export default formatDecisionTaskStartedEvent;

--- a/src/utils/data-formatters/schema/format-history-event-schema.ts
+++ b/src/utils/data-formatters/schema/format-history-event-schema.ts
@@ -18,8 +18,8 @@ import formatChildWorkflowExecutionStartedEvent from '../format-workflow-history
 import formatChildWorkflowExecutionTimedOutEvent from '../format-workflow-history-event/format-child-workflow-execution-timed-out-event';
 import formatDecisionTaskCompletedEvent from '../format-workflow-history-event/format-decision-task-completed-event';
 import formatDecisionTaskFailedEvent from '../format-workflow-history-event/format-decision-task-failed-event';
-import formatDecisionTaskStartedEvent from '../format-workflow-history-event/format-decision-task-scheduled-event';
-import formatDecisionTaskScheduledEvent from '../format-workflow-history-event/format-decision-task-started-event';
+import formatDecisionTaskScheduledEvent from '../format-workflow-history-event/format-decision-task-scheduled-event';
+import formatDecisionTaskStartedEvent from '../format-workflow-history-event/format-decision-task-started-event';
 import formatDecisionTaskTimedOutEvent from '../format-workflow-history-event/format-decision-timed-out-event';
 import formatExternalWorkflowExecutionCancelRequestedEvent from '../format-workflow-history-event/format-external-workflow-execution-cancel-requested-event';
 import formatExternalWorkflowExecutionSignaledEvent from '../format-workflow-history-event/format-external-workflow-execution-signaled-event';


### PR DESCRIPTION
### Summary
Switch decision scheduled and started files content as they are named incorrectly.