### PR TITLE
Manage dates using dayjs library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@tanstack/react-query-next-experimental": "^5.45.0",
         "baseui": "^14.0.0",
         "copy-to-clipboard": "^3.3.3",
-        "date-fns": "^2.30.0",
+        "dayjs": "^1.11.13",
         "lodash": "^4.17.21",
         "lossless-json": "^4.0.2",
         "next": "14.2.16",
@@ -4109,6 +4109,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://unpm.uberinternal.com/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha1-kkMLATkFXD67YBUKoT6GCktaNmw=",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4112,9 +4112,8 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.13",
-      "resolved": "https://unpm.uberinternal.com/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha1-kkMLATkFXD67YBUKoT6GCktaNmw=",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@tanstack/react-query-next-experimental": "^5.45.0",
     "baseui": "^14.0.0",
     "copy-to-clipboard": "^3.3.3",
-    "date-fns": "^2.30.0",
+    "dayjs": "^1.11.13",
     "lodash": "^4.17.21",
     "lossless-json": "^4.0.2",
     "next": "14.2.16",

--- a/src/utils/data-formatters/__tests__/format-date.test.ts
+++ b/src/utils/data-formatters/__tests__/format-date.test.ts
@@ -5,13 +5,13 @@ jest.useFakeTimers().setSystemTime(new Date('2023-05-25'));
 describe(formatDate.name, () => {
   it('returns formatted date for the current year', () => {
     expect(formatDate(new Date('2023-01-01T12:34:56').getTime())).toEqual(
-      '01 Jan, 12:34:56 GMT+0'
+      '01 Jan, 12:34:56 UTC'
     );
   });
 
   it('returns formatted date for a prior year', () => {
     expect(formatDate(new Date('2022-01-01T12:34:56').getTime())).toEqual(
-      '01 Jan 2022, 12:34:56 GMT+0'
+      '01 Jan 2022, 12:34:56 UTC'
     );
   });
 });

--- a/src/utils/data-formatters/format-date.ts
+++ b/src/utils/data-formatters/format-date.ts
@@ -1,9 +1,9 @@
-import { format, isThisYear } from 'date-fns';
+import dayjs from '@/utils/datetime/dayjs';
 
 export default function formatDate(timestampMs: number) {
-  const date = new Date(timestampMs);
-  return format(
-    date,
-    isThisYear(date) ? 'dd MMM, HH:mm:ss z' : 'dd MMM yyyy, HH:mm:ss z'
+  const date = dayjs(timestampMs);
+  const now = dayjs();
+  return date.format(
+    date.isSame(now, 'year') ? 'DD MMM, HH:mm:ss z' : 'DD MMM YYYY, HH:mm:ss z'
   );
 }

--- a/src/utils/datetime/__tests__/dayjs.test.ts
+++ b/src/utils/datetime/__tests__/dayjs.test.ts
@@ -1,0 +1,30 @@
+import dayjs from '../dayjs';
+
+describe('dayjs utility', () => {
+  it('should format date using advancedFormat plugin', () => {
+    const date = dayjs('2024-05-25');
+    expect(date.format('MMMM Do YYYY')).toBe('May 25th 2024');
+  });
+
+  it('should calculate relative time using relativeTime plugin', () => {
+    const now = dayjs();
+    const futureDate = now.add(2, 'day');
+    expect(futureDate.from(now)).toBe('in 2 days');
+  });
+
+  it('should calculate duration using duration plugin', () => {
+    const duration = dayjs.duration({ hours: 2, minutes: 30 });
+    expect(duration.humanize()).toBe('3 hours');
+  });
+
+  it('should handle UTC time using utc plugin', () => {
+    const date = dayjs.utc('2024-05-25T00:00:00Z');
+    expect(date.format()).toBe('2024-05-25T00:00:00+00:00');
+    expect(date.isUTC()).toBe(true);
+  });
+
+  it('should handle timezone using timezone plugin', () => {
+    const date = dayjs('2024-05-25T00:00:00Z').tz('America/New_York');
+    expect(date.format()).toBe('2024-05-24T20:00:00-04:00');
+  });
+});

--- a/src/utils/datetime/dayjs.ts
+++ b/src/utils/datetime/dayjs.ts
@@ -1,0 +1,14 @@
+import { default as dayjs } from 'dayjs';
+import advancedFormat from 'dayjs/plugin/advancedFormat';
+import duration from 'dayjs/plugin/duration';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import timezone from 'dayjs/plugin/timezone';
+import utc from 'dayjs/plugin/utc';
+
+dayjs.extend(relativeTime);
+dayjs.extend(duration);
+dayjs.extend(utc);
+dayjs.extend(timezone);
+dayjs.extend(advancedFormat);
+
+export default dayjs;

--- a/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
+++ b/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
@@ -40,8 +40,8 @@ describe('getCommonHistoryGroupFields', () => {
   it('should return group eventsMetadata with correct timeLabel', () => {
     const group = setup({});
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Started at 07 Sep, 22:32:50 GMT+0',
-      'Fired at 07 Sep, 22:34:30 GMT+0',
+      'Started at 07 Sep, 22:32:50 UTC',
+      'Fired at 07 Sep, 22:34:30 UTC',
     ]);
   });
 
@@ -52,8 +52,8 @@ describe('getCommonHistoryGroupFields', () => {
       },
     });
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Happend at 07 Sep, 22:32:50 GMT+0',
-      'Fired at 07 Sep, 22:34:30 GMT+0',
+      'Happend at 07 Sep, 22:32:50 UTC',
+      'Fired at 07 Sep, 22:34:30 UTC',
     ]);
   });
 

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -181,9 +181,9 @@ describe('getActivityGroupFromEvents', () => {
     ];
     const group = getActivityGroupFromEvents(events);
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Scheduled at 07 Sep, 22:16:10 GMT+0',
-      'Started at 07 Sep, 22:16:10 GMT+0',
-      'Completed at 07 Sep, 22:16:10 GMT+0',
+      'Scheduled at 07 Sep, 22:16:10 UTC',
+      'Started at 07 Sep, 22:16:10 UTC',
+      'Completed at 07 Sep, 22:16:10 UTC',
     ]);
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -201,13 +201,13 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     ];
     const group = getChildWorkflowExecutionGroupFromEvents(events);
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Initiated at 21 Jun 1975, 10:47:51 GMT+0',
-      'Initiation failed at 08 Sep, 04:27:52 GMT+0',
-      'Started at 08 Sep, 04:27:53 GMT+0',
-      'Completed at 08 Sep, 04:27:54 GMT+0',
-      'Failed at 08 Sep, 04:27:58 GMT+0',
-      'Timed out at 08 Sep, 04:27:57 GMT+0',
-      'Canceled at 08 Sep, 04:27:55 GMT+0',
+      'Initiated at 21 Jun 1975, 10:47:51 UTC',
+      'Initiation failed at 08 Sep, 04:27:52 UTC',
+      'Started at 08 Sep, 04:27:53 UTC',
+      'Completed at 08 Sep, 04:27:54 UTC',
+      'Failed at 08 Sep, 04:27:58 UTC',
+      'Timed out at 08 Sep, 04:27:57 UTC',
+      'Canceled at 08 Sep, 04:27:55 UTC',
     ]);
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -138,9 +138,9 @@ describe('getDecisionGroupFromEvents', () => {
     ];
     const group = getDecisionGroupFromEvents(events);
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Scheduled at 07 Sep, 22:16:10 GMT+0',
-      'Started at 07 Sep, 22:16:10 GMT+0',
-      'Completed at 07 Sep, 22:16:10 GMT+0',
+      'Scheduled at 07 Sep, 22:16:10 UTC',
+      'Started at 07 Sep, 22:16:10 UTC',
+      'Completed at 07 Sep, 22:16:10 UTC',
     ]);
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
@@ -85,8 +85,8 @@ describe('getRequestCancelExternalWorkflowExecutionGroupFromEvents', () => {
     const group =
       getRequestCancelExternalWorkflowExecutionGroupFromEvents(events);
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Initiated at 07 Sep, 22:51:10 GMT+0',
-      'Requested at 07 Sep, 22:52:50 GMT+0',
+      'Initiated at 07 Sep, 22:51:10 UTC',
+      'Requested at 07 Sep, 22:52:50 UTC',
     ]);
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -104,8 +104,8 @@ describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
     ];
     const group = getSignalExternalWorkflowExecutionGroupFromEvents(events);
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Initiated at 08 Sep, 04:24:30 GMT+0',
-      'Signaled at 08 Sep, 04:26:10 GMT+0',
+      'Initiated at 08 Sep, 04:24:30 UTC',
+      'Signaled at 08 Sep, 04:26:10 UTC',
     ]);
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -91,8 +91,8 @@ describe('getTimerGroupFromEvents', () => {
     ];
     const group = getTimerGroupFromEvents(events);
     expect(group.eventsMetadata.map(({ timeLabel }) => timeLabel)).toEqual([
-      'Started at 07 Sep, 22:32:50 GMT+0',
-      'Fired at 07 Sep, 22:34:30 GMT+0',
+      'Started at 07 Sep, 22:32:50 UTC',
+      'Fired at 07 Sep, 22:34:30 UTC',
     ]);
   });
 });


### PR DESCRIPTION
### Summary
Moving from date-fns to dayjs

### Changes
- Remove date-fns
- add dayjs library
- create dayjs util with default plugins
- use dayjs in the date formatter function 