### PR TITLE
History page - unify "Ongoing" and "Waiting" filters into "Pending"

### DIFF
--- a/src/views/workflow-history/workflow-history-filters-status/__tests__/workflow-history-filters-status.test.tsx
+++ b/src/views/workflow-history/workflow-history-filters-status/__tests__/workflow-history-filters-status.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@/test-utils/rtl';
 
 import WorkflowHistoryFiltersType from '../workflow-history-filters-status';
-import { WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_LABELS_MAP } from '../workflow-history-filters-status.constants';
+import { HISTORY_EVENT_FILTER_STATUS_LABELS_MAP } from '../workflow-history-filters-status.constants';
 import { type WorkflowHistoryFiltersStatusValue } from '../workflow-history-filters-status.types';
 
 describe('WorkflowHistoryFiltersStatus', () => {
@@ -19,7 +19,7 @@ describe('WorkflowHistoryFiltersStatus', () => {
       fireEvent.click(selectFilter);
     });
 
-    Object.entries(WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_LABELS_MAP).forEach(
+    Object.entries(HISTORY_EVENT_FILTER_STATUS_LABELS_MAP).forEach(
       ([_, label]) => expect(screen.getByText(label)).toBeInTheDocument()
     );
   });

--- a/src/views/workflow-history/workflow-history-filters-status/helpers/__tests__/filter-events-by-event-status.test.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/helpers/__tests__/filter-events-by-event-status.test.ts
@@ -1,0 +1,87 @@
+import { type ActivityHistoryGroup } from '../../../workflow-history.types';
+import { type WorkflowHistoryFiltersStatusValue } from '../../workflow-history-filters-status.types';
+import filterEventsByEventStatus from '../filter-events-by-event-status';
+
+const ACTIVITY_HISTORY_GROUP_COMPLETED: ActivityHistoryGroup = {
+  label: 'Mock activity',
+  eventsMetadata: [],
+  status: 'COMPLETED',
+  hasMissingEvents: false,
+  timeMs: 123456789,
+  timeLabel: 'Mock time label',
+  groupType: 'Activity',
+  events: [],
+};
+
+describe(filterEventsByEventStatus.name, () => {
+  it('should return true if historyEventStatuses is undefined', () => {
+    const value: WorkflowHistoryFiltersStatusValue = {
+      historyEventStatuses: undefined,
+    };
+
+    expect(
+      filterEventsByEventStatus(ACTIVITY_HISTORY_GROUP_COMPLETED, value)
+    ).toBe(true);
+  });
+
+  it('should return true if group status is included in historyEventStatuses', () => {
+    const value: WorkflowHistoryFiltersStatusValue = {
+      historyEventStatuses: ['COMPLETED'],
+    };
+
+    expect(
+      filterEventsByEventStatus(ACTIVITY_HISTORY_GROUP_COMPLETED, value)
+    ).toBe(true);
+  });
+
+  it('should return false if group status is not included in historyEventStatuses', () => {
+    const value: WorkflowHistoryFiltersStatusValue = {
+      historyEventStatuses: ['COMPLETED'],
+    };
+
+    expect(
+      filterEventsByEventStatus(
+        {
+          ...ACTIVITY_HISTORY_GROUP_COMPLETED,
+          status: 'FAILED',
+        },
+        value
+      )
+    ).toBe(false);
+  });
+
+  it('should return true if group status is ONGOING or WAITING when historyEventStatuses includes PENDING', () => {
+    const value: WorkflowHistoryFiltersStatusValue = {
+      historyEventStatuses: ['PENDING'],
+    };
+
+    expect(
+      filterEventsByEventStatus(
+        {
+          ...ACTIVITY_HISTORY_GROUP_COMPLETED,
+          status: 'ONGOING',
+        },
+        value
+      )
+    ).toBe(true);
+    expect(
+      filterEventsByEventStatus(
+        {
+          ...ACTIVITY_HISTORY_GROUP_COMPLETED,
+          status: 'WAITING',
+        },
+        value
+      )
+    ).toBe(true);
+  });
+
+  it('should return false if group status is not ONGOING or WAITING when historyEventStatuses includes PENDING', () => {
+    const value: WorkflowHistoryFiltersStatusValue = {
+      historyEventStatuses: ['PENDING'],
+    };
+
+    expect(
+      filterEventsByEventStatus(ACTIVITY_HISTORY_GROUP_COMPLETED, value)
+    ).toBe(false);
+  });
+});

--- a/src/views/workflow-history/workflow-history-filters-status/helpers/filter-events-by-event-status.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/helpers/filter-events-by-event-status.ts
@@ -1,12 +1,28 @@
+import { type WorkflowEventStatus } from '../../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
 import { type HistoryEventsGroup } from '../../workflow-history.types';
-import { type WorkflowHistoryFiltersStatusValue } from '../workflow-history-filters-status.types';
+import {
+  type HistoryEventFilterStatus,
+  type WorkflowHistoryFiltersStatusValue,
+} from '../workflow-history-filters-status.types';
 
 export default function filterEventsByEventStatus(
   group: HistoryEventsGroup,
   value: WorkflowHistoryFiltersStatusValue
 ) {
-  const selectedGroupStatuses = value.historyEventStatuses;
-  if (!selectedGroupStatuses) return true;
+  const historyFiltersStatuses = value.historyEventStatuses;
+  if (!historyFiltersStatuses) return true;
 
-  return selectedGroupStatuses.includes(group.status);
+  const workflowEventStatuses = historyFiltersStatuses.reduce(
+    (acc: WorkflowEventStatus[], currentValue: HistoryEventFilterStatus) => {
+      if (currentValue === 'PENDING') {
+        acc.push('ONGOING', 'WAITING');
+      } else {
+        acc.push(currentValue);
+      }
+      return acc;
+    },
+    []
+  );
+
+  return workflowEventStatuses.includes(group.status);
 }

--- a/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants.ts
@@ -1,10 +1,15 @@
-import { WORKFLOW_EVENT_STATUS } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.constants';
-import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+import { type HistoryEventFilterStatus } from './workflow-history-filters-status.types';
 
-export const WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_LABELS_MAP = {
-  [WORKFLOW_EVENT_STATUS.ONGOING]: 'On Going',
-  [WORKFLOW_EVENT_STATUS.WAITING]: 'Waiting',
-  [WORKFLOW_EVENT_STATUS.CANCELED]: 'Canceled',
-  [WORKFLOW_EVENT_STATUS.FAILED]: 'Failed',
-  [WORKFLOW_EVENT_STATUS.COMPLETED]: 'Completed',
-} as const satisfies Record<WorkflowEventStatus, string>;
+export const HISTORY_EVENT_FILTER_STATUSES = {
+  PENDING: 'PENDING',
+  CANCELED: 'CANCELED',
+  FAILED: 'FAILED',
+  COMPLETED: 'COMPLETED',
+} as const satisfies Record<HistoryEventFilterStatus, string>;
+
+export const HISTORY_EVENT_FILTER_STATUS_LABELS_MAP = {
+  PENDING: 'Pending',
+  CANCELED: 'Canceled',
+  FAILED: 'Failed',
+  COMPLETED: 'Completed',
+} as const satisfies Record<HistoryEventFilterStatus, string>;

--- a/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.tsx
+++ b/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.tsx
@@ -6,11 +6,12 @@ import { Select, SIZE } from 'baseui/select';
 
 import { type PageFilterComponentProps } from '@/components/page-filters/page-filters.types';
 
-import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
-
-import { WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_LABELS_MAP } from './workflow-history-filters-status.constants';
+import { HISTORY_EVENT_FILTER_STATUS_LABELS_MAP } from './workflow-history-filters-status.constants';
 import { overrides } from './workflow-history-filters-status.styles';
-import { type WorkflowHistoryFiltersStatusValue } from './workflow-history-filters-status.types';
+import {
+  type HistoryEventFilterStatus,
+  type WorkflowHistoryFiltersStatusValue,
+} from './workflow-history-filters-status.types';
 
 export default function WorkflowHistoryFiltersStatus({
   value,
@@ -19,7 +20,7 @@ export default function WorkflowHistoryFiltersStatus({
   const statusOptionsValue =
     value.historyEventStatuses?.map((status) => ({
       id: status,
-      label: WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_LABELS_MAP[status],
+      label: HISTORY_EVENT_FILTER_STATUS_LABELS_MAP[status],
     })) ?? [];
 
   return (
@@ -28,17 +29,17 @@ export default function WorkflowHistoryFiltersStatus({
         multi
         size={SIZE.compact}
         value={statusOptionsValue}
-        options={Object.entries(
-          WORKFLOW_HISTORY_EVENT_FILTERING_STATUS_LABELS_MAP
-        ).map(([id, label]) => ({
-          id,
-          label,
-        }))}
+        options={Object.entries(HISTORY_EVENT_FILTER_STATUS_LABELS_MAP).map(
+          ([id, label]) => ({
+            id,
+            label,
+          })
+        )}
         onChange={(params) => {
           setValue({
             historyEventStatuses:
               params.value.length > 0
-                ? params.value.map((v) => v.id as WorkflowEventStatus)
+                ? params.value.map((v) => v.id as HistoryEventFilterStatus)
                 : undefined,
           });
         }}

--- a/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.types.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.types.ts
@@ -1,5 +1,9 @@
-import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+export type HistoryEventFilterStatus =
+  | 'COMPLETED'
+  | 'FAILED'
+  | 'CANCELED'
+  | 'PENDING';
 
 export type WorkflowHistoryFiltersStatusValue = {
-  historyEventStatuses: WorkflowEventStatus[] | undefined;
+  historyEventStatuses: HistoryEventFilterStatus[] | undefined;
 };

--- a/src/views/workflow-page/config/workflow-page-query-params.config.ts
+++ b/src/views/workflow-page/config/workflow-page-query-params.config.ts
@@ -1,6 +1,6 @@
 import { type PageQueryParamMultiValue } from '@/hooks/use-page-query-params/use-page-query-params.types';
-import { WORKFLOW_EVENT_STATUS } from '@/views/workflow-history/workflow-history-event-status-badge/workflow-history-event-status-badge.constants';
-import { type WorkflowEventStatus } from '@/views/workflow-history/workflow-history-event-status-badge/workflow-history-event-status-badge.types';
+import { HISTORY_EVENT_FILTER_STATUSES } from '@/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants';
+import { type HistoryEventFilterStatus } from '@/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.types';
 import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES } from '@/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants';
 import { type WorkflowHistoryEventFilteringType } from '@/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.types';
 
@@ -11,7 +11,7 @@ const workflowPageQueryParamsConfig: [
   >,
   PageQueryParamMultiValue<
     'historyEventStatuses',
-    WorkflowEventStatus[] | undefined
+    HistoryEventFilterStatus[] | undefined
   >,
 ] = [
   {
@@ -36,8 +36,8 @@ const workflowPageQueryParamsConfig: [
     queryParamKey: 'hs',
     isMultiValue: true,
     parseValue: (v) => {
-      if (v.every((s) => s in WORKFLOW_EVENT_STATUS)) {
-        return v as WorkflowEventStatus[];
+      if (v.every((s) => s in HISTORY_EVENT_FILTER_STATUSES)) {
+        return v as HistoryEventFilterStatus[];
       }
       return undefined;
     },


### PR DESCRIPTION
## Summary
- Create new history filter status type which combines Ongoing and Waiting into Pending
- Use "Pending" to show all ongoing *and* waiting tasks 

## Test plan
Added unit tests + ran locally.

<img width="1653" alt="Screenshot 2025-01-06 at 2 28 26 PM" src="https://github.com/user-attachments/assets/f939997f-858d-45e2-9e15-68d2ecfbafa1" />
