### PR TITLE
Fix unstable dayjs test case

### DIFF
--- a/src/utils/datetime/__tests__/dayjs.test.ts
+++ b/src/utils/datetime/__tests__/dayjs.test.ts
@@ -13,7 +13,7 @@ describe('dayjs utility', () => {
   });
 
   it('should calculate duration using duration plugin', () => {
-    const duration = dayjs.duration({ hours: 2, minutes: 30 });
+    const duration = dayjs.duration({ hours: 2, minutes: 55 });
     expect(duration.humanize()).toBe('3 hours');
   });
 


### PR DESCRIPTION
### Summary
Increase minutes for more stable duration formatting by avoid inconsistent formatting between 2 hours & 3 hours