### PR TITLE
Add Workflow Actions UI components

### DIFF
--- a/src/views/workflow-page/__fixtures__/workflow-actions-config.ts
+++ b/src/views/workflow-page/__fixtures__/workflow-actions-config.ts
@@ -1,0 +1,20 @@
+import { MdHighlightOff, MdPowerSettingsNew } from 'react-icons/md';
+
+import { type WorkflowAction } from '../workflow-page-actions-menu/workflow-page-actions-menu.types';
+
+export const mockWorkflowPageActionsConfig = [
+  {
+    id: 'cancel',
+    label: 'Mock cancel',
+    subtitle: 'Mock cancel a workflow execution',
+    icon: MdHighlightOff,
+    getIsEnabled: () => true,
+  },
+  {
+    id: 'terminate',
+    label: 'Mock terminate',
+    subtitle: 'Mock terminate a workflow execution',
+    icon: MdPowerSettingsNew,
+    getIsEnabled: () => false,
+  },
+] as const satisfies Array<WorkflowAction>;

--- a/src/views/workflow-page/config/workflow-page-actions.config.ts
+++ b/src/views/workflow-page/config/workflow-page-actions.config.ts
@@ -1,0 +1,29 @@
+import { MdHighlightOff, MdPowerSettingsNew } from 'react-icons/md';
+
+import getWorkflowIsCompleted from '../helpers/get-workflow-is-completed';
+import { type WorkflowAction } from '../workflow-page-actions-menu/workflow-page-actions-menu.types';
+
+const workflowPageActionsConfig = [
+  {
+    id: 'cancel',
+    label: 'Cancel',
+    description: 'Cancel a workflow execution',
+    icon: MdHighlightOff,
+    getIsEnabled: (workflow) =>
+      !getWorkflowIsCompleted(
+        workflow.workflowExecutionInfo?.closeEvent?.attributes ?? ''
+      ),
+  },
+  {
+    id: 'terminate',
+    label: 'Terminate',
+    description: 'Terminate a workflow execution',
+    icon: MdPowerSettingsNew,
+    getIsEnabled: (workflow) =>
+      !getWorkflowIsCompleted(
+        workflow.workflowExecutionInfo?.closeEvent?.attributes ?? ''
+      ),
+  },
+] as const satisfies Array<WorkflowAction>;
+
+export default workflowPageActionsConfig;

--- a/src/views/workflow-page/config/workflow-page-actions.config.ts
+++ b/src/views/workflow-page/config/workflow-page-actions.config.ts
@@ -7,7 +7,7 @@ const workflowPageActionsConfig = [
   {
     id: 'cancel',
     label: 'Cancel',
-    description: 'Cancel a workflow execution',
+    subtitle: 'Cancel a workflow execution',
     icon: MdHighlightOff,
     getIsEnabled: (workflow) =>
       !getWorkflowIsCompleted(
@@ -17,7 +17,7 @@ const workflowPageActionsConfig = [
   {
     id: 'terminate',
     label: 'Terminate',
-    description: 'Terminate a workflow execution',
+    subtitle: 'Terminate a workflow execution',
     icon: MdPowerSettingsNew,
     getIsEnabled: (workflow) =>
       !getWorkflowIsCompleted(

--- a/src/views/workflow-page/workflow-page-actions-button/__tests__/workflow-page-actions-button.test.tsx
+++ b/src/views/workflow-page/workflow-page-actions-button/__tests__/workflow-page-actions-button.test.tsx
@@ -1,0 +1,116 @@
+import React, { Suspense } from 'react';
+
+import { HttpResponse } from 'msw';
+
+import { act, render, screen, userEvent } from '@/test-utils/rtl';
+
+import { describeWorkflowResponse } from '../../__fixtures__/describe-workflow-response';
+import { mockWorkflowPageActionsConfig } from '../../__fixtures__/workflow-actions-config';
+import WorkflowPageActionsButton from '../workflow-page-actions-button';
+
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  useParams: () => ({
+    cluster: 'testCluster',
+    domain: 'testDomain',
+    workflowId: 'testWorkflowId',
+    runId: 'testRunId',
+  }),
+}));
+
+jest.mock('../../workflow-page-actions-modal/workflow-page-actions-modal', () =>
+  jest.fn((props) => {
+    return props.action ? (
+      <div data-testid="actions-modal">Actions Modal</div>
+    ) : null;
+  })
+);
+
+jest.mock('../../workflow-page-actions-menu/workflow-page-actions-menu', () =>
+  jest.fn((props) => {
+    return (
+      <div
+        onClick={() => props.onActionSelect(mockWorkflowPageActionsConfig[0])}
+        data-testid="actions-menu"
+      >
+        Actions Menu{props.disabled ? ' (disabled)' : ''}
+      </div>
+    );
+  })
+);
+
+describe(WorkflowPageActionsButton.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the button with the correct text', async () => {
+    await setup({});
+    const actionsButton = await screen.findByRole('button');
+    expect(actionsButton).toHaveTextContent('Workflow Actions');
+  });
+
+  it('renders the menu when the button is clicked', async () => {
+    const { user } = await setup({});
+
+    await user.click(await screen.findByText('Workflow Actions'));
+
+    expect(await screen.findByTestId('actions-menu')).toBeInTheDocument();
+  });
+
+  it('shows the modal when a menu option is clicked', async () => {
+    const { user } = await setup({});
+
+    await user.click(await screen.findByText('Workflow Actions'));
+    await user.click(await screen.findByTestId('actions-menu'));
+
+    expect(await screen.findByTestId('actions-modal')).toBeInTheDocument();
+  });
+
+  it('renders nothing if describeWorkflow fails', async () => {
+    let renderErrorMessage;
+    try {
+      await act(async () => {
+        await setup({ isError: true });
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        renderErrorMessage = error.message;
+      }
+    }
+
+    expect(renderErrorMessage).toEqual('Failed to fetch workflow summary');
+  });
+});
+
+async function setup({ isError }: { isError?: boolean }) {
+  const user = userEvent.setup();
+
+  const renderResult = render(
+    <Suspense>
+      <WorkflowPageActionsButton />
+    </Suspense>,
+    {
+      endpointsMocks: [
+        {
+          path: '/api/domains/:domain/:cluster/workflows/:workflowId/:runId',
+          httpMethod: 'GET',
+          httpResolver: () => {
+            if (isError) {
+              return HttpResponse.json(
+                { message: 'Failed to fetch workflow summary' },
+                { status: 500 }
+              );
+            } else {
+              return HttpResponse.json(describeWorkflowResponse, {
+                status: 200,
+              });
+            }
+          },
+        },
+      ],
+    }
+  );
+
+  return { user, renderResult };
+}

--- a/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.styles.ts
+++ b/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.styles.ts
@@ -1,0 +1,13 @@
+import { type Theme } from 'baseui';
+import { type PopoverOverrides } from 'baseui/popover';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  popover: {
+    Inner: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        backgroundColor: $theme.colors.backgroundPrimary,
+      }),
+    },
+  } satisfies PopoverOverrides,
+};

--- a/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
+++ b/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
@@ -1,25 +1,57 @@
 'use client';
 import React from 'react';
 
-import { Button } from 'baseui/button';
-import { StatefulPopover } from 'baseui/popover';
+import { Button, KIND, SIZE } from 'baseui/button';
+import { PLACEMENT, StatefulPopover } from 'baseui/popover';
+import { pick } from 'lodash';
+import { useParams } from 'next/navigation';
 import { MdArrowDropDown } from 'react-icons/md';
 
+import useDescribeWorkflow from '../hooks/use-describe-workflow';
 import WorkflowPageActionsMenu from '../workflow-page-actions-menu/workflow-page-actions-menu';
+import { type WorkflowPageParams } from '../workflow-page.types';
+
+import { overrides } from './workflow-page-actions-button.styles';
 
 export default function WorkflowPageActionsButton() {
+  const params = useParams<WorkflowPageParams>();
+  const workflowDetailsParams = pick(
+    params,
+    'cluster',
+    'workflowId',
+    'runId',
+    'domain'
+  );
+
+  const {
+    data: workflow,
+    isLoading,
+    isError,
+  } = useDescribeWorkflow({
+    ...workflowDetailsParams,
+  });
+
   return (
     <StatefulPopover
-      content={() => <WorkflowPageActionsMenu />}
+      placement={PLACEMENT.bottomRight}
+      overrides={overrides.popover}
+      content={() => (
+        <WorkflowPageActionsMenu
+          workflow={workflow}
+          isLoading={isLoading}
+          disableAll={isError}
+          onMenuItemSelect={() => {}}
+        />
+      )}
       returnFocus
       autoFocus
     >
       <Button
-        size="compact"
-        kind="tertiary"
+        size={SIZE.compact}
+        kind={KIND.secondary}
         endEnhancer={<MdArrowDropDown size={20} />}
       >
-        Actions
+        Workflow Actions
       </Button>
       {/* <WorkflowPageActionsModal /> */}
     </StatefulPopover>

--- a/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
+++ b/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
@@ -25,11 +25,7 @@ export default function WorkflowPageActionsButton() {
     'domain'
   );
 
-  const {
-    data: workflow,
-    isLoading,
-    isError,
-  } = useDescribeWorkflow({
+  const { data: workflow } = useDescribeWorkflow({
     ...workflowDetailsParams,
   });
 
@@ -45,8 +41,6 @@ export default function WorkflowPageActionsButton() {
         content={() => (
           <WorkflowPageActionsMenu
             workflow={workflow}
-            isLoading={isLoading}
-            disableAll={isError}
             onActionSelect={(action) => setSelectedAction(action)}
           />
         )}

--- a/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
+++ b/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Button, KIND, SIZE } from 'baseui/button';
 import { PLACEMENT, StatefulPopover } from 'baseui/popover';
@@ -9,6 +9,8 @@ import { MdArrowDropDown } from 'react-icons/md';
 
 import useDescribeWorkflow from '../hooks/use-describe-workflow';
 import WorkflowPageActionsMenu from '../workflow-page-actions-menu/workflow-page-actions-menu';
+import { type WorkflowAction } from '../workflow-page-actions-menu/workflow-page-actions-menu.types';
+import WorkflowPageActionsModal from '../workflow-page-actions-modal/workflow-page-actions-modal';
 import { type WorkflowPageParams } from '../workflow-page.types';
 
 import { overrides } from './workflow-page-actions-button.styles';
@@ -31,29 +33,39 @@ export default function WorkflowPageActionsButton() {
     ...workflowDetailsParams,
   });
 
+  const [selectedAction, setSelectedAction] = useState<
+    WorkflowAction | undefined
+  >(undefined);
+
   return (
-    <StatefulPopover
-      placement={PLACEMENT.bottomRight}
-      overrides={overrides.popover}
-      content={() => (
-        <WorkflowPageActionsMenu
-          workflow={workflow}
-          isLoading={isLoading}
-          disableAll={isError}
-          onMenuItemSelect={() => {}}
-        />
-      )}
-      returnFocus
-      autoFocus
-    >
-      <Button
-        size={SIZE.compact}
-        kind={KIND.secondary}
-        endEnhancer={<MdArrowDropDown size={20} />}
+    <>
+      <StatefulPopover
+        placement={PLACEMENT.bottomRight}
+        overrides={overrides.popover}
+        content={() => (
+          <WorkflowPageActionsMenu
+            workflow={workflow}
+            isLoading={isLoading}
+            disableAll={isError}
+            onActionSelect={(action) => setSelectedAction(action)}
+          />
+        )}
+        returnFocus
+        autoFocus
       >
-        Workflow Actions
-      </Button>
-      {/* <WorkflowPageActionsModal /> */}
-    </StatefulPopover>
+        <Button
+          size={SIZE.compact}
+          kind={KIND.secondary}
+          endEnhancer={<MdArrowDropDown size={20} />}
+        >
+          Workflow Actions
+        </Button>
+      </StatefulPopover>
+      <WorkflowPageActionsModal
+        workflow={workflow}
+        action={selectedAction}
+        onClose={() => setSelectedAction(undefined)}
+      />
+    </>
   );
 }

--- a/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
+++ b/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.tsx
@@ -1,0 +1,27 @@
+'use client';
+import React from 'react';
+
+import { Button } from 'baseui/button';
+import { StatefulPopover } from 'baseui/popover';
+import { MdArrowDropDown } from 'react-icons/md';
+
+import WorkflowPageActionsMenu from '../workflow-page-actions-menu/workflow-page-actions-menu';
+
+export default function WorkflowPageActionsButton() {
+  return (
+    <StatefulPopover
+      content={() => <WorkflowPageActionsMenu />}
+      returnFocus
+      autoFocus
+    >
+      <Button
+        size="compact"
+        kind="tertiary"
+        endEnhancer={<MdArrowDropDown size={20} />}
+      >
+        Actions
+      </Button>
+      {/* <WorkflowPageActionsModal /> */}
+    </StatefulPopover>
+  );
+}

--- a/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.types.ts
+++ b/src/views/workflow-page/workflow-page-actions-button/workflow-page-actions-button.types.ts
@@ -1,0 +1,6 @@
+export type Props = {
+  domain: string;
+  cluster: string;
+  workflowId: string;
+  runId: string;
+};

--- a/src/views/workflow-page/workflow-page-actions-menu/__tests__/workflow-page-actions-menu.test.tsx
+++ b/src/views/workflow-page/workflow-page-actions-menu/__tests__/workflow-page-actions-menu.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+import { render, screen, userEvent, within } from '@/test-utils/rtl';
+
+import { describeWorkflowResponse } from '../../__fixtures__/describe-workflow-response';
+import { mockWorkflowPageActionsConfig } from '../../__fixtures__/workflow-actions-config';
+import WorkflowPageActionsMenu from '../workflow-page-actions-menu';
+
+jest.mock(
+  '../../config/workflow-page-actions.config',
+  () => mockWorkflowPageActionsConfig
+);
+
+describe(WorkflowPageActionsMenu.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the menu items correctly', () => {
+    setup();
+
+    const menuButtons = screen.getAllByRole('button');
+    expect(menuButtons).toHaveLength(2);
+
+    expect(within(menuButtons[0]).getByText('Mock cancel')).toBeInTheDocument();
+    expect(
+      within(menuButtons[0]).getByText('Mock cancel a workflow execution')
+    ).toBeInTheDocument();
+    expect(menuButtons[0]).not.toBeDisabled();
+
+    expect(
+      within(menuButtons[1]).getByText('Mock terminate')
+    ).toBeInTheDocument();
+    expect(
+      within(menuButtons[1]).getByText('Mock terminate a workflow execution')
+    ).toBeInTheDocument();
+    expect(menuButtons[1]).toBeDisabled();
+  });
+
+  it('calls onActionSelect when the action button is clicked', async () => {
+    const { user, mockOnActionSelect } = setup();
+
+    const menuButtons = screen.getAllByRole('button');
+    expect(menuButtons).toHaveLength(2);
+
+    await user.click(menuButtons[0]);
+    expect(mockOnActionSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'cancel' })
+    );
+  });
+});
+
+function setup() {
+  const user = userEvent.setup();
+  const mockOnActionSelect = jest.fn();
+
+  const renderResult = render(
+    <WorkflowPageActionsMenu
+      workflow={describeWorkflowResponse}
+      onActionSelect={mockOnActionSelect}
+    />
+  );
+
+  return { user, mockOnActionSelect, renderResult };
+}

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.styles.ts
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.styles.ts
@@ -1,0 +1,36 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import { type ButtonOverrides } from 'baseui/button';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  MenuItemsContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    padding: $theme.sizing.scale200,
+  })),
+  MenuItemContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    gap: $theme.sizing.scale500,
+    alignItems: 'flex-start',
+  })),
+  MenuItemLabel: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'flex-start',
+    ...$theme.typography.LabelSmall,
+  })),
+  MenuItemDescription: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.ParagraphXSmall,
+  })),
+};
+
+export const overrides = {
+  button: {
+    BaseButton: {
+      style: {
+        justifyContent: 'flex-start',
+      } satisfies StyleObject,
+    },
+  } satisfies ButtonOverrides,
+};

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.styles.ts
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.styles.ts
@@ -20,7 +20,7 @@ export const styled = {
     alignItems: 'flex-start',
     ...$theme.typography.LabelSmall,
   })),
-  MenuItemDescription: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+  MenuItemSubtitle: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
     ...$theme.typography.ParagraphXSmall,
   })),
 };

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
@@ -1,0 +1,23 @@
+import { StatefulMenu } from 'baseui/menu';
+
+export default function WorkflowPageActionsMenu() {
+  return (
+    <StatefulMenu
+      // placeholder
+      items={[
+        {
+          label: 'Item One',
+        },
+        {
+          label: 'Item Two',
+        },
+        {
+          label: 'Item Three',
+        },
+        {
+          label: 'Item Four',
+        },
+      ]}
+    />
+  );
+}

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
@@ -1,23 +1,38 @@
-import { StatefulMenu } from 'baseui/menu';
+import { Button, KIND } from 'baseui/button';
 
-export default function WorkflowPageActionsMenu() {
+import workflowPageActionsConfig from '../config/workflow-page-actions.config';
+
+import { overrides, styled } from './workflow-page-actions-menu.styles';
+import { type Props } from './workflow-page-actions-menu.types';
+
+export default function WorkflowPageActionsMenu({
+  workflow,
+  isLoading,
+  disableAll,
+  onMenuItemSelect,
+}: Props) {
   return (
-    <StatefulMenu
-      // placeholder
-      items={[
-        {
-          label: 'Item One',
-        },
-        {
-          label: 'Item Two',
-        },
-        {
-          label: 'Item Three',
-        },
-        {
-          label: 'Item Four',
-        },
-      ]}
-    />
+    <styled.MenuItemsContainer>
+      {workflowPageActionsConfig.map((action) => (
+        <Button
+          key={action.id}
+          kind={KIND.tertiary}
+          overrides={overrides.button}
+          onClick={() => onMenuItemSelect(action)}
+          isLoading={isLoading}
+          disabled={disableAll ? true : !action.getIsEnabled(workflow)}
+        >
+          <styled.MenuItemContainer>
+            <action.icon />
+            <styled.MenuItemLabel>
+              {action.label}
+              <styled.MenuItemDescription>
+                {action.description}
+              </styled.MenuItemDescription>
+            </styled.MenuItemLabel>
+          </styled.MenuItemContainer>
+        </Button>
+      ))}
+    </styled.MenuItemsContainer>
   );
 }

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
@@ -9,7 +9,7 @@ export default function WorkflowPageActionsMenu({
   workflow,
   isLoading,
   disableAll,
-  onMenuItemSelect,
+  onActionSelect,
 }: Props) {
   return (
     <styled.MenuItemsContainer>
@@ -18,7 +18,7 @@ export default function WorkflowPageActionsMenu({
           key={action.id}
           kind={KIND.tertiary}
           overrides={overrides.button}
-          onClick={() => onMenuItemSelect(action)}
+          onClick={() => onActionSelect(action)}
           isLoading={isLoading}
           disabled={disableAll ? true : !action.getIsEnabled(workflow)}
         >
@@ -26,9 +26,9 @@ export default function WorkflowPageActionsMenu({
             <action.icon />
             <styled.MenuItemLabel>
               {action.label}
-              <styled.MenuItemDescription>
-                {action.description}
-              </styled.MenuItemDescription>
+              <styled.MenuItemSubtitle>
+                {action.subtitle}
+              </styled.MenuItemSubtitle>
             </styled.MenuItemLabel>
           </styled.MenuItemContainer>
         </Button>

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.tsx
@@ -7,8 +7,6 @@ import { type Props } from './workflow-page-actions-menu.types';
 
 export default function WorkflowPageActionsMenu({
   workflow,
-  isLoading,
-  disableAll,
   onActionSelect,
 }: Props) {
   return (
@@ -19,8 +17,7 @@ export default function WorkflowPageActionsMenu({
           kind={KIND.tertiary}
           overrides={overrides.button}
           onClick={() => onActionSelect(action)}
-          isLoading={isLoading}
-          disabled={disableAll ? true : !action.getIsEnabled(workflow)}
+          disabled={!action.getIsEnabled(workflow)}
         >
           <styled.MenuItemContainer>
             <action.icon />

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
@@ -1,6 +1,21 @@
+import { type IconProps } from 'baseui/icon';
+
+import { type DescribeWorkflowResponse } from '@/route-handlers/describe-workflow/describe-workflow.types';
+
 export type WorkflowAction = {
-  name: string;
+  id: string;
   label: string;
   description: string;
-  icon: string;
+  icon: React.ComponentType<{
+    size?: IconProps['size'];
+    color?: IconProps['color'];
+  }>;
+  getIsEnabled: (workflow: DescribeWorkflowResponse) => boolean;
+};
+
+export type Props = {
+  workflow: DescribeWorkflowResponse;
+  isLoading: boolean;
+  disableAll: boolean;
+  onMenuItemSelect: (action: WorkflowAction) => void;
 };

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
@@ -1,0 +1,6 @@
+export type WorkflowAction = {
+  name: string;
+  label: string;
+  description: string;
+  icon: string;
+};

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
@@ -5,17 +5,18 @@ import { type DescribeWorkflowResponse } from '@/route-handlers/describe-workflo
 export type WorkflowAction = {
   id: string;
   label: string;
-  description: string;
+  subtitle: string;
   icon: React.ComponentType<{
     size?: IconProps['size'];
     color?: IconProps['color'];
   }>;
   getIsEnabled: (workflow: DescribeWorkflowResponse) => boolean;
+  // Add a field for the endpoint to call
 };
 
 export type Props = {
   workflow: DescribeWorkflowResponse;
   isLoading: boolean;
   disableAll: boolean;
-  onMenuItemSelect: (action: WorkflowAction) => void;
+  onActionSelect: (action: WorkflowAction) => void;
 };

--- a/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
+++ b/src/views/workflow-page/workflow-page-actions-menu/workflow-page-actions-menu.types.ts
@@ -16,7 +16,5 @@ export type WorkflowAction = {
 
 export type Props = {
   workflow: DescribeWorkflowResponse;
-  isLoading: boolean;
-  disableAll: boolean;
   onActionSelect: (action: WorkflowAction) => void;
 };

--- a/src/views/workflow-page/workflow-page-actions-modal/__tests__/workflow-page-actions-modal.test.tsx
+++ b/src/views/workflow-page/workflow-page-actions-modal/__tests__/workflow-page-actions-modal.test.tsx
@@ -1,0 +1,65 @@
+import { type ModalProps } from 'baseui/modal';
+
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { describeWorkflowResponse } from '../../__fixtures__/describe-workflow-response';
+import { mockWorkflowPageActionsConfig } from '../../__fixtures__/workflow-actions-config';
+import WorkflowPageActionsModal from '../workflow-page-actions-modal';
+
+jest.mock('baseui/modal', () => ({
+  ...jest.requireActual('baseui/modal'),
+  Modal: ({ isOpen, children }: ModalProps) =>
+    isOpen ? (
+      <div aria-modal aria-label="dialog" role="dialog">
+        {typeof children === 'function' ? children() : children}
+      </div>
+    ) : null,
+}));
+
+describe(WorkflowPageActionsModal.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the action as expected', async () => {
+    setup({});
+
+    expect(await screen.findAllByText('Mock cancel workflow')).toHaveLength(2);
+    expect(
+      screen.getByText('Mock cancel a workflow execution')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Mock cancel workflow' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing if no action is passed', async () => {
+    setup({ omitAction: true });
+
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('calls onClose when the Go Back button is pressed', async () => {
+    const { user, mockOnClose } = setup({});
+
+    const goBackButton = await screen.findByText('Go back');
+    await user.click(goBackButton);
+
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});
+
+function setup({ omitAction }: { omitAction?: boolean }) {
+  const user = userEvent.setup();
+  const mockOnClose = jest.fn();
+
+  render(
+    <WorkflowPageActionsModal
+      workflow={describeWorkflowResponse}
+      action={omitAction ? undefined : mockWorkflowPageActionsConfig[0]}
+      onClose={mockOnClose}
+    />
+  );
+
+  return { user, mockOnClose };
+}

--- a/src/views/workflow-page/workflow-page-actions-modal/workflow-page-actions-modal.styles.ts
+++ b/src/views/workflow-page/workflow-page-actions-modal/workflow-page-actions-modal.styles.ts
@@ -1,0 +1,32 @@
+import { type Theme, withStyle } from 'baseui';
+import {
+  ModalBody,
+  ModalFooter,
+  ModalHeader,
+  type ModalOverrides,
+} from 'baseui/modal';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  ModalHeader: withStyle(ModalHeader, ({ $theme }: { $theme: Theme }) => ({
+    marginTop: $theme.sizing.scale850,
+  })),
+  ModalBody: withStyle(ModalBody, ({ $theme }: { $theme: Theme }) => ({
+    marginBottom: $theme.sizing.scale800,
+  })),
+  ModalFooter: withStyle(ModalFooter, {
+    display: 'flex',
+    justifyContent: 'space-between',
+  }),
+};
+
+export const overrides = {
+  modal: {
+    Close: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        top: $theme.sizing.scale850,
+        right: $theme.sizing.scale800,
+      }),
+    },
+  } satisfies ModalOverrides,
+};

--- a/src/views/workflow-page/workflow-page-actions-modal/workflow-page-actions-modal.tsx
+++ b/src/views/workflow-page/workflow-page-actions-modal/workflow-page-actions-modal.tsx
@@ -1,0 +1,52 @@
+import { KIND, SIZE } from 'baseui/button';
+import { Modal, ModalButton } from 'baseui/modal';
+
+import { type DescribeWorkflowResponse } from '@/route-handlers/describe-workflow/describe-workflow.types';
+
+import { type WorkflowAction } from '../workflow-page-actions-menu/workflow-page-actions-menu.types';
+
+import { overrides, styled } from './workflow-page-actions-modal.styles';
+
+export default function WorkflowPageActionsModal({
+  // workflow,
+  action,
+  onClose,
+}: {
+  workflow: DescribeWorkflowResponse;
+  action: WorkflowAction | undefined;
+  onClose: () => void;
+}) {
+  return (
+    <Modal
+      isOpen={Boolean(action)}
+      onClose={onClose}
+      closeable
+      overrides={overrides.modal}
+    >
+      {action && (
+        <>
+          <styled.ModalHeader>{action.label} workflow</styled.ModalHeader>
+          <styled.ModalBody>{action.subtitle}</styled.ModalBody>
+          <styled.ModalFooter>
+            <ModalButton
+              size={SIZE.compact}
+              kind={KIND.secondary}
+              onClick={onClose}
+            >
+              Go back
+            </ModalButton>
+            <ModalButton
+              size={SIZE.compact}
+              kind={KIND.primary}
+              onClick={() => {
+                // perform the action here
+              }}
+            >
+              {action.label} workflow
+            </ModalButton>
+          </styled.ModalFooter>
+        </>
+      )}
+    </Modal>
+  );
+}

--- a/src/views/workflow-page/workflow-page-cli-commands-button/workflow-page-cli-commands-button.tsx
+++ b/src/views/workflow-page/workflow-page-cli-commands-button/workflow-page-cli-commands-button.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useState } from 'react';
 
-import { Button } from 'baseui/button';
+import { Button, KIND, SIZE } from 'baseui/button';
 import { MdOutlineTerminal } from 'react-icons/md';
 
 import WorkflowPageCliCommandsModal from '../workflow-page-cli-commands-modal/workflow-page-cli-commands-modal';
@@ -12,8 +12,8 @@ export default function WorkflowPageCliCommandsButton() {
   return (
     <>
       <Button
-        size="compact"
-        kind="tertiary"
+        size={SIZE.compact}
+        kind={KIND.tertiary}
         startEnhancer={<MdOutlineTerminal size={20} />}
         onClick={() => setIsOpen((v) => !v)}
       >

--- a/src/views/workflow-page/workflow-page-cli-commands-modal/workflow-page-cli-commands-modal.tsx
+++ b/src/views/workflow-page/workflow-page-cli-commands-modal/workflow-page-cli-commands-modal.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 
+import { SIZE as BUTTON_SIZE } from 'baseui/button';
 import {
   Modal,
   ModalHeader,
@@ -74,7 +75,7 @@ export default function WorkflowPageCliCommandsModal({
         </div>
       </ModalBody>
       <ModalFooter>
-        <ModalButton size="compact" onClick={onClose}>
+        <ModalButton size={BUTTON_SIZE.compact} onClick={onClose}>
           Close
         </ModalButton>
       </ModalFooter>

--- a/src/views/workflow-page/workflow-page-tabs/__tests__/workflow-page-tabs.test.tsx
+++ b/src/views/workflow-page/workflow-page-tabs/__tests__/workflow-page-tabs.test.tsx
@@ -38,6 +38,16 @@ jest.mock('../../config/workflow-page-tabs.config', () => [
   },
 ]);
 
+jest.mock(
+  '../../workflow-page-cli-commands-button/workflow-page-cli-commands-button',
+  () => jest.fn(() => <div>CLI Commands</div>)
+);
+
+jest.mock(
+  '../../workflow-page-actions-button/workflow-page-actions-button',
+  () => jest.fn(() => <div>Actions</div>)
+);
+
 describe('WorkflowPageTabs', () => {
   afterEach(() => {
     jest.clearAllMocks();
@@ -50,6 +60,14 @@ describe('WorkflowPageTabs', () => {
       expect(screen.getByText(title)).toBeInTheDocument();
     });
   });
+
+  it('renders tabs buttons correctly', () => {
+    setup();
+
+    expect(screen.getByText('CLI Commands')).toBeInTheDocument();
+    expect(screen.getByText('Actions')).toBeInTheDocument();
+  });
+
   it('renders tabs artworks correctly', () => {
     setup();
     workflowPageTabsConfig.forEach(({ key, artwork }) => {

--- a/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.styles.ts
+++ b/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.styles.ts
@@ -1,0 +1,8 @@
+import { styled as createStyled, type Theme } from 'baseui';
+
+export const styled = {
+  EndButtonsContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    gap: $theme.sizing.scale300,
+  })),
+};

--- a/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
+++ b/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
@@ -28,7 +28,7 @@ export default function WorkflowPageTabs() {
       endEnhancer={
         <styled.EndButtonsContainer>
           <WorkflowPageCliCommandsButton />
-          <ErrorBoundary fallbackRender={() => null} omitLogging={true}>
+          <ErrorBoundary fallbackRender={() => null}>
             <WorkflowPageActionsButton />
           </ErrorBoundary>
         </styled.EndButtonsContainer>

--- a/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
+++ b/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
@@ -3,12 +3,15 @@ import React from 'react';
 
 import { useRouter, useParams } from 'next/navigation';
 
+import ErrorBoundary from '@/components/error-boundary/error-boundary';
 import PageTabs from '@/components/page-tabs/page-tabs';
 import decodeUrlParams from '@/utils/decode-url-params';
 
 import workflowPageTabsConfig from '../config/workflow-page-tabs.config';
+import WorkflowPageActionsButton from '../workflow-page-actions-button/workflow-page-actions-button';
 import WorkflowPageCliCommandsButton from '../workflow-page-cli-commands-button/workflow-page-cli-commands-button';
 
+import { styled } from './workflow-page-tabs.styles';
 import type { WorkflowPageTabsParams } from './workflow-page-tabs.types';
 
 export default function WorkflowPageTabs() {
@@ -22,7 +25,14 @@ export default function WorkflowPageTabs() {
       setSelectedTab={(newTab) => {
         router.push(encodeURIComponent(newTab.toString()));
       }}
-      endEnhancer={<WorkflowPageCliCommandsButton />}
+      endEnhancer={
+        <styled.EndButtonsContainer>
+          <WorkflowPageCliCommandsButton />
+          <ErrorBoundary fallbackRender={() => null} omitLogging={true}>
+            <WorkflowPageActionsButton />
+          </ErrorBoundary>
+        </styled.EndButtonsContainer>
+      }
     />
   );
 }


### PR DESCRIPTION
## Summary
- Add WorkflowPageActionsButton to show actions menu & modal
- Add WorkflowPageActionsMenu that shows a list of actions based on config
- Add WorkflowPageActionsModal as a confirmation modal for user to perform action
- (the actions themselves have not been implemented yet)
- Use defined constants for SIZE and KIND in Workflow Page CLI commands components

## Test plan
Unit tests + ran locally.

Enabled
<img width="402" alt="Screenshot 2025-01-09 at 4 26 56 PM" src="https://github.com/user-attachments/assets/64055f5d-36b6-403d-9b6d-8c706af5fd10" />
<img width="513" alt="Screenshot 2025-01-09 at 4 27 15 PM" src="https://github.com/user-attachments/assets/91dd212b-91df-4862-bcb6-2e72cce191bc" />

Disabled (for a non-running workflow)
<img width="374" alt="Screenshot 2025-01-09 at 4 26 36 PM" src="https://github.com/user-attachments/assets/32ddb438-68d8-450d-881a-033ce23e51e3" />

Modal
<img width="548" alt="Screenshot 2025-01-09 at 4 27 36 PM" src="https://github.com/user-attachments/assets/fa008cb6-a773-4738-956f-4a9c2c43fcf2" />
