### PR TITLE
Fix parse input function

### DIFF
--- a/src/utils/data-formatters/__tests__/format-input-payload.test.ts
+++ b/src/utils/data-formatters/__tests__/format-input-payload.test.ts
@@ -33,7 +33,7 @@ describe('formatInputPayload', () => {
   });
   // end of empty data checks
 
-  test('should parse base64 encoded JSON lines correctly', () => {
+  test('should parse base64 encoded JSON lines separated by \n correctly', () => {
     const input = {
       data: btoa(`{"name": "John", "age": 30}\n{"name": "Jane", "age": 25}`),
     };
@@ -44,8 +44,32 @@ describe('formatInputPayload', () => {
     expect(formatInputPayload(input)).toEqual(expected);
   });
 
+  test('should parse base64 encoded JSON lines separated by space correctly', () => {
+    const input = {
+      data: btoa(`{"name": "John", "age": 30} {"name": "Jane", "age": 25}`),
+    };
+    const expected = [
+      { name: 'John', age: 30 },
+      { name: 'Jane', age: 25 },
+    ];
+    expect(formatInputPayload(input)).toEqual(expected);
+  });
+
+  test('should parse base64 encoded JSON with spaced strings correctly', () => {
+    const input = {
+      data: btoa(`{"name": "John Doe", "age": 30} {"name": "Jane", "age": 25}`),
+    };
+    const expected = [
+      { name: 'John Doe', age: 30 },
+      { name: 'Jane', age: 25 },
+    ];
+    expect(formatInputPayload(input)).toEqual(expected);
+  });
+
   test('should handle base64 encoded JSON with \\n within string values', () => {
     const input = {
+      // new line is added as \\n within "John Doe" as the object is strigified and therfore escaped
+      // while it used as \n only between the JSON values as it is not part of the json values
       data: btoa(
         `{"name": "John\\nDoe", "age": 30}\n{"name": "Alice", "city": "Wonderland"}`
       ),

--- a/src/utils/data-formatters/format-input-payload.ts
+++ b/src/utils/data-formatters/format-input-payload.ts
@@ -15,26 +15,30 @@ const formatInputPayload = (
 };
 
 function parseJsonLines(input: string) {
-  // Split the input by new lines
-  const lines = input.split('\n');
-
   const jsonArray = [];
   let currentJson = '';
+  const separators = ['\n', ' '];
 
-  lines.forEach((line) => {
-    currentJson += line; // Append the line to the current JSON string
-
-    try {
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    if (separators.includes(char)) {
       // Try to parse the current JSON string
-      const jsonObject = losslessJsonParse(currentJson);
-      // If successful, add the object to the array
-      jsonArray.push(jsonObject);
-      // Reset currentJson for the next JSON object
-      currentJson = '';
-    } catch {
-      // If parsing fails, keep appending lines until we get a valid JSON
+      if (currentJson) {
+        try {
+          const jsonObject = losslessJsonParse(currentJson);
+          // If successful, add the object to the array
+          jsonArray.push(jsonObject);
+          // Reset currentJson for the next JSON object
+          currentJson = '';
+        } catch {
+          // If parsing fails, treat the separator as part of the currentJson and continue with the next char
+          currentJson += char;
+        }
+      }
+    } else {
+      currentJson += char;
     }
-  });
+  }
 
   // Handle case where the last JSON object might be malformed
   if (currentJson.trim() !== '') {


### PR DESCRIPTION
### Summary
Currently UI only parse workflow inputs separated by new line separators. While it seems that inputs can be separated by spaces. This PR adds support for parsing inputs separated by spaces.