### PR TITLE
Dynamic config resolver schemas and types

### DIFF
--- a/src/config/dynamic/dynamic.config.ts
+++ b/src/config/dynamic/dynamic.config.ts
@@ -10,9 +10,15 @@ const dynamicConfigs: {
   CADENCE_WEB_PORT: ConfigEnvDefinition;
   ADMIN_SECURITY_TOKEN: ConfigEnvDefinition;
   GRPC_PROTO_DIR_BASE_PATH: ConfigEnvDefinition;
-  GRPC_SERVICES_NAMES: ConfigEnvDefinition;
-  COMPUTED: ConfigSyncResolverDefinition<[string], [string]>;
-  DYNAMIC: ConfigAsyncResolverDefinition<undefined, number>;
+  GRPC_SERVICES_NAMES: ConfigEnvDefinition<true>;
+  DYNAMIC: ConfigAsyncResolverDefinition<undefined, number, 'serverStart'>;
+  DYNAMIC_WITH_ARG: ConfigAsyncResolverDefinition<number, number, 'request'>;
+  COMPUTED: ConfigSyncResolverDefinition<undefined, [string], 'request'>;
+  COMPUTED_WITH_ARG: ConfigSyncResolverDefinition<
+    [string],
+    [string],
+    'request'
+  >;
 } = {
   CADENCE_WEB_PORT: {
     env: 'CADENCE_WEB_PORT',
@@ -30,17 +36,32 @@ const dynamicConfigs: {
   GRPC_SERVICES_NAMES: {
     env: 'NEXT_PUBLIC_CADENCE_GRPC_SERVICES_NAMES',
     default: 'cadence-frontend',
+    isPublic: true,
   },
   // For testing purposes
   DYNAMIC: {
     resolver: async () => {
       return 1;
     },
+    evaluateOn: 'serverStart',
+  },
+  DYNAMIC_WITH_ARG: {
+    resolver: async (value: number) => {
+      return value;
+    },
+    evaluateOn: 'request',
   },
   COMPUTED: {
+    resolver: () => {
+      return ['value'];
+    },
+    evaluateOn: 'request',
+  },
+  COMPUTED_WITH_ARG: {
     resolver: (value: [string]) => {
       return value;
     },
+    evaluateOn: 'request',
   },
 } as const;
 

--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+import { type ResolverSchemas } from '../../../../utils/config/config.types';
+
+// Example usage:
+const resolverSchemas: ResolverSchemas = {
+  COMPUTED: {
+    args: z.undefined(),
+    returnType: z.tuple([z.string()]),
+  },
+  COMPUTED_WITH_ARG: {
+    args: z.tuple([z.string()]),
+    returnType: z.tuple([z.string()]),
+  },
+  DYNAMIC: {
+    args: z.undefined(),
+    returnType: z.number(),
+  },
+  DYNAMIC_WITH_ARG: {
+    args: z.number(),
+    returnType: z.number(),
+  },
+};
+
+export default resolverSchemas;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,10 +1,21 @@
 import getTransformedConfigs from './utils/config/get-transformed-configs';
 import { setLoadedGlobalConfigs } from './utils/config/global-configs-ref';
-import { registerLoggers } from './utils/logger';
+import logger, { registerLoggers } from './utils/logger';
 
 export async function register() {
   registerLoggers();
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    setLoadedGlobalConfigs(getTransformedConfigs());
+    try {
+      const configs = await getTransformedConfigs();
+      setLoadedGlobalConfigs(configs);
+    } catch (e) {
+      // manually catching and logging the error to prevent the error being replaced
+      // by "Cannot set property message of [object Object] which has only a getter"
+      logger.error({
+        message: 'Failed to load configs',
+        cause: String(e),
+      });
+      process.exit(1); // use process.exit to exit without an extra error log from instrumentation
+    }
   }
 }

--- a/src/utils/config/__tests__/get-config-value.node.ts
+++ b/src/utils/config/__tests__/get-config-value.node.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import { type LoadedConfigs } from '../config.types';
 import getConfigValue from '../get-config-value';
 import { loadedGlobalConfigs } from '../global-configs-ref';
@@ -7,6 +9,14 @@ jest.mock('../global-configs-ref', () => ({
     COMPUTED: jest.fn(),
     CADENCE_WEB_PORT: 'someValue',
   } satisfies Partial<LoadedConfigs>,
+}));
+
+jest.mock('@/config/dynamic/resolvers/schemas/resolver-schemas', () => ({
+  COMPUTED: {
+    args: z.undefined(),
+    returnType: z.string(),
+  },
+  CADENCE_WEB_PORT: 'someValue',
 }));
 
 describe('getConfigValue', () => {
@@ -23,8 +33,8 @@ describe('getConfigValue', () => {
     const mockFn = loadedGlobalConfigs.COMPUTED as jest.Mock;
     mockFn.mockResolvedValue('resolvedValue');
 
-    const result = await getConfigValue('COMPUTED', ['arg']);
-    expect(mockFn).toHaveBeenCalledWith(['arg']);
+    const result = await getConfigValue('COMPUTED');
+    expect(mockFn).toHaveBeenCalledWith(undefined);
     expect(result).toBe('resolvedValue');
   });
 });

--- a/src/utils/config/__tests__/get-transformed-configs.test.ts
+++ b/src/utils/config/__tests__/get-transformed-configs.test.ts
@@ -1,3 +1,5 @@
+import { z } from 'zod';
+
 import {
   type ConfigEnvDefinition,
   type ConfigSyncResolverDefinition,
@@ -7,7 +9,6 @@ import transformConfigs from '../transform-configs';
 describe('transformConfigs', () => {
   const originalEnv = process.env;
   beforeEach(() => {
-    jest.resetModules();
     process.env = {
       ...originalEnv,
       $$$_MOCK_ENV_CONFIG1: 'envValue1',
@@ -18,42 +19,61 @@ describe('transformConfigs', () => {
     process.env = originalEnv;
   });
 
-  it('should add resolver function as is', () => {
+  it('should add resolver function as is', async () => {
     const configDefinitions: {
       config1: ConfigEnvDefinition;
-      config2: ConfigSyncResolverDefinition<undefined, string>;
+      config2: ConfigSyncResolverDefinition<undefined, string, 'request'>;
     } = {
       config1: { env: '$$$_MOCK_ENV_CONFIG1', default: 'default1' },
       config2: {
         resolver: () => 'resolvedValue',
+        evaluateOn: 'request',
       },
     };
-    const result = transformConfigs(configDefinitions);
+
+    const mockResolvedSchemas = {
+      config2: {
+        args: z.undefined(),
+        returnType: z.string(),
+      },
+    };
+    const result = await transformConfigs(
+      configDefinitions,
+      mockResolvedSchemas
+    );
     expect(result).toEqual({
       config1: 'envValue1',
       config2: configDefinitions.config2.resolver,
     });
   });
 
-  it('should return environment variable value when present', () => {
+  it('should return environment variable value when present', async () => {
     const configDefinitions: {
       config1: ConfigEnvDefinition;
     } = {
       config1: { env: '$$$_MOCK_ENV_CONFIG1', default: 'default1' },
     };
-    const result = transformConfigs(configDefinitions);
+    const mockResolvedSchemas = {};
+    const result = await transformConfigs(
+      configDefinitions,
+      mockResolvedSchemas
+    );
     expect(result).toEqual({
       config1: 'envValue1',
     });
   });
 
-  it('should return default value when environment variable is not present', () => {
+  it('should return default value when environment variable is not present', async () => {
     const configDefinitions: {
       config3: ConfigEnvDefinition;
     } = {
       config3: { env: '$$$_MOCK_ENV_CONFIG3', default: 'default3' },
     };
-    const result = transformConfigs(configDefinitions);
+    const mockResolvedSchemas = {};
+    const result = await transformConfigs(
+      configDefinitions,
+      mockResolvedSchemas
+    );
     expect(result).toEqual({
       config3: 'default3',
     });

--- a/src/utils/config/__tests__/transform-configs.test.ts
+++ b/src/utils/config/__tests__/transform-configs.test.ts
@@ -1,23 +1,17 @@
-import { type ConfigEnvDefinition, type LoadedConfigs } from '../config.types';
-import { default as getTransformedConfigs } from '../get-transformed-configs';
+import { z } from 'zod';
 
-type MockConfigDefinitions = {
-  config1: ConfigEnvDefinition;
-  config2: ConfigEnvDefinition;
-};
-jest.mock(
-  '@/config/dynamic/dynamic.config',
-  () =>
-    ({
-      config1: { env: '$$$_MOCK_ENV_CONFIG1', default: 'default1' },
-      config2: { env: '$$$_MOCK_ENV_CONFIG2', default: 'default2' },
-    }) satisfies MockConfigDefinitions
-);
+import {
+  type InferResolverSchema,
+  type ConfigEnvDefinition,
+  type LoadedConfigs,
+  type ConfigSyncResolverDefinition,
+  type ConfigAsyncResolverDefinition,
+} from '../config.types';
+import transformConfigs from '../transform-configs';
 
 describe('getTransformedConfigs', () => {
   const originalEnv = process.env;
   beforeEach(() => {
-    jest.resetModules();
     process.env = {
       ...originalEnv,
       $$$_MOCK_ENV_CONFIG1: 'envValue1',
@@ -29,11 +23,95 @@ describe('getTransformedConfigs', () => {
     process.env = originalEnv;
   });
 
-  it('should return transformed dynamic configs', () => {
-    const result = getTransformedConfigs();
+  it('should get value for existing non empty environment variables', async () => {
+    const configs = {
+      config1: { env: '$$$_MOCK_ENV_CONFIG1', default: 'default1' },
+    } satisfies { config1: ConfigEnvDefinition };
+
+    const resolversSchemas = {} as InferResolverSchema<typeof configs>;
+
+    const result = await transformConfigs(configs, resolversSchemas);
     expect(result).toEqual({
       config1: 'envValue1',
+    } satisfies LoadedConfigs<typeof configs>);
+  });
+
+  it('should get default value for unset environment variables', async () => {
+    const configs = {
+      config2: { env: '$$$_MOCK_ENV_CONFIG2', default: 'default2' },
+    } satisfies { config2: ConfigEnvDefinition };
+
+    const resolversSchemas: InferResolverSchema<typeof configs> = {};
+
+    const result = await transformConfigs(configs, resolversSchemas);
+    expect(result).toEqual({
       config2: 'default2',
-    } satisfies LoadedConfigs<MockConfigDefinitions>);
+    } satisfies LoadedConfigs<typeof configs>);
+  });
+
+  it('should get resolved value for configuration that is evaluated on server start', async () => {
+    const configs = {
+      config3: { evaluateOn: 'serverStart', resolver: jest.fn(() => 3) },
+    } satisfies {
+      config3: ConfigSyncResolverDefinition<undefined, number, 'serverStart'>;
+    };
+
+    const resolversSchemas: InferResolverSchema<typeof configs> = {
+      config3: {
+        args: z.undefined(),
+        returnType: z.number(),
+      },
+    };
+
+    const result = await transformConfigs(configs, resolversSchemas);
+    expect(configs.config3.resolver).toHaveBeenCalledWith(undefined);
+    expect(result).toEqual({
+      config3: 3,
+    } satisfies LoadedConfigs<typeof configs>);
+  });
+
+  it('should get the resolver for configuration that is evaluated on request', async () => {
+    const configs = {
+      config3: { evaluateOn: 'request', resolver: (n) => n },
+    } satisfies {
+      config3: ConfigSyncResolverDefinition<number, number, 'request'>;
+    };
+
+    const resolversSchemas: InferResolverSchema<typeof configs> = {
+      config3: {
+        args: z.number(),
+        returnType: z.number(),
+      },
+    };
+
+    const result = await transformConfigs(configs, resolversSchemas);
+    expect(result).toEqual({
+      config3: configs.config3.resolver,
+    } satisfies LoadedConfigs<typeof configs>);
+  });
+
+  // should throw an error if the resolved value does not match the schema
+  it('should throw an error if the resolved value does not match the schema', async () => {
+    const configs = {
+      config3: {
+        evaluateOn: 'serverStart',
+        // @ts-expect-error - intentionally testing invalid return type
+        resolver: async () => '3',
+      },
+    } satisfies {
+      config3: ConfigAsyncResolverDefinition<undefined, number, 'serverStart'>;
+    };
+
+    const resolversSchemas: InferResolverSchema<typeof configs> = {
+      config3: {
+        args: z.undefined(),
+        // @ts-expect-error - intentionally testing invalid return type
+        returnType: z.number(),
+      },
+    };
+
+    await expect(transformConfigs(configs, resolversSchemas)).rejects.toThrow(
+      /Failed to parse config 'config3' resolved value/
+    );
   });
 });

--- a/src/utils/config/__tests__/transform-configs.test.ts
+++ b/src/utils/config/__tests__/transform-configs.test.ts
@@ -90,7 +90,6 @@ describe('getTransformedConfigs', () => {
     } satisfies LoadedConfigs<typeof configs>);
   });
 
-  // should throw an error if the resolved value does not match the schema
   it('should throw an error if the resolved value does not match the schema', async () => {
     const configs = {
       config3: {

--- a/src/utils/config/get-config-value.ts
+++ b/src/utils/config/get-config-value.ts
@@ -1,16 +1,19 @@
+import resolverSchemas from '../../config/dynamic/resolvers/schemas/resolver-schemas';
+
 import type {
   LoadedConfigValue,
   LoadedConfigs,
-  ArgOfConfigResolver,
+  ArgsOfLoadedConfigResolver,
   ConfigKeysWithArgs,
   ConfigKeysWithoutArgs,
+  ResolverSchemas,
 } from './config.types';
 import { loadedGlobalConfigs } from './global-configs-ref';
 
 // Overload for keys requiring arguments
 export default async function getConfigValue<K extends ConfigKeysWithArgs>(
   key: K,
-  arg: ArgOfConfigResolver<K>
+  arg: ArgsOfLoadedConfigResolver<K>
 ): Promise<LoadedConfigValue<K>>;
 
 // Overload for keys not requiring arguments (env configs)
@@ -21,7 +24,7 @@ export default async function getConfigValue<K extends ConfigKeysWithoutArgs>(
 
 export default async function getConfigValue<K extends keyof LoadedConfigs>(
   key: K,
-  arg?: ArgOfConfigResolver<K>
+  arg?: ArgsOfLoadedConfigResolver<K>
 ): Promise<LoadedConfigValue<K>> {
   if (typeof window !== 'undefined') {
     throw new Error('getConfigValue cannot be invoked on browser');
@@ -30,7 +33,24 @@ export default async function getConfigValue<K extends keyof LoadedConfigs>(
   const value = loadedGlobalConfigs[key] as LoadedConfigs[K];
 
   if (typeof value === 'function') {
-    return (await value(arg)) as LoadedConfigValue<K>;
+    const k = key as keyof ResolverSchemas;
+    // validate runtime arguments and resolved value
+    const { error: argsValidationError, data: validatedArg } =
+      resolverSchemas[k].args.safeParse(arg);
+    if (argsValidationError) {
+      throw new Error(
+        `Failed to parse config '${k}' arguments: ${argsValidationError.errors[0].message}`
+      );
+    }
+    const resolvedValue = await value(validatedArg);
+    const { error: valueValidationError, data: validatedValue } =
+      resolverSchemas[k].returnType.safeParse(resolvedValue);
+    if (valueValidationError) {
+      throw new Error(
+        `Failed to parse config '${k}' resolved value: ${valueValidationError.errors[0].message}`
+      );
+    }
+    return validatedValue as LoadedConfigValue<K>;
   }
 
   return value as LoadedConfigValue<K>;

--- a/src/utils/config/get-transformed-configs.ts
+++ b/src/utils/config/get-transformed-configs.ts
@@ -1,12 +1,13 @@
 import 'server-only';
 
 import configDefinitions from '../../config/dynamic/dynamic.config';
+import resolverSchemas from '../../config/dynamic/resolvers/schemas/resolver-schemas';
 
 import type { LoadedConfigs } from './config.types';
 import transformConfigs from './transform-configs';
 
-export default function getTransformedConfigs(): LoadedConfigs<
-  typeof configDefinitions
+export default async function getTransformedConfigs(): Promise<
+  LoadedConfigs<typeof configDefinitions>
 > {
-  return transformConfigs(configDefinitions);
+  return await transformConfigs(configDefinitions, resolverSchemas);
 }

--- a/src/utils/config/transform-configs.ts
+++ b/src/utils/config/transform-configs.ts
@@ -1,12 +1,28 @@
 import 'server-only';
 
-import type { ConfigDefinitionRecords, LoadedConfigs } from './config.types';
+import type {
+  ConfigDefinitionRecords,
+  InferResolverSchema,
+  LoadedConfigs,
+} from './config.types';
 
-export default function transformConfigs<C extends ConfigDefinitionRecords>(
-  configDefinitions: C
-): LoadedConfigs<C> {
-  const resolvedConfig = Object.fromEntries(
-    Object.entries(configDefinitions).map(([key, definition]) => {
+export default async function transformConfigs<
+  C extends ConfigDefinitionRecords,
+  S extends InferResolverSchema<C>,
+>(configDefinitions: C, resolverSchemas: S): Promise<LoadedConfigs<C>> {
+  const resolvedEntries = await Promise.all(
+    Object.entries(configDefinitions).map(async ([key, definition]) => {
+      if ('resolver' in definition && definition.evaluateOn === 'serverStart') {
+        const resolvedValue = await definition.resolver(undefined);
+        const { error, data: validatedValue } =
+          resolverSchemas[key as keyof S].returnType.safeParse(resolvedValue);
+        if (error) {
+          throw new Error(
+            `Failed to parse config '${key}' resolved value: ${error.errors[0].message}`
+          );
+        }
+        return [key, validatedValue];
+      }
       if ('resolver' in definition) {
         return [key, definition.resolver];
       }
@@ -15,6 +31,7 @@ export default function transformConfigs<C extends ConfigDefinitionRecords>(
       return [key, envValue === '' ? definition.default : envValue];
     })
   );
+  const resolvedConfig = Object.fromEntries(resolvedEntries);
 
   return resolvedConfig;
 }


### PR DESCRIPTION
### Summary
Adding validation schemas for config resolvers (args/return types) & use those schemas to validate the input/output of resolvers on runtime.

Add `evaluateOn` flag to configs to define when resolvers are being executed. It supports `request` & `serverStart`.

Add `isPublic` flag to configs to identify which configs are accessible from client code.

### Changes
- Extract logic from `getTransformedConfigs`  to `transformConfigs` for better testing (doing the same for `get-config-value.ts` in upcomming PR)
- Add schemas directory under configs as they can also be modified
- Add `evaluateOn` & `isPublic` flags
- Refactored types

### Upcoming plans
- Revisit naming for Types and functions to make them more understandable
- better testing for `get-config-value.ts`