### PR TITLE
Replace dayjs(newDate()) invocations with dayjs()

### DIFF
--- a/src/components/date-filter/date-filter.tsx
+++ b/src/components/date-filter/date-filter.tsx
@@ -70,13 +70,11 @@ export default function DateFilter({
         }}
         quickSelectOptions={QUICK_SELECT_OPTIONS.map(
           ({ label, durationSeconds }) => {
-            const now = new Date();
+            const now = dayjs();
             return {
               id: label,
-              beginDate: dayjs(now)
-                .subtract(durationSeconds, 'seconds')
-                .toDate(),
-              endDate: now,
+              beginDate: now.subtract(durationSeconds, 'seconds').toDate(),
+              endDate: now.toDate(),
             };
           }
         )}

--- a/src/views/domain-workflows-archival/domain-workflows-archival-header/domain-workflows-archival-header.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-header/domain-workflows-archival-header.tsx
@@ -41,7 +41,7 @@ export default function DomainWorkflowsArchivalHeader({
       !queryParams.timeRangeStartArchival &&
       !queryParams.timeRangeEndArchival
     ) {
-      const now = dayjs(new Date());
+      const now = dayjs();
       setQueryParams({
         timeRangeStartArchival: now
           .subtract(DOMAIN_WORKFLOWS_ARCHIVAL_START_DAYS_CONFIG, 'days')

--- a/src/views/domain-workflows-basic/domain-workflows-basic-filters/domain-workflows-basic-filters.tsx
+++ b/src/views/domain-workflows-basic/domain-workflows-basic-filters/domain-workflows-basic-filters.tsx
@@ -25,7 +25,7 @@ export default function DomainWorkflowsBasicFilters() {
 
   useEffect(() => {
     if (!queryParams.timeRangeStart && !queryParams.timeRangeEnd) {
-      const now = dayjs(new Date());
+      const now = dayjs();
       setQueryParams({
         timeRangeStart: now
           .subtract(DOMAIN_WORKFLOWS_BASIC_START_DAYS_CONFIG, 'days')


### PR DESCRIPTION
## Summary
- Address nit comment: https://github.com/cadence-workflow/cadence-web/pull/792#discussion_r1918815732
- Clean up code slightly to use `dayjs()` directly instead of calling `new Date()` and invoking `dayjs()` on it

## Test plan
Builds/tests passing