### PR TITLE
API for accessing public config

### DIFF
--- a/src/app/api/config/route.ts
+++ b/src/app/api/config/route.ts
@@ -1,0 +1,7 @@
+import { type NextRequest } from 'next/server';
+
+import getConfig from '@/route-handlers/get-config/get-config';
+
+export async function GET(request: NextRequest) {
+  return getConfig(request);
+}

--- a/src/route-handlers/get-config/__tests__/get-config.node.ts
+++ b/src/route-handlers/get-config/__tests__/get-config.node.ts
@@ -1,0 +1,85 @@
+import { NextRequest } from 'next/server';
+
+import getConfigValue from '@/utils/config/get-config-value';
+
+import getConfig from '../get-config';
+import getConfigValueQueryParamsSchema from '../schemas/get-config-query-params-schema';
+
+jest.mock('../schemas/get-config-query-params-schema');
+jest.mock('@/utils/config/get-config-value');
+
+describe('getConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 400 if query parameters are invalid', async () => {
+    (getConfigValueQueryParamsSchema.safeParse as jest.Mock).mockReturnValue({
+      data: null,
+      error: { errors: ['Invalid query parameters'] },
+    });
+
+    const { res } = await setup({
+      configKey: 'testKey',
+      jsonArgs: '',
+    });
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Invalid values provided for config key/args',
+      })
+    );
+  });
+
+  it('should return config value if query parameters are valid', async () => {
+    (getConfigValueQueryParamsSchema.safeParse as jest.Mock).mockReturnValue({
+      data: { configKey: 'testKey', jsonArgs: '{}' },
+      error: null,
+    });
+    (getConfigValue as jest.Mock).mockResolvedValue('value');
+
+    const { res } = await setup({
+      configKey: 'testKey',
+      jsonArgs: '{}',
+    });
+
+    expect(getConfigValue).toHaveBeenCalledWith('testKey', '{}');
+    const responseJson = await res.json();
+    expect(responseJson).toEqual('value');
+  });
+
+  it('should handle errors from getConfigValue', async () => {
+    (getConfigValueQueryParamsSchema.safeParse as jest.Mock).mockReturnValue({
+      data: { configKey: 'testKey', jsonArgs: '{}' },
+      error: null,
+    });
+    (getConfigValue as jest.Mock).mockRejectedValue(new Error('Config error'));
+
+    await expect(
+      setup({
+        configKey: 'testKey',
+        jsonArgs: '',
+      })
+    ).rejects.toThrow('Config error');
+  });
+});
+
+async function setup({
+  configKey,
+  jsonArgs,
+}: {
+  configKey: string;
+  jsonArgs: string;
+  error?: true;
+}) {
+  const res = await getConfig(
+    new NextRequest(
+      `http://localhost?configKey=${configKey}&jsonArgs=${jsonArgs}`,
+      {
+        method: 'GET',
+      }
+    )
+  );
+
+  return { res };
+}

--- a/src/route-handlers/get-config/get-config.ts
+++ b/src/route-handlers/get-config/get-config.ts
@@ -1,0 +1,29 @@
+import { NextResponse, type NextRequest } from 'next/server';
+
+import getConfigValue from '@/utils/config/get-config-value';
+
+import getConfigValueQueryParamsSchema from './schemas/get-config-query-params-schema';
+
+export default async function getConfig(request: NextRequest) {
+  const { data: queryParams, error } =
+    getConfigValueQueryParamsSchema.safeParse(
+      Object.fromEntries(request.nextUrl.searchParams)
+    );
+
+  if (error) {
+    return NextResponse.json(
+      {
+        message: 'Invalid values provided for config key/args',
+        cause: error.errors,
+      },
+      {
+        status: 400,
+      }
+    );
+  }
+
+  const { configKey, jsonArgs } = queryParams;
+  const res = await getConfigValue(configKey, jsonArgs);
+
+  return NextResponse.json(res);
+}

--- a/src/route-handlers/get-config/schemas/get-config-query-params-schema.ts
+++ b/src/route-handlers/get-config/schemas/get-config-query-params-schema.ts
@@ -1,0 +1,74 @@
+import { z } from 'zod';
+
+import dynamicConfigs from '@/config/dynamic/dynamic.config';
+import resolverSchemas from '@/config/dynamic/resolvers/schemas/resolver-schemas';
+import {
+  type PublicDynamicConfigKeys,
+  type ArgsOfLoadedConfigsResolvers,
+} from '@/utils/config/config.types';
+
+const publicConfigKeys = Object.entries(dynamicConfigs)
+  .filter(([_, d]) => d.isPublic)
+  .map(([k]) => k) as PublicDynamicConfigKeys[];
+
+const getConfigValueQueryParamsSchema = z
+  .object({
+    configKey: z.string(),
+    jsonArgs: z.string().optional(),
+  })
+  .transform((data, ctx) => {
+    const configKey = data.configKey as PublicDynamicConfigKeys;
+
+    // validate configKey
+    if (!publicConfigKeys.includes(configKey)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_enum_value,
+        options: publicConfigKeys,
+        received: configKey,
+        fatal: true,
+      });
+
+      return z.NEVER;
+    }
+
+    // parse jsonArgs
+    let parsedArgs;
+    try {
+      parsedArgs = data.jsonArgs
+        ? JSON.parse(decodeURIComponent(data.jsonArgs))
+        : undefined;
+    } catch {
+      ctx.addIssue({ code: 'custom', message: 'Invalid JSON' });
+      return z.NEVER;
+    }
+
+    // validate jsonArgs
+    const configKeyForSchema = configKey as keyof typeof resolverSchemas;
+    let validatedArgs = parsedArgs;
+    if (resolverSchemas[configKeyForSchema]) {
+      const schema = resolverSchemas[configKey as keyof typeof resolverSchemas];
+      const { error, data } = schema.args.safeParse(parsedArgs);
+      validatedArgs = data;
+      if (error) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Invalid jsonArgs type provided. ${error.errors[0].message}`,
+          fatal: true,
+        });
+        return z.NEVER;
+      }
+    }
+    const result: {
+      configKey: PublicDynamicConfigKeys;
+      jsonArgs: Pick<
+        ArgsOfLoadedConfigsResolvers,
+        PublicDynamicConfigKeys
+      >[PublicDynamicConfigKeys];
+    } = {
+      configKey,
+      jsonArgs: validatedArgs,
+    };
+    return result;
+  });
+
+export default getConfigValueQueryParamsSchema;

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -7,29 +7,7 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
   COMPUTED: ['mock-computed'],
   COMPUTED_WITH_ARG: ['mock-arg'],
   DYNAMIC_WITH_ARG: 5,
-  CLUSTERS: [
-    {
-      clusterName: 'mock-cluster1',
-      grpc: {
-        serviceName: 'mock-service1',
-        peer: 'mock.localhost:7933',
-      },
-    },
-    {
-      clusterName: 'mock-cluster2',
-      grpc: {
-        serviceName: 'mock-service2',
-        peer: 'mock.localhost:7933',
-      },
-    },
-  ],
-  CLUSTERS_PUBLIC: [
-    {
-      clusterName: 'mock-cluster1',
-    },
-    {
-      clusterName: 'mock-cluster2',
-    },
-  ],
+  GRPC_PROTO_DIR_BASE_PATH: 'mock/path/to/grpc/proto',
+  GRPC_SERVICES_NAMES: 'mock-grpc-service-name',
 };
 export default mockResolvedConfigValues;

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -1,0 +1,35 @@
+import { type LoadedConfigResolvedValues } from '../config.types';
+
+const mockResolvedConfigValues: LoadedConfigResolvedValues = {
+  DYNAMIC: 2,
+  ADMIN_SECURITY_TOKEN: 'mock-secret',
+  CADENCE_WEB_PORT: '3000',
+  COMPUTED: ['mock-computed'],
+  COMPUTED_WITH_ARG: ['mock-arg'],
+  DYNAMIC_WITH_ARG: 5,
+  CLUSTERS: [
+    {
+      clusterName: 'mock-cluster1',
+      grpc: {
+        serviceName: 'mock-service1',
+        peer: 'mock.localhost:7933',
+      },
+    },
+    {
+      clusterName: 'mock-cluster2',
+      grpc: {
+        serviceName: 'mock-service2',
+        peer: 'mock.localhost:7933',
+      },
+    },
+  ],
+  CLUSTERS_PUBLIC: [
+    {
+      clusterName: 'mock-cluster1',
+    },
+    {
+      clusterName: 'mock-cluster2',
+    },
+  ],
+};
+export default mockResolvedConfigValues;

--- a/src/utils/config/__mocks__/get-config-value.ts
+++ b/src/utils/config/__mocks__/get-config-value.ts
@@ -1,0 +1,8 @@
+import mockResolvedConfigValues from '../__fixtures__/resolved-config-values';
+import { type LoadedConfigResolvedValues } from '../config.types';
+
+export default jest.fn(function <K extends keyof LoadedConfigResolvedValues>(
+  key: K
+) {
+  return Promise.resolve(mockResolvedConfigValues[key]);
+});

--- a/src/utils/config/get-config-value.ts
+++ b/src/utils/config/get-config-value.ts
@@ -19,7 +19,12 @@ export default async function getConfigValue<K extends ConfigKeysWithArgs>(
 // Overload for keys not requiring arguments (env configs)
 export default async function getConfigValue<K extends ConfigKeysWithoutArgs>(
   key: K,
-  arg?: undefined
+  arg?: ArgsOfLoadedConfigResolver<K>
+): Promise<LoadedConfigValue<K>>;
+
+export default async function getConfigValue<K extends keyof LoadedConfigs>(
+  key: K,
+  arg: ArgsOfLoadedConfigResolver<K>
 ): Promise<LoadedConfigValue<K>>;
 
 export default async function getConfigValue<K extends keyof LoadedConfigs>(
@@ -30,7 +35,7 @@ export default async function getConfigValue<K extends keyof LoadedConfigs>(
     throw new Error('getConfigValue cannot be invoked on browser');
   }
 
-  const value = loadedGlobalConfigs[key] as LoadedConfigs[K];
+  const value = loadedGlobalConfigs[key as K];
 
   if (typeof value === 'function') {
     const k = key as keyof ResolverSchemas;

--- a/src/utils/config/get-transformed-configs.ts
+++ b/src/utils/config/get-transformed-configs.ts
@@ -6,8 +6,6 @@ import resolverSchemas from '../../config/dynamic/resolvers/schemas/resolver-sch
 import type { LoadedConfigs } from './config.types';
 import transformConfigs from './transform-configs';
 
-export default async function getTransformedConfigs(): Promise<
-  LoadedConfigs<typeof configDefinitions>
-> {
+export default async function getTransformedConfigs(): Promise<LoadedConfigs> {
   return await transformConfigs(configDefinitions, resolverSchemas);
 }

--- a/src/utils/config/transform-configs.ts
+++ b/src/utils/config/transform-configs.ts
@@ -9,13 +9,19 @@ import type {
 export default async function transformConfigs<
   C extends ConfigDefinitionRecords,
   S extends InferResolverSchema<C>,
->(configDefinitions: C, resolverSchemas: S): Promise<LoadedConfigs<C>> {
+>(configDefinitions: C, resolverSchemas: S): Promise<LoadedConfigs> {
   const resolvedEntries = await Promise.all(
     Object.entries(configDefinitions).map(async ([key, definition]) => {
       if ('resolver' in definition && definition.evaluateOn === 'serverStart') {
         const resolvedValue = await definition.resolver(undefined);
+        const resolverSchema = resolverSchemas[key as keyof S];
+        if (resolverSchema === undefined) {
+          throw new Error(
+            `Failed to parse config '${key}': resolver schema is required`
+          );
+        }
         const { error, data: validatedValue } =
-          resolverSchemas[key as keyof S].returnType.safeParse(resolvedValue);
+          resolverSchema.returnType.safeParse(resolvedValue);
         if (error) {
           throw new Error(
             `Failed to parse config '${key}' resolved value: ${error.errors[0].message}`


### PR DESCRIPTION
### Summary
Creating API to access configurations flagged as public from client side.

### Changes
- Create a route & route handler for `getConfig`
- Validate route inputs (key & args) based on config definition
- Create a mock for `get-config-value` utility
- Add types for public config and refactor resolved value types