### PR TITLE
Workflow Queries - panel when there are no queries available

### DIFF
--- a/src/views/workflow-queries/config/workflow-queries-empty-panel.config.ts
+++ b/src/views/workflow-queries/config/workflow-queries-empty-panel.config.ts
@@ -1,0 +1,15 @@
+import { type Props as ErrorPanelProps } from '@/components/error-panel/error-panel.types';
+
+const workflowQueriesEmptyPanelConfig = {
+  message: 'No queries available for this workflow',
+  omitLogging: true,
+  actions: [
+    {
+      kind: 'link-external',
+      label: 'Read more about workflow queries',
+      link: 'https://cadenceworkflow.io/docs/concepts/queries',
+    },
+  ],
+} as const satisfies ErrorPanelProps;
+
+export default workflowQueriesEmptyPanelConfig;

--- a/src/views/workflow-queries/workflow-queries.tsx
+++ b/src/views/workflow-queries/workflow-queries.tsx
@@ -4,11 +4,14 @@ import React, { useMemo, useState } from 'react';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 
+import ErrorPanel from '@/components/error-panel/error-panel';
+import PanelSection from '@/components/panel-section/panel-section';
 import { type FetchWorkflowQueryTypesResponse } from '@/route-handlers/fetch-workflow-query-types/fetch-workflow-query-types.types';
 import request from '@/utils/request';
 import { type RequestError } from '@/utils/request/request-error';
 import { type WorkflowPageTabContentProps } from '@/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.types';
 
+import workflowQueriesEmptyPanelConfig from './config/workflow-queries-empty-panel.config';
 import getWorkflowQueryStatus from './helpers/get-workflow-query-status';
 import useWorkflowQueries from './hooks/use-workflow-queries';
 import WorkflowQueriesResultJson from './workflow-queries-result-json/workflow-queries-result-json';
@@ -44,6 +47,14 @@ export default function WorkflowQueries(props: WorkflowPageTabContentProps) {
     ...props.params,
     queryTypes: filteredQueryTypes,
   });
+
+  if (filteredQueryTypes.length === 0) {
+    return (
+      <PanelSection>
+        <ErrorPanel {...workflowQueriesEmptyPanelConfig} />
+      </PanelSection>
+    );
+  }
 
   return (
     <styled.PageSection>


### PR DESCRIPTION
## Summary
- Show error panel when there are no queries available for a workflow
- Add panel config with message and actions

## Test plan
Added unit tests + ran locally.

<img width="1716" alt="Screenshot 2025-01-21 at 11 02 09 AM" src="https://github.com/user-attachments/assets/88c7d9b8-8f8b-4ab7-86e5-d3ca4bf4d3d8" />
