### PR TITLE
cache grpc services

### DIFF
--- a/src/utils/__tests__/global-ref.node.ts
+++ b/src/utils/__tests__/global-ref.node.ts
@@ -23,6 +23,11 @@ describe('GlobalRef', () => {
     expect(globalRef.value).toBeUndefined();
   });
 
+  it('should return default value if value is not set and default value is passed', () => {
+    const globalRef = new GlobalRef<number>('unique-name', 100);
+    expect(globalRef.value).toBe(100);
+  });
+
   it('should handle different types of values', () => {
     const stringRef = new GlobalRef<string>('string-unique-name');
     stringRef.value = 'test string';

--- a/src/utils/config/global-configs-ref.ts
+++ b/src/utils/config/global-configs-ref.ts
@@ -1,5 +1,6 @@
+import GlobalRef from '../global-ref';
+
 import { type LoadedConfigs } from './config.types';
-import GlobalRef from './global-ref';
 
 const globalConfigRef = new GlobalRef<LoadedConfigs>('cadence-config');
 const setLoadedGlobalConfigs = (c: LoadedConfigs): void => {

--- a/src/utils/global-ref.ts
+++ b/src/utils/global-ref.ts
@@ -1,8 +1,10 @@
 export default class GlobalRef<T> {
   private readonly sym: symbol;
 
-  constructor(uniqueName: string) {
+  constructor(uniqueName: string, defaultValue?: T) {
     this.sym = Symbol.for(uniqueName);
+    const g = global as any;
+    if (g[this.sym] === undefined) g[this.sym] = defaultValue;
   }
 
   get value() {

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -1,5 +1,3 @@
-import { result } from 'lodash';
-
 import { type DescribeClusterRequest__Input } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterRequest';
 import { type DescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
 import { type DescribeWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeWorkflowExecutionRequest';
@@ -37,7 +35,6 @@ import { type ClusterConfig } from '@/config/dynamic/resolvers/clusters.types';
 import grpcServiceConfigurations from '../../config/grpc/grpc-services-config';
 import getConfigValue from '../config/get-config-value';
 import GlobalRef from '../global-ref';
-import logger from '../logger';
 
 import GRPCService, {
   type GRPCMetadata,
@@ -111,10 +108,7 @@ const clusterServicesMap: ClustersServices = clisterServicesMapGlobalRef.value;
 
 const getClusterServices = async (c: ClusterConfig) => {
   if (clusterServicesMap[c.clusterName]) {
-    logger.info(`Returning cluster service ${c.clusterName} from cache`);
     return clusterServicesMap[c.clusterName];
-  } else {
-    logger.info(`Adding cluster service ${c.clusterName} from cache`);
   }
 
   const requestConfig: GRPCRequestConfig = {

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -100,11 +100,11 @@ export type GRPCClusterMethods = {
 };
 
 // cache services instances
-const clisterServicesMapGlobalRef = new GlobalRef<ClustersServices>(
+const clusterServicesMapGlobalRef = new GlobalRef<ClustersServices>(
   'cluster-services-map',
   {}
 );
-const clusterServicesMap: ClustersServices = clisterServicesMapGlobalRef.value;
+const clusterServicesMap: ClustersServices = clusterServicesMapGlobalRef.value;
 
 const getClusterServices = async (c: ClusterConfig) => {
   if (clusterServicesMap[c.clusterName]) {
@@ -148,7 +148,7 @@ const getClusterServices = async (c: ClusterConfig) => {
   return services;
 };
 
-const getClustersServices = async () => {
+const getAllClustersServices = async () => {
   const CLUSTERS_CONFIGS = await getConfigValue('CLUSTERS');
   const clustersServices: ClustersServices = {};
 
@@ -162,7 +162,7 @@ const getClusterServicesMethods = async (
   c: string,
   metadata?: GRPCMetadata
 ): Promise<GRPCClusterMethods> => {
-  const clusterServices = await getClustersServices();
+  const clusterServices = await getAllClustersServices();
   const { visibilityService, adminService, domainService, workflowService } =
     clusterServices[c];
 


### PR DESCRIPTION
### Summary
Cache grpc services so that they are not created on each request. This helps avoid high memory consumption as they are heavy objects.

### Changes
- Added global cache for cluster services
- Moved Global ref to utils root to be used in grpc too
- add default value for GlobalRef