### PR TITLE
Track selected event in url

### DIFF
--- a/src/views/workflow-history/hooks/__tests__/use-initial-selected-event.test.ts
+++ b/src/views/workflow-history/hooks/__tests__/use-initial-selected-event.test.ts
@@ -1,0 +1,62 @@
+import { renderHook } from '@/test-utils/rtl';
+
+import { completedActivityTaskEvents } from '../../__fixtures__/workflow-history-activity-events';
+import { completedDecisionTaskEvents } from '../../__fixtures__/workflow-history-decision-events';
+import useInitialSelectedEvent from '../use-initial-selected-event';
+
+jest.mock('../../helpers/get-history-event-group-id');
+
+describe('useInitialSelectedEvent', () => {
+  const events = [...completedDecisionTaskEvents];
+  const filteredEventGroupsEntries: [string, any][] = [
+    ['group1', completedDecisionTaskEvents],
+  ];
+
+  it('should return shouldSearchForInitialEvent as true when initialEventId is defined', () => {
+    const { result } = renderHook(() =>
+      useInitialSelectedEvent({
+        selectedEventId: '2',
+        events,
+        filteredEventGroupsEntries,
+      })
+    );
+
+    expect(result.current.shouldSearchForInitialEvent).toBe(true);
+  });
+
+  it('should return shouldSearchForInitialEvent as false when initialEventId is undefined', () => {
+    const { result } = renderHook(() =>
+      useInitialSelectedEvent({
+        selectedEventId: undefined,
+        events,
+        filteredEventGroupsEntries,
+      })
+    );
+
+    expect(result.current.shouldSearchForInitialEvent).toBe(false);
+  });
+
+  it('should return initialEventGroupIndex as undefined when initialEventId is defined & group is not found', () => {
+    const { result } = renderHook(() =>
+      useInitialSelectedEvent({
+        selectedEventId: '500',
+        events,
+        filteredEventGroupsEntries: [],
+      })
+    );
+
+    expect(result.current.initialEventGroupIndex).toBe(undefined);
+  });
+
+  it('should return initialEventFound as false when initialEventId is defined & event is not found', () => {
+    const { result } = renderHook(() =>
+      useInitialSelectedEvent({
+        selectedEventId: '500',
+        events,
+        filteredEventGroupsEntries,
+      })
+    );
+
+    expect(result.current.initialEventFound).toBe(false);
+  });
+});

--- a/src/views/workflow-history/hooks/__tests__/use-keep-loading-events.test.ts
+++ b/src/views/workflow-history/hooks/__tests__/use-keep-loading-events.test.ts
@@ -1,0 +1,132 @@
+import { renderHook } from '@/test-utils/rtl';
+
+import { completedDecisionTaskEvents } from '../../__fixtures__/workflow-history-decision-events';
+import useKeepLoadingEvents from '../use-keep-loading-events';
+import { type UseKeepLoadingEventsParams } from '../use-keep-loading-events.types';
+
+describe('useKeepLoadingEvents', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should set reachedAvailableHistoryEnd to true when there are no more pages', () => {
+    const { result } = setup({ hasNextPage: false });
+    expect(result.current.reachedAvailableHistoryEnd).toBe(true);
+  });
+
+  it('should call fetchNextPage when keepLoading is true and there are more pages', () => {
+    const { fetchNextPageMock } = setup({ keepLoading: true });
+
+    expect(fetchNextPageMock).toHaveBeenCalled();
+  });
+
+  it('should not call fetchNextPage when keepLoading is false', () => {
+    const { fetchNextPageMock } = setup({ keepLoading: false });
+
+    expect(fetchNextPageMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call fetchNextPage when isFetchingNextPage is true', () => {
+    const { fetchNextPageMock } = setup({ isFetchingNextPage: true });
+
+    expect(fetchNextPageMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call fetchNextPage when stopAfterEndReached is true and reachedAvailableHistoryEnd is true', () => {
+    const { fetchNextPageMock } = setup({
+      hasNextPage: false,
+      stopAfterEndReached: true,
+    });
+
+    expect(fetchNextPageMock).not.toHaveBeenCalled();
+  });
+
+  it('should set stoppedDueToError to true when isFetchNextPageError is true', () => {
+    const { result, rerender } = setup({
+      isFetchNextPageError: false,
+    });
+
+    expect(result.current.stoppedDueToError).toBe(false);
+
+    rerender({ isFetchNextPageError: true });
+
+    expect(result.current.stoppedDueToError).toBe(true);
+  });
+
+  it('should not call fetchNextPage when stoppedDueToError is true', () => {
+    const { fetchNextPageMock } = setup({ isFetchNextPageError: true });
+
+    expect(fetchNextPageMock).not.toHaveBeenCalled();
+  });
+
+  it('should return isLoadingMore as true when keepLoadingMore conditions are met', () => {
+    const { result, rerender } = setup({
+      keepLoading: true,
+      stopAfterEndReached: true,
+      hasNextPage: true,
+      isFetchNextPageError: false,
+    });
+
+    expect(result.current.isLoadingMore).toBe(true);
+
+    rerender({
+      keepLoading: true,
+      hasNextPage: true,
+      isFetchNextPageError: false,
+      // stopAfterEndReached and simulate end by empty events page
+      stopAfterEndReached: true,
+      resultPages: [
+        {
+          history: { events: completedDecisionTaskEvents },
+          rawHistory: [],
+          nextPageToken: '',
+          archived: false,
+        },
+        // last page is empty should signify end of history
+        {
+          history: { events: [] },
+          rawHistory: [],
+          nextPageToken: '',
+          archived: false,
+        },
+      ],
+    });
+    expect(result.current.isLoadingMore).toBe(false);
+
+    rerender({
+      keepLoading: true,
+      stopAfterEndReached: true,
+      hasNextPage: true,
+      // adding error
+      isFetchNextPageError: true,
+    });
+    expect(result.current.isLoadingMore).toBe(false);
+  });
+});
+
+function setup(params: Partial<UseKeepLoadingEventsParams>) {
+  const fetchNextPage = jest.fn();
+  const { result, rerender } = renderHook(
+    (runTimeChanges?: Partial<UseKeepLoadingEventsParams>) =>
+      useKeepLoadingEvents({
+        keepLoading: true,
+        stopAfterEndReached: true,
+        resultPages: [
+          {
+            history: { events: completedDecisionTaskEvents },
+            rawHistory: [],
+            nextPageToken: '',
+            archived: false,
+          },
+        ],
+        hasNextPage: true,
+        fetchNextPage,
+        isFetchingNextPage: false,
+        isFetchNextPageError: false,
+        ...params,
+        ...runTimeChanges,
+      })
+  );
+
+  return { result, rerender, fetchNextPageMock: fetchNextPage };
+}

--- a/src/views/workflow-history/hooks/__tests__/use-keep-loading-events.test.ts
+++ b/src/views/workflow-history/hooks/__tests__/use-keep-loading-events.test.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@/test-utils/rtl';
 
-import { completedDecisionTaskEvents } from '../../__fixtures__/workflow-history-decision-events';
 import useKeepLoadingEvents from '../use-keep-loading-events';
 import { type UseKeepLoadingEventsParams } from '../use-keep-loading-events.types';
 
@@ -14,14 +13,14 @@ describe('useKeepLoadingEvents', () => {
     expect(result.current.reachedAvailableHistoryEnd).toBe(true);
   });
 
-  it('should call fetchNextPage when keepLoading is true and there are more pages', () => {
-    const { fetchNextPageMock } = setup({ keepLoading: true });
+  it('should call fetchNextPage when shouldKeepLoading is true and there are more pages', () => {
+    const { fetchNextPageMock } = setup({ shouldKeepLoading: true });
 
     expect(fetchNextPageMock).toHaveBeenCalled();
   });
 
-  it('should not call fetchNextPage when keepLoading is false', () => {
-    const { fetchNextPageMock } = setup({ keepLoading: false });
+  it('should not call fetchNextPage when shouldKeepLoading is false', () => {
+    const { fetchNextPageMock } = setup({ shouldKeepLoading: false });
 
     expect(fetchNextPageMock).not.toHaveBeenCalled();
   });
@@ -61,7 +60,7 @@ describe('useKeepLoadingEvents', () => {
 
   it('should return isLoadingMore as true when keepLoadingMore conditions are met', () => {
     const { result, rerender } = setup({
-      keepLoading: true,
+      shouldKeepLoading: true,
       stopAfterEndReached: true,
       hasNextPage: true,
       isFetchNextPageError: false,
@@ -70,31 +69,17 @@ describe('useKeepLoadingEvents', () => {
     expect(result.current.isLoadingMore).toBe(true);
 
     rerender({
-      keepLoading: true,
+      shouldKeepLoading: true,
       hasNextPage: true,
       isFetchNextPageError: false,
       // stopAfterEndReached and simulate end by empty events page
       stopAfterEndReached: true,
-      resultPages: [
-        {
-          history: { events: completedDecisionTaskEvents },
-          rawHistory: [],
-          nextPageToken: '',
-          archived: false,
-        },
-        // last page is empty should signify end of history
-        {
-          history: { events: [] },
-          rawHistory: [],
-          nextPageToken: '',
-          archived: false,
-        },
-      ],
+      isLastPageEmpty: true,
     });
     expect(result.current.isLoadingMore).toBe(false);
 
     rerender({
-      keepLoading: true,
+      shouldKeepLoading: true,
       stopAfterEndReached: true,
       hasNextPage: true,
       // adding error
@@ -109,16 +94,9 @@ function setup(params: Partial<UseKeepLoadingEventsParams>) {
   const { result, rerender } = renderHook(
     (runTimeChanges?: Partial<UseKeepLoadingEventsParams>) =>
       useKeepLoadingEvents({
-        keepLoading: true,
+        shouldKeepLoading: true,
         stopAfterEndReached: true,
-        resultPages: [
-          {
-            history: { events: completedDecisionTaskEvents },
-            rawHistory: [],
-            nextPageToken: '',
-            archived: false,
-          },
-        ],
+        isLastPageEmpty: false,
         hasNextPage: true,
         fetchNextPage,
         isFetchingNextPage: false,

--- a/src/views/workflow-history/hooks/use-initial-selected-event.ts
+++ b/src/views/workflow-history/hooks/use-initial-selected-event.ts
@@ -4,6 +4,12 @@ import getHistoryEventGroupId from '../helpers/get-history-event-group-id';
 
 import { type UseInitialSelectedEventParams } from './use-initial-selected-event.types';
 
+/*
+ * This hook is used to search for the event and the group of the event that
+ * was selected when the component is mounted. It returns a boolean indicating if the
+ * initial event should be searched for, a boolean indicating if the initial
+ * event was found, and the index of the group that contains the event.
+ */
 export default function useInitialSelectedEvent({
   selectedEventId,
   events,

--- a/src/views/workflow-history/hooks/use-initial-selected-event.ts
+++ b/src/views/workflow-history/hooks/use-initial-selected-event.ts
@@ -1,0 +1,36 @@
+import { useMemo, useState } from 'react';
+
+import getHistoryEventGroupId from '../helpers/get-history-event-group-id';
+
+import { type UseInitialSelectedEventParams } from './use-initial-selected-event.types';
+
+export default function useInitialSelectedEvent({
+  selectedEventId,
+  events,
+  filteredEventGroupsEntries,
+}: UseInitialSelectedEventParams) {
+  const [initialEventId] = useState(selectedEventId);
+
+  const initialEvent = useMemo(() => {
+    if (!initialEventId) return undefined;
+    return events.find((e) => e.eventId === initialEventId);
+  }, [events, initialEventId]);
+
+  const shouldSearchForInitialEvent = initialEventId !== undefined;
+  const initialEventFound = initialEvent !== undefined;
+
+  const initialEventGroupIndex = useMemo(() => {
+    if (!initialEvent) return undefined;
+    const groupId = getHistoryEventGroupId(initialEvent);
+    const index = filteredEventGroupsEntries.findIndex(
+      ([id]) => id === groupId
+    );
+    return index > -1 ? index : undefined;
+  }, [initialEvent, filteredEventGroupsEntries]);
+
+  return {
+    shouldSearchForInitialEvent,
+    initialEventFound,
+    initialEventGroupIndex,
+  };
+}

--- a/src/views/workflow-history/hooks/use-initial-selected-event.types.ts
+++ b/src/views/workflow-history/hooks/use-initial-selected-event.types.ts
@@ -1,0 +1,7 @@
+import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
+
+export type UseInitialSelectedEventParams = {
+  events: HistoryEvent[];
+  selectedEventId?: string;
+  filteredEventGroupsEntries: [string, any][];
+};

--- a/src/views/workflow-history/hooks/use-keep-loading-events.ts
+++ b/src/views/workflow-history/hooks/use-keep-loading-events.ts
@@ -3,8 +3,8 @@ import { useEffect, useRef } from 'react';
 import { type UseKeepLoadingEventsParams } from './use-keep-loading-events.types';
 
 export default function useKeepLoadingEvents({
-  keepLoading,
-  resultPages,
+  shouldKeepLoading,
+  isLastPageEmpty,
   hasNextPage,
   fetchNextPage,
   isFetchingNextPage,
@@ -16,10 +16,7 @@ export default function useKeepLoadingEvents({
   const stoppedDueToError = useRef(isFetchNextPageError);
 
   // update reachedAvailableHistoryEnd
-  const reached =
-    !hasNextPage ||
-    (hasNextPage &&
-      resultPages[resultPages.length - 1].history?.events.length === 0);
+  const reached = !hasNextPage || (hasNextPage && isLastPageEmpty);
   if (reached && !reachedAvailableHistoryEnd.current)
     reachedAvailableHistoryEnd.current = true;
 
@@ -27,26 +24,19 @@ export default function useKeepLoadingEvents({
   if (isFetchNextPageError && !stoppedDueToError.current)
     stoppedDueToError.current = true;
 
-  const keepLoadingMore =
-    keepLoading &&
+  const canLoadMore =
+    shouldKeepLoading &&
     !(stopAfterEndReached && reachedAvailableHistoryEnd.current) &&
     !stoppedDueToError.current &&
     hasNextPage;
 
   useEffect(() => {
-    if (!keepLoadingMore) return;
-    if (keepLoading && hasNextPage && !isFetchingNextPage) fetchNextPage();
-  }, [
-    hasNextPage,
-    isFetchingNextPage,
-    fetchNextPage,
-    keepLoadingMore,
-    keepLoading,
-  ]);
+    if (canLoadMore && !isFetchingNextPage) fetchNextPage();
+  }, [isFetchingNextPage, fetchNextPage, canLoadMore]);
 
   return {
     reachedAvailableHistoryEnd: reachedAvailableHistoryEnd.current,
     stoppedDueToError: stoppedDueToError.current,
-    isLoadingMore: keepLoadingMore,
+    isLoadingMore: canLoadMore,
   };
 }

--- a/src/views/workflow-history/hooks/use-keep-loading-events.ts
+++ b/src/views/workflow-history/hooks/use-keep-loading-events.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+
+import { type UseKeepLoadingEventsParams } from './use-keep-loading-events.types';
+
+export default function useKeepLoadingEvents({
+  keepLoading,
+  resultPages,
+  hasNextPage,
+  fetchNextPage,
+  isFetchingNextPage,
+  stopAfterEndReached,
+  isFetchNextPageError,
+}: UseKeepLoadingEventsParams) {
+  const reachedAvailableHistoryEnd = useRef(false);
+
+  const stoppedDueToError = useRef(isFetchNextPageError);
+
+  // update reachedAvailableHistoryEnd
+  const reached =
+    !hasNextPage ||
+    (hasNextPage &&
+      resultPages[resultPages.length - 1].history?.events.length === 0);
+  if (reached && !reachedAvailableHistoryEnd.current)
+    reachedAvailableHistoryEnd.current = true;
+
+  // update stoppedDueToError
+  if (isFetchNextPageError && !stoppedDueToError.current)
+    stoppedDueToError.current = true;
+
+  const keepLoadingMore =
+    keepLoading &&
+    !(stopAfterEndReached && reachedAvailableHistoryEnd.current) &&
+    !stoppedDueToError.current &&
+    hasNextPage;
+
+  useEffect(() => {
+    if (!keepLoadingMore) return;
+    if (keepLoading && hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+    keepLoadingMore,
+    keepLoading,
+  ]);
+
+  return {
+    reachedAvailableHistoryEnd: reachedAvailableHistoryEnd.current,
+    stoppedDueToError: stoppedDueToError.current,
+    isLoadingMore: keepLoadingMore,
+  };
+}

--- a/src/views/workflow-history/hooks/use-keep-loading-events.types.ts
+++ b/src/views/workflow-history/hooks/use-keep-loading-events.types.ts
@@ -1,8 +1,6 @@
-import { type GetWorkflowHistoryResponse } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
-
 export type UseKeepLoadingEventsParams = {
-  keepLoading: boolean;
-  resultPages: GetWorkflowHistoryResponse[];
+  shouldKeepLoading: boolean;
+  isLastPageEmpty: boolean;
   hasNextPage: boolean;
   fetchNextPage: () => void;
   isFetchingNextPage: boolean;

--- a/src/views/workflow-history/hooks/use-keep-loading-events.types.ts
+++ b/src/views/workflow-history/hooks/use-keep-loading-events.types.ts
@@ -1,0 +1,11 @@
+import { type GetWorkflowHistoryResponse } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
+
+export type UseKeepLoadingEventsParams = {
+  keepLoading: boolean;
+  resultPages: GetWorkflowHistoryResponse[];
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+  isFetchingNextPage: boolean;
+  isFetchNextPageError: boolean;
+  stopAfterEndReached?: boolean;
+};

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.styles.ts
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.styles.ts
@@ -11,8 +11,19 @@ import type {
 export const overrides = {
   title: {
     Root: {
-      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+      style: ({
+        $theme,
+        $selected,
+      }: {
+        $theme: Theme;
+        $selected: boolean;
+      }): StyleObject => ({
         padding: $theme.sizing.scale550,
+        ...($selected
+          ? {
+              boxShadow: `inset 0px 0px 0px 2px ${$theme.colors.primary}`,
+            }
+          : null),
       }),
     },
     BodyContainerContent: {

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.tsx
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.tsx
@@ -20,6 +20,7 @@ export default function WorkflowHistoryCompactEventCard({
   label,
   badges,
   showLabelPlaceholder,
+  selected,
   onClick,
 }: Props) {
   const { cls, theme } = useStyletronClasses(cssStyles);
@@ -31,6 +32,7 @@ export default function WorkflowHistoryCompactEventCard({
       tileKind={TILE_KIND.selection}
       headerAlignment={ALIGNMENT.right}
       bodyAlignment={ALIGNMENT.left}
+      selected={selected}
       onClick={onClick}
     >
       <WorkflowHistoryEventStatusBadge status={status} size="small" />

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.types.ts
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.types.ts
@@ -10,4 +10,5 @@ export type Props = {
   showLabelPlaceholder?: boolean;
   badges?: HistoryGroupBadge[];
   onClick: TileProps['onClick'];
+  selected?: boolean;
 };

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -15,6 +15,7 @@ import usePageFilters from '@/components/page-filters/hooks/use-page-filters';
 import PageFiltersFields from '@/components/page-filters/page-filters-fields/page-filters-fields';
 import PageFiltersToggle from '@/components/page-filters/page-filters-toggle/page-filters-toggle';
 import PageSection from '@/components/page-section/page-section';
+import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 import { type GetWorkflowHistoryResponse } from '@/route-handlers/get-workflow-history/get-workflow-history.types';
 import decodeUrlParams from '@/utils/decode-url-params';
@@ -28,6 +29,8 @@ import useDescribeWorkflow from '../workflow-page/hooks/use-describe-workflow';
 import workflowHistoryFiltersConfig from './config/workflow-history-filters.config';
 import { groupHistoryEvents } from './helpers/group-history-events';
 import useEventExpansionToggle from './hooks/use-event-expansion-toggle';
+import useInitialSelectedEvent from './hooks/use-initial-selected-event';
+import useKeepLoadingEvents from './hooks/use-keep-loading-events';
 import WorkflowHistoryCompactEventCard from './workflow-history-compact-event-card/workflow-history-compact-event-card';
 import WorkflowHistoryExpandAllEventsButton from './workflow-history-expand-all-events-button/workflow-history-expand-all-events-button';
 import WorkflowHistoryExportJsonButton from './workflow-history-export-json-button/workflow-history-export-json-button';
@@ -48,11 +51,15 @@ export default function WorkflowHistory({ params }: Props) {
     waitForNewEvent: 'true',
   };
 
-  const { activeFiltersCount, queryParams, ...pageFiltersRest } =
-    usePageFilters({
-      pageQueryParamsConfig: workflowPageQueryParamsConfig,
-      pageFiltersConfig: workflowHistoryFiltersConfig,
-    });
+  const {
+    activeFiltersCount,
+    queryParams,
+    setQueryParams,
+    ...pageFiltersRest
+  } = usePageFilters({
+    pageQueryParamsConfig: workflowPageQueryParamsConfig,
+    pageFiltersConfig: workflowHistoryFiltersConfig,
+  });
 
   const {
     data: { workflowExecutionInfo },
@@ -64,6 +71,7 @@ export default function WorkflowHistory({ params }: Props) {
     fetchNextPage,
     isFetchingNextPage,
     error,
+    isFetchNextPageError,
   } = useSuspenseInfiniteQuery<
     GetWorkflowHistoryResponse,
     RequestError,
@@ -129,6 +137,33 @@ export default function WorkflowHistory({ params }: Props) {
     [eventGroups, queryParams]
   );
 
+  const {
+    initialEventFound,
+    initialEventGroupIndex,
+    shouldSearchForInitialEvent,
+  } = useInitialSelectedEvent({
+    selectedEventId: queryParams.historySelectedEventId,
+    events,
+    filteredEventGroupsEntries,
+  });
+  const keepLoadingMoreEvents = useMemo(() => {
+    if (shouldSearchForInitialEvent && !initialEventFound) return true;
+    return false;
+  }, [shouldSearchForInitialEvent, initialEventFound]);
+
+  const { isLoadingMore } = useKeepLoadingEvents({
+    keepLoading: keepLoadingMoreEvents,
+    stopAfterEndReached: true,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+    resultPages: result.pages,
+    isFetchNextPageError,
+  });
+
+  const contentIsLoading =
+    shouldSearchForInitialEvent && !initialEventFound && isLoadingMore;
+
   const [areFiltersShown, setAreFiltersShown] = useState(true);
   const {
     isExpandAllEvents,
@@ -143,6 +178,9 @@ export default function WorkflowHistory({ params }: Props) {
 
   const timelineSectionListRef = useRef<VirtuosoHandle>(null);
 
+  if (contentIsLoading) {
+    return <SectionLoadingIndicator />;
+  }
   return (
     <PageSection className={cls.pageContainer}>
       <div className={cls.pageHeader}>
@@ -173,6 +211,7 @@ export default function WorkflowHistory({ params }: Props) {
         <PageFiltersFields
           pageFiltersConfig={workflowHistoryFiltersConfig}
           queryParams={queryParams}
+          setQueryParams={setQueryParams}
           {...pageFiltersRest}
         />
       )}
@@ -196,9 +235,14 @@ export default function WorkflowHistory({ params }: Props) {
           <div role="list" className={cls.compactSection}>
             <Virtuoso
               data={filteredEventGroupsEntries}
+              {...(initialEventGroupIndex === undefined
+                ? {}
+                : {
+                    initialTopMostItemIndex: initialEventGroupIndex,
+                  })}
               itemContent={(
                 index,
-                [groupId, { label, status, timeLabel, badges }]
+                [groupId, { label, status, timeLabel, badges, events }]
               ) => (
                 <div role="listitem" className={cls.compactCardContainer}>
                   <WorkflowHistoryCompactEventCard
@@ -208,7 +252,13 @@ export default function WorkflowHistory({ params }: Props) {
                     secondaryLabel={timeLabel}
                     showLabelPlaceholder={!label}
                     badges={badges}
+                    selected={
+                      queryParams.historySelectedEventId === events[0].eventId
+                    }
                     onClick={() => {
+                      setQueryParams({
+                        historySelectedEventId: events[0].eventId,
+                      });
                       timelineSectionListRef.current?.scrollToIndex({
                         index,
                         align: 'start',
@@ -228,6 +278,16 @@ export default function WorkflowHistory({ params }: Props) {
               useWindowScroll
               data={filteredEventGroupsEntries}
               ref={timelineSectionListRef}
+              defaultItemHeight={160}
+              {...(initialEventGroupIndex === undefined
+                ? {}
+                : {
+                    initialTopMostItemIndex: {
+                      index: initialEventGroupIndex,
+                      align: 'start',
+                      behavior: 'smooth',
+                    },
+                  })}
               itemContent={(index, [groupId, group]) => (
                 <WorkflowHistoryTimelineGroup
                   key={groupId}

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -146,18 +146,22 @@ export default function WorkflowHistory({ params }: Props) {
     events,
     filteredEventGroupsEntries,
   });
+
+  const isLastPageEmpty =
+    result.pages[result.pages.length - 1].history?.events.length === 0;
+
   const keepLoadingMoreEvents = useMemo(() => {
     if (shouldSearchForInitialEvent && !initialEventFound) return true;
     return false;
   }, [shouldSearchForInitialEvent, initialEventFound]);
 
   const { isLoadingMore } = useKeepLoadingEvents({
-    keepLoading: keepLoadingMoreEvents,
+    shouldKeepLoading: keepLoadingMoreEvents,
     stopAfterEndReached: true,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
-    resultPages: result.pages,
+    isLastPageEmpty,
     isFetchNextPageError,
   });
 
@@ -181,6 +185,7 @@ export default function WorkflowHistory({ params }: Props) {
   if (contentIsLoading) {
     return <SectionLoadingIndicator />;
   }
+
   return (
     <PageSection className={cls.pageContainer}>
       <div className={cls.pageHeader}>
@@ -221,8 +226,7 @@ export default function WorkflowHistory({ params }: Props) {
           isLoading={
             workflowExecutionInfo?.closeStatus ===
             'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
-              ? result.pages[result.pages.length - 1].history?.events.length !==
-                0
+              ? !isLastPageEmpty
               : hasNextPage
           }
           hasMoreEvents={hasNextPage}

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -137,6 +137,7 @@ export default function WorkflowHistory({ params }: Props) {
     [eventGroups, queryParams]
   );
 
+  // search for the event selected in the URL on initial page load
   const {
     initialEventFound,
     initialEventGroupIndex,

--- a/src/views/workflow-page/config/workflow-page-query-params.config.ts
+++ b/src/views/workflow-page/config/workflow-page-query-params.config.ts
@@ -1,4 +1,7 @@
-import { type PageQueryParamMultiValue } from '@/hooks/use-page-query-params/use-page-query-params.types';
+import {
+  type PageQueryParam,
+  type PageQueryParamMultiValue,
+} from '@/hooks/use-page-query-params/use-page-query-params.types';
 import { HISTORY_EVENT_FILTER_STATUSES } from '@/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.constants';
 import { type HistoryEventFilterStatus } from '@/views/workflow-history/workflow-history-filters-status/workflow-history-filters-status.types';
 import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES } from '@/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants';
@@ -13,6 +16,7 @@ const workflowPageQueryParamsConfig: [
     'historyEventStatuses',
     HistoryEventFilterStatus[] | undefined
   >,
+  PageQueryParam<'historySelectedEventId', string | undefined>,
 ] = [
   {
     key: 'historyEventTypes',
@@ -41,6 +45,10 @@ const workflowPageQueryParamsConfig: [
       }
       return undefined;
     },
+  },
+  {
+    key: 'historySelectedEventId',
+    queryParamKey: 'he',
   },
 ] as const;
 


### PR DESCRIPTION
### Summary
Track event selection in url and show selection indicator on compact group cards.

### Changes
- add eventId to url on selection
- show selection border on compact cards
- create `useInitialSelectedEvent` hook to find get selected event on first page load
- create `useKeepLoadingEvents` hook to keep loading events until selected event is found or reaching the end of available events
- make virtuoso scroll to selected event on page load


### Screenshots
![Screenshot 2025-02-03 at 17 49 30](https://github.com/user-attachments/assets/a466e5c7-a4ba-4013-ae70-b1c539a9d02d)
