### PR TITLE
Workflow history - fix flaky test

### DIFF
--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -8,6 +8,7 @@ import {
   render,
   screen,
   userEvent,
+  waitFor,
   waitForElementToBeRemoved,
 } from '@/test-utils/rtl';
 
@@ -139,7 +140,7 @@ describe('WorkflowHistory', () => {
       hasNextPage: true,
     });
 
-    await act(() => {
+    act(() => {
       const resolver = getRequestResolver();
       resolver({
         history: {
@@ -153,19 +154,21 @@ describe('WorkflowHistory', () => {
 
     expect(await screen.findByText('keep loading events')).toBeInTheDocument();
 
-    const secondPageResolver = getRequestResolver();
-    secondPageResolver({
-      history: {
-        events: [completedDecisionTaskEvents[1]],
-      },
-      archived: false,
-      nextPageToken: 'mock-next-page-token',
-      rawHistory: [],
+    act(() => {
+      const secondPageResolver = getRequestResolver();
+      secondPageResolver({
+        history: {
+          events: [completedDecisionTaskEvents[1]],
+        },
+        archived: false,
+        nextPageToken: 'mock-next-page-token',
+        rawHistory: [],
+      });
     });
 
-    expect(
-      await screen.findByText('keep loading events')
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText('keep loading events')).not.toBeInTheDocument();
+    });
   });
 });
 

--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -8,7 +8,6 @@ import {
   render,
   screen,
   userEvent,
-  waitFor,
   waitForElementToBeRemoved,
 } from '@/test-utils/rtl';
 
@@ -142,7 +141,7 @@ describe('WorkflowHistory', () => {
       hasNextPage: true,
     });
 
-    act(() => {
+    await act(async () => {
       const resolver = getRequestResolver();
       resolver({
         history: {
@@ -154,9 +153,10 @@ describe('WorkflowHistory', () => {
       });
     });
 
-    expect(await screen.findByText('keep loading events')).toBeInTheDocument();
+    const loadingIndicator = await screen.findByText('keep loading events');
+    expect(loadingIndicator).toBeInTheDocument();
 
-    act(() => {
+    await act(async () => {
       const secondPageResolver = getRequestResolver();
       secondPageResolver({
         history: {
@@ -168,9 +168,7 @@ describe('WorkflowHistory', () => {
       });
     });
 
-    await waitFor(() => {
-      expect(screen.queryByText('keep loading events')).not.toBeInTheDocument();
-    });
+    await waitForElementToBeRemoved(loadingIndicator);
   });
 });
 

--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -136,7 +136,9 @@ describe('WorkflowHistory', () => {
   it('should show loading while searching for initial selectedEventId', async () => {
     const { getRequestResolver } = await setup({
       resolveLoadMoreManually: true,
-      pageQueryParamsValues: { historySelectedEventId: '3' },
+      pageQueryParamsValues: {
+        historySelectedEventId: completedDecisionTaskEvents[1].eventId,
+      },
       hasNextPage: true,
     });
 


### PR DESCRIPTION
Fix flaky test in workflow-history.test.tsx by:
- wrapping request resolution in act()
- using waitForElementToBeRemoved to assert that the loader vanishes