### PR TITLE
Allow spaces in search term

### DIFF
--- a/src/components/page-filters/page-filters-search/__tests__/page-filters-search.test.tsx
+++ b/src/components/page-filters/page-filters-search/__tests__/page-filters-search.test.tsx
@@ -33,14 +33,14 @@ describe(PageFiltersSearch.name, () => {
     expect(mockSetQueryParams).toHaveBeenCalledWith({ search: 'test-search' });
   });
 
-  it('should prune quotes and spaces from input text if no regexp is passed', async () => {
+  it('should prune quotes and start spaces from input text if no regexp is passed', async () => {
     const { user } = setup({});
 
     const searchInput = await screen.findByRole('textbox');
 
-    await user.type(searchInput, ` "test-search'`);
+    await user.type(searchInput, ` "test search' `);
 
-    expect(mockSetQueryParams).toHaveBeenCalledWith({ search: 'test-search' });
+    expect(mockSetQueryParams).toHaveBeenCalledWith({ search: 'test search ' });
   });
 
   it('should prune symbols from input text if regexp is passed', async () => {

--- a/src/components/page-filters/page-filters-search/page-filters-search.tsx
+++ b/src/components/page-filters/page-filters-search/page-filters-search.tsx
@@ -21,7 +21,7 @@ export default function PageFiltersSearch<
   pageQueryParamsConfig,
   searchQueryParamKey,
   searchPlaceholder,
-  searchTrimRegExp = /['"\s]/g,
+  searchTrimRegExp = /^\s+|['"]/g,
   inputDebounceDurationMs,
 }: Props<P, K>) {
   const [queryParams, setQueryParams] = usePageQueryParams(

--- a/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
+++ b/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
@@ -14,7 +14,7 @@ const listWorkflowsQueryParamSchema = z
       ),
     listType: z.enum(['default', 'archived']),
     inputType: z.enum(['search', 'query']),
-    search: z.string().optional(),
+    search: z.string().trim().optional(),
     query: z.string().optional(),
     status: z
       .custom<WorkflowStatus>(isWorkflowStatus, {


### PR DESCRIPTION
## Summary
Instead of pruning all spaces from the workflow search bar, we will now prune only the leading space in the UI, and prune the trailing space on the server side. This will allow users to search for workflows with spaces in the name/type.

## Test Plan
Unit tests + ran locally to verify.