### PR TITLE
Increase width of details label to 200px

### DIFF
--- a/src/views/workflow-history/workflow-history-event-details-group/workflow-history-event-details-group.styles.ts
+++ b/src/views/workflow-history/workflow-history-event-details-group/workflow-history-event-details-group.styles.ts
@@ -26,8 +26,8 @@ export const styled = {
     'div',
     { $forceWrap?: boolean; $useBlackText?: boolean }
   >('div', ({ $theme, $forceWrap, $useBlackText }) => ({
-    minWidth: '150px',
-    maxWidth: '150px',
+    minWidth: '200px',
+    maxWidth: '200px',
     display: 'flex',
     color: $useBlackText
       ? $theme.colors.contentPrimary


### PR DESCRIPTION
## Summary
Increase width of history details label to 200px to support longer field names.

## Test Plan
Ran locally.

Before:
<img width="316" alt="before screenshot" src="https://github.com/user-attachments/assets/fcab81b0-92a7-49e3-b50e-b3f8f46b1f42" />

On wider screens:
<img width="316" alt="Screenshot 2025-02-06 at 1 33 30 PM" src="https://github.com/user-attachments/assets/31ae8a31-9ddc-4343-8123-2e035cf051be" />

On narrow screens:
<img width="234" alt="Screenshot 2025-02-06 at 1 34 58 PM" src="https://github.com/user-attachments/assets/7d9ecf7d-c62e-4247-9d04-28a98a3c84a0" />
