### PR TITLE
Update license headers to 2025

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
            * // Copyright (c) 2024 Uber Technologies Inc.
            *
            * 2. multi-year span
-           * // Copyright (c) 2017-2024 Uber Technologies Inc.
+           * // Copyright (c) 2017-2025 Uber Technologies Inc.
            *
            * 3. new file from another company referenced
            * // Modifications Copyright (c) 2024 Uber Technologies Inc.
@@ -52,8 +52,8 @@ module.exports = {
            *         to:
            *           Copyright (c) 2024 Uber Technologies Inc.
            *         but should be (respectively):
-           *           Copyright (c) 2017-2024 Uber Technologies Inc.
-           *           Copyright (c) 2020-2024 Uber Technologies Inc.
+           *           Copyright (c) 2017-2025 Uber Technologies Inc.
+           *           Copyright (c) 2020-2025 Uber Technologies Inc.
            *
            *       I have requested for a new feature which allows templates to
            *       use named capture groups in the template. See open issue:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,13 +30,13 @@ module.exports = {
            * Examples which match pattern:
            *
            * 1. single year span (by default for new files)
-           * // Copyright (c) 2024 Uber Technologies Inc.
+           * // Copyright (c) 2025 Uber Technologies Inc.
            *
            * 2. multi-year span
            * // Copyright (c) 2017-2025 Uber Technologies Inc.
            *
            * 3. new file from another company referenced
-           * // Modifications Copyright (c) 2024 Uber Technologies Inc.
+           * // Modifications Copyright (c) 2025 Uber Technologies Inc.
            *
            * See `client/test/lint/license` for passing examples.
            *
@@ -50,7 +50,7 @@ module.exports = {
            *           Copyright (c) 2017-2023 Uber Technologies Inc.
            *           Copyright (c) 2020 Uber Technologies Inc.
            *         to:
-           *           Copyright (c) 2024 Uber Technologies Inc.
+           *           Copyright (c) 2025 Uber Technologies Inc.
            *         but should be (respectively):
            *           Copyright (c) 2017-2025 Uber Technologies Inc.
            *           Copyright (c) 2020-2025 Uber Technologies Inc.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/App.vue
+++ b/client/App.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/autocomplete.vue
+++ b/client/components/autocomplete.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/bar-loader.vue
+++ b/client/components/bar-loader.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/button-fill.vue
+++ b/client/components/button-fill.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/button-group.vue
+++ b/client/components/button-group.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/button-icon.vue
+++ b/client/components/button-icon.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/copy.vue
+++ b/client/components/copy.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/data-viewer.vue
+++ b/client/components/data-viewer.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/constants.js
+++ b/client/components/date-range-picker/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/helpers.js
+++ b/client/components/date-range-picker/helpers.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/helpers.spec.js
+++ b/client/components/date-range-picker/helpers.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/date-range-picker/index.vue
+++ b/client/components/date-range-picker/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/detail-list.vue
+++ b/client/components/detail-list.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/error-message.vue
+++ b/client/components/error-message.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/feature-flag.vue
+++ b/client/components/feature-flag.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/flex-grid-item.vue
+++ b/client/components/flex-grid-item.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/flex-grid.vue
+++ b/client/components/flex-grid.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/highlight-toggle.vue
+++ b/client/components/highlight-toggle.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,29 +19,29 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-export { default as Autocomplete } from './autocomplete';
-export { default as BarLoader } from './bar-loader';
-export { default as ButtonFill } from './button-fill';
-export { default as ButtonGroup } from './button-group';
-export { default as ButtonIcon } from './button-icon';
-export { default as Copy } from './copy';
-export { default as DataViewer } from './data-viewer';
-export { default as DateRangePicker } from './date-range-picker';
-export { default as DetailList } from './detail-list';
-export { default as ErrorMessage } from './error-message';
-export { default as FeatureFlag } from './feature-flag';
-export { default as FlexGrid } from './flex-grid';
-export { default as FlexGridItem } from './flex-grid-item';
-export { default as HighlightToggle } from './highlight-toggle';
-export { default as LoadingMessage } from './loading-message';
-export { default as LoadingSpinner } from './loading-spinner';
-export { default as NavigationBar } from './navigation-bar';
-export { default as NavigationLink } from './navigation-link';
-export { default as NewsModal } from './news-modal';
-export { default as NoResults } from './no-results';
-export { default as NotificationBar } from './notification-bar';
-export { default as SelectInput } from './select-input';
-export { default as SettingsFooter } from './settings-footer';
-export { default as SettingsToggle } from './settings-toggle';
-export { default as TextInput } from './text-input';
-export { default as WorkflowGrid } from './workflow-grid';
+export { default as Autocomplete } from "./autocomplete";
+export { default as BarLoader } from "./bar-loader";
+export { default as ButtonFill } from "./button-fill";
+export { default as ButtonGroup } from "./button-group";
+export { default as ButtonIcon } from "./button-icon";
+export { default as Copy } from "./copy";
+export { default as DataViewer } from "./data-viewer";
+export { default as DateRangePicker } from "./date-range-picker";
+export { default as DetailList } from "./detail-list";
+export { default as ErrorMessage } from "./error-message";
+export { default as FeatureFlag } from "./feature-flag";
+export { default as FlexGrid } from "./flex-grid";
+export { default as FlexGridItem } from "./flex-grid-item";
+export { default as HighlightToggle } from "./highlight-toggle";
+export { default as LoadingMessage } from "./loading-message";
+export { default as LoadingSpinner } from "./loading-spinner";
+export { default as NavigationBar } from "./navigation-bar";
+export { default as NavigationLink } from "./navigation-link";
+export { default as NewsModal } from "./news-modal";
+export { default as NoResults } from "./no-results";
+export { default as NotificationBar } from "./notification-bar";
+export { default as SelectInput } from "./select-input";
+export { default as SettingsFooter } from "./settings-footer";
+export { default as SettingsToggle } from "./settings-toggle";
+export { default as TextInput } from "./text-input";
+export { default as WorkflowGrid } from "./workflow-grid";

--- a/client/components/index.js
+++ b/client/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/loading-message.vue
+++ b/client/components/loading-message.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/loading-spinner.vue
+++ b/client/components/loading-spinner.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/navigation-bar.vue
+++ b/client/components/navigation-bar.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/navigation-link.vue
+++ b/client/components/navigation-link.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/news-modal.vue
+++ b/client/components/news-modal.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/no-results.vue
+++ b/client/components/no-results.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/notification-bar.vue
+++ b/client/components/notification-bar.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/paged-grid.js
+++ b/client/components/paged-grid.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/select-input.vue
+++ b/client/components/select-input.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-footer.vue
+++ b/client/components/settings-footer.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/settings-toggle.vue
+++ b/client/components/settings-toggle.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/text-input.vue
+++ b/client/components/text-input.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/components/workflow-grid.vue
+++ b/client/components/workflow-grid.vue
@@ -1,6 +1,6 @@
 <script>
 // Modifications Copyright (c) 2021-2025 Uber Technologies Inc.
-// Copyright (c) 2020-2024 Temporal Technologies, Inc.
+// Copyright (c) 2020-2025 Temporal Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,12 +20,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { RecycleScroller } from 'vue-virtual-scroller';
-import NoResults from './no-results';
+import { RecycleScroller } from "vue-virtual-scroller";
+import NoResults from "./no-results";
 
 export default {
-  name: 'workflow-grid',
-  props: ['workflows', 'loading', 'noResultsText'],
+  name: "workflow-grid",
+  props: ["workflows", "loading", "noResultsText"],
   data() {
     return {
       nextPageToken: undefined,
@@ -37,7 +37,7 @@ export default {
         return;
       }
 
-      this.$emit('onScroll', startIndex, endIndex);
+      this.$emit("onScroll", startIndex, endIndex);
     },
   },
   computed: {
@@ -47,7 +47,7 @@ export default {
   },
   components: {
     RecycleScroller,
-    'no-results': NoResults,
+    "no-results": NoResults,
   },
 };
 </script>

--- a/client/components/workflow-grid.vue
+++ b/client/components/workflow-grid.vue
@@ -1,5 +1,5 @@
 <script>
-// Modifications Copyright (c) 2021-2024 Uber Technologies Inc.
+// Modifications Copyright (c) 2021-2025 Uber Technologies Inc.
 // Copyright (c) 2020-2024 Temporal Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/constants.js
+++ b/client/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/action-types.js
+++ b/client/containers/active-status/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/actions.js
+++ b/client/containers/active-status/actions.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/component.vue
+++ b/client/containers/active-status/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/connector.js
+++ b/client/containers/active-status/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/constants.js
+++ b/client/containers/active-status/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/getter-types.js
+++ b/client/containers/active-status/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/getters.js
+++ b/client/containers/active-status/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/getters.spec.js
+++ b/client/containers/active-status/getters.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/get-cluster-from-cluster-list.js
+++ b/client/containers/active-status/helpers/get-cluster-from-cluster-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/get-cluster-list-from-domain-config-list.js
+++ b/client/containers/active-status/helpers/get-cluster-list-from-domain-config-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/get-filtered-cluster-list.js
+++ b/client/containers/active-status/helpers/get-filtered-cluster-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/get-href-from-cluster.js
+++ b/client/containers/active-status/helpers/get-href-from-cluster.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/index.js
+++ b/client/containers/active-status/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/merge-domain-config-list.js
+++ b/client/containers/active-status/helpers/merge-domain-config-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/state-prefix.js
+++ b/client/containers/active-status/helpers/state-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/helpers/type-prefix.js
+++ b/client/containers/active-status/helpers/type-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/active-status/index.js
+++ b/client/containers/active-status/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/action-types.js
+++ b/client/containers/cluster/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/actions.js
+++ b/client/containers/cluster/actions.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/actions.spec.js
+++ b/client/containers/cluster/actions.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/constants.js
+++ b/client/containers/cluster/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/get-default-state.js
+++ b/client/containers/cluster/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/get-default-state.spec.js
+++ b/client/containers/cluster/get-default-state.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/getter-types.js
+++ b/client/containers/cluster/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/getters.js
+++ b/client/containers/cluster/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/getters.spec.js
+++ b/client/containers/cluster/getters.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/helpers/can-fetch-cluster.js
+++ b/client/containers/cluster/helpers/can-fetch-cluster.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/helpers/can-fetch-cluster.spec.js
+++ b/client/containers/cluster/helpers/can-fetch-cluster.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/helpers/index.js
+++ b/client/containers/cluster/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/index.js
+++ b/client/containers/cluster/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/mutation-types.js
+++ b/client/containers/cluster/mutation-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/mutations.js
+++ b/client/containers/cluster/mutations.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cluster/mutations.spec.js
+++ b/client/containers/cluster/mutations.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/action-types.js
+++ b/client/containers/cross-region/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/actions.js
+++ b/client/containers/cross-region/actions.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/component.vue
+++ b/client/containers/cross-region/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/connector.js
+++ b/client/containers/cross-region/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/constants.js
+++ b/client/containers/cross-region/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/get-default-state.js
+++ b/client/containers/cross-region/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/getter-types.js
+++ b/client/containers/cross-region/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/getters.js
+++ b/client/containers/cross-region/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/helpers/index.js
+++ b/client/containers/cross-region/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/helpers/state-prefix.js
+++ b/client/containers/cross-region/helpers/state-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/helpers/type-prefix.js
+++ b/client/containers/cross-region/helpers/type-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/index.js
+++ b/client/containers/cross-region/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/mutation-types.js
+++ b/client/containers/cross-region/mutation-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/cross-region/mutations.js
+++ b/client/containers/cross-region/mutations.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/action-types.js
+++ b/client/containers/domain-autocomplete/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/actions.js
+++ b/client/containers/domain-autocomplete/actions.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/component.vue
+++ b/client/containers/domain-autocomplete/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/connector.js
+++ b/client/containers/domain-autocomplete/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/constants.js
+++ b/client/containers/domain-autocomplete/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/get-default-state.js
+++ b/client/containers/domain-autocomplete/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/getter-types.js
+++ b/client/containers/domain-autocomplete/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/getters.js
+++ b/client/containers/domain-autocomplete/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/combine-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/combine-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/combine-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/combine-domain-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/filter-duplicates-from-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/filter-duplicates-from-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/filter-top-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/filter-top-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/filter-top-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/filter-top-domain-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/filter-visited-domain-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/format-domain-label.js
+++ b/client/containers/domain-autocomplete/helpers/format-domain-label.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/format-domain-label.spec.js
+++ b/client/containers/domain-autocomplete/helpers/format-domain-label.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/format-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/format-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/index.js
+++ b/client/containers/domain-autocomplete/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/migrate-recent-domains.js
+++ b/client/containers/domain-autocomplete/helpers/migrate-recent-domains.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/migrate-recent-domains.spec.js
+++ b/client/containers/domain-autocomplete/helpers/migrate-recent-domains.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/sort-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/sort-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/sort-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/sort-domain-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/state-prefix.js
+++ b/client/containers/domain-autocomplete/helpers/state-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/type-prefix.js
+++ b/client/containers/domain-autocomplete/helpers/type-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/update-visited-domain-list.js
+++ b/client/containers/domain-autocomplete/helpers/update-visited-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/helpers/update-visited-domain-list.spec.js
+++ b/client/containers/domain-autocomplete/helpers/update-visited-domain-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/index.js
+++ b/client/containers/domain-autocomplete/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/mutation-types.js
+++ b/client/containers/domain-autocomplete/mutation-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/mutations.js
+++ b/client/containers/domain-autocomplete/mutations.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain-autocomplete/reducer.js
+++ b/client/containers/domain-autocomplete/reducer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/action-types.js
+++ b/client/containers/domain/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/actions.js
+++ b/client/containers/domain/actions.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/component.vue
+++ b/client/containers/domain/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/connector.js
+++ b/client/containers/domain/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/constants.js
+++ b/client/containers/domain/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/get-default-state.js
+++ b/client/containers/domain/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/getter-types.js
+++ b/client/containers/domain/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/getters.js
+++ b/client/containers/domain/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/helpers/get-cross-origin.js
+++ b/client/containers/domain/helpers/get-cross-origin.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/helpers/get-domain.js
+++ b/client/containers/domain/helpers/get-domain.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/helpers/index.js
+++ b/client/containers/domain/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/helpers/state-prefix.js
+++ b/client/containers/domain/helpers/state-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/helpers/type-prefix.js
+++ b/client/containers/domain/helpers/type-prefix.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/index.js
+++ b/client/containers/domain/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/mutation-types.js
+++ b/client/containers/domain/mutation-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/domain/mutations.js
+++ b/client/containers/domain/mutations.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/graph/get-default-state.js
+++ b/client/containers/graph/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/graph/getters.js
+++ b/client/containers/graph/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/graph/index.js
+++ b/client/containers/graph/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/graph/mutations.js
+++ b/client/containers/graph/mutations.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/index.js
+++ b/client/containers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/action-creator.js
+++ b/client/containers/route/action-creator.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/action-creator.spec.js
+++ b/client/containers/route/action-creator.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/action-types.js
+++ b/client/containers/route/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/getter-types.js
+++ b/client/containers/route/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/getters.js
+++ b/client/containers/route/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/getters.spec.js
+++ b/client/containers/route/getters.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/helpers/get-updated-query.js
+++ b/client/containers/route/helpers/get-updated-query.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/helpers/get-updated-query.spec.js
+++ b/client/containers/route/helpers/get-updated-query.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/helpers/index.js
+++ b/client/containers/route/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/route/index.js
+++ b/client/containers/route/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-modal/component.vue
+++ b/client/containers/settings-modal/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-modal/components/settings-date-format.vue
+++ b/client/containers/settings-modal/components/settings-date-format.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-modal/components/settings-header.vue
+++ b/client/containers/settings-modal/components/settings-header.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-modal/components/settings-list.vue
+++ b/client/containers/settings-modal/components/settings-list.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-modal/constants.js
+++ b/client/containers/settings-modal/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-modal/index.js
+++ b/client/containers/settings-modal/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/component.vue
+++ b/client/containers/settings-workflow-history/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/connector.js
+++ b/client/containers/settings-workflow-history/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/constants.js
+++ b/client/containers/settings-workflow-history/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/get-default-state.js
+++ b/client/containers/settings-workflow-history/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/getter-types.js
+++ b/client/containers/settings-workflow-history/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/getters.js
+++ b/client/containers/settings-workflow-history/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/index.js
+++ b/client/containers/settings-workflow-history/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/mutation-types.js
+++ b/client/containers/settings-workflow-history/mutation-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/settings-workflow-history/mutations.js
+++ b/client/containers/settings-workflow-history/mutations.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/component.vue
+++ b/client/containers/workflow-history/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/event-detail.vue
+++ b/client/containers/workflow-history/components/event-detail.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/footer-toolbar.vue
+++ b/client/containers/workflow-history/components/footer-toolbar.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/index.js
+++ b/client/containers/workflow-history/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/timeline.vue
+++ b/client/containers/workflow-history/components/timeline.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/components/graph-legend.vue
+++ b/client/containers/workflow-history/components/workflow-graph/components/graph-legend.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/components/graph.vue
+++ b/client/containers/workflow-history/components/workflow-graph/components/graph.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/constants.js
+++ b/client/containers/workflow-history/components/workflow-graph/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/arrange-graph.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/arrange-graph.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/arrange-nodes.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/arrange-nodes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/cytoscape-layout.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/cytoscape-layout.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/find-child-event.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/find-child-event.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-cancel-requested.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-cancel-requested.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-canceled.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-canceled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-completed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-completed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-scheduled.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-scheduled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-started.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-started.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-timed-out.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/activity-task-timed-out.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/cancel-timer-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/cancel-timer-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-canceled.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-canceled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-completed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-completed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-started.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-started.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-terminated.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-terminated.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-timed-out.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/child-workflow-execution-timed-out.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-completed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-completed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-started.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-started.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-timed-out.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/decision-task-timed-out.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/external-workflow-execution-cancel-requested.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/external-workflow-execution-cancel-requested.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/external-workflow-execution-signaled.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/external-workflow-execution-signaled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/index.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/marker-recorded.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/marker-recorded.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/request-cancel-activity-task-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/request-cancel-activity-task-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/request-cancel-external-workflow-execution-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/request-cancel-external-workflow-execution-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/request-cancel-external-workflow-execution-initiated.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/request-cancel-external-workflow-execution-initiated.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/signal-external-workflow-execution-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/signal-external-workflow-execution-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/signal-external-workflow-execution-initiated.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/signal-external-workflow-execution-initiated.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/start-child-workflow-execution-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/start-child-workflow-execution-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/start-child-workflow-execution-initiated.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/start-child-workflow-execution-initiated.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/timer-canceled.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/timer-canceled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/timer-fired.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/timer-fired.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/timer-started.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/timer-started.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/upsert-workflow-search-attributes.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/upsert-workflow-search-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-cancel-requested.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-cancel-requested.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-canceled.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-canceled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-completed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-completed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-continued-as-new.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-continued-as-new.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-failed.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-failed.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-signaled.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-signaled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-started.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-started.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-timed-out.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-event-connections/workflow-execution-timed-out.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-graph-pan-center.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-graph-pan-center.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/get-time-index-pair-key.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/get-time-index-pair-key.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/index.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/select-node.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/select-node.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/set-chronological-children.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/set-chronological-children.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/helpers/set-direct-and-inferred-children.js
+++ b/client/containers/workflow-history/components/workflow-graph/helpers/set-direct-and-inferred-children.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/components/workflow-graph/index.vue
+++ b/client/containers/workflow-history/components/workflow-graph/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/connector.js
+++ b/client/containers/workflow-history/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/constants.js
+++ b/client/containers/workflow-history/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/get-default-state.js
+++ b/client/containers/workflow-history/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/get-default-state.spec.js
+++ b/client/containers/workflow-history/get-default-state.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/helpers.js
+++ b/client/containers/workflow-history/helpers.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-history/index.js
+++ b/client/containers/workflow-history/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/action-types.js
+++ b/client/containers/workflow-list/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/actions.js
+++ b/client/containers/workflow-list/actions.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/actions.spec.js
+++ b/client/containers/workflow-list/actions.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -1,6 +1,6 @@
 <script>
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import moment from 'moment';
-import debounce from 'lodash-es/debounce';
-import lowerCase from 'lodash-es/lowerCase';
+import moment from "moment";
+import debounce from "lodash-es/debounce";
+import lowerCase from "lodash-es/lowerCase";
 import {
   IS_CRON_LIST,
   FILTER_MODE_ADVANCED,
@@ -33,14 +33,14 @@ import {
   STATUS_CLOSED,
   STATUS_LIST,
   STATUS_OPEN,
-} from './constants';
+} from "./constants";
 import {
   getCriteria,
   getFormattedResults,
   getMinStartDate,
   isRangeValid,
   isRouteRangeValid,
-} from './helpers';
+} from "./helpers";
 import {
   ButtonFill,
   DateRangePicker,
@@ -51,32 +51,32 @@ import {
   SelectInput,
   TextInput,
   WorkflowGrid,
-} from '~components';
-import { delay, getEndTimeIsoString, getStartTimeIsoString } from '~helpers';
-import { httpService } from '~services';
-import { featureFlagService } from '~services';
+} from "~components";
+import { delay, getEndTimeIsoString, getStartTimeIsoString } from "~helpers";
+import { httpService } from "~services";
+import { featureFlagService } from "~services";
 
 export default {
-  name: 'workflow-list',
+  name: "workflow-list",
   props: [
-    'clusterName',
-    'dateFormat',
-    'domain',
-    'fetchWorkflowListUrl',
-    'filterBy',
-    'filterMode',
-    'filterModeButtonEnabled',
-    'filterModeButtonLabel',
-    'isCron',
-    'isCronInputVisible',
-    'queryString',
-    'state',
-    'status',
-    'statusName',
-    'timeFormat',
-    'timezone',
-    'workflowId',
-    'workflowName',
+    "clusterName",
+    "dateFormat",
+    "domain",
+    "fetchWorkflowListUrl",
+    "filterBy",
+    "filterMode",
+    "filterModeButtonEnabled",
+    "filterModeButtonLabel",
+    "isCron",
+    "isCronInputVisible",
+    "queryString",
+    "state",
+    "status",
+    "statusName",
+    "timeFormat",
+    "timezone",
+    "workflowId",
+    "workflowName",
   ],
   data() {
     return {
@@ -95,7 +95,7 @@ export default {
   },
   async created() {
     const defaultDateRange = await featureFlagService.getConfiguration({
-      name: 'defaultDateRange',
+      name: "defaultDateRange",
     });
 
     this.defaultDateRange = Number(defaultDateRange) || 30;
@@ -111,15 +111,15 @@ export default {
     clearInterval(this.interval);
   },
   components: {
-    'button-fill': ButtonFill,
-    'date-range-picker': DateRangePicker,
-    'error-message': ErrorMessage,
-    'feature-flag': FeatureFlag,
-    'flex-grid': FlexGrid,
-    'flex-grid-item': FlexGridItem,
-    'select-input': SelectInput,
-    'text-input': TextInput,
-    'workflow-grid': WorkflowGrid,
+    "button-fill": ButtonFill,
+    "date-range-picker": DateRangePicker,
+    "error-message": ErrorMessage,
+    "feature-flag": FeatureFlag,
+    "flex-grid": FlexGrid,
+    "flex-grid-item": FlexGridItem,
+    "select-input": SelectInput,
+    "text-input": TextInput,
+    "workflow-grid": WorkflowGrid,
   },
   computed: {
     criteria() {
@@ -219,7 +219,7 @@ export default {
         return `No workflows for the selected filters`;
       }
 
-      if (typeof this.range === 'string') {
+      if (typeof this.range === "string") {
         return `No workflows within ${lowerCase(this.range)}`;
       }
 
@@ -227,7 +227,7 @@ export default {
         return `No workflows within selected period`;
       }
 
-      return 'No Results';
+      return "No Results";
     },
     crossRegionProps() {
       const { clusterName, domain } = this;
@@ -245,9 +245,9 @@ export default {
     },
     async fetch(url, queryWithStatus) {
       let workflows = [];
-      let nextPageToken = '';
+      let nextPageToken = "";
 
-      if ([null, ''].includes(queryWithStatus.nextPageToken)) {
+      if ([null, ""].includes(queryWithStatus.nextPageToken)) {
         return { workflows, nextPageToken };
       }
 
@@ -280,19 +280,19 @@ export default {
 
         nextPageToken = request.nextPageToken;
       } catch (error) {
-        if (error.name === 'AbortError') {
-          return { status: 'aborted' };
+        if (error.name === "AbortError") {
+          return { status: "aborted" };
         }
 
         this.error =
           (error.json && error.json.message) || error.status || error.message;
 
-        return { status: 'error' };
+        return { status: "error" };
       } finally {
         this.loading = false;
       }
 
-      return { status: 'success', workflows, nextPageToken };
+      return { status: "success", workflows, nextPageToken };
     },
     async fetchDomain() {
       const { domain, now } = this;
@@ -367,7 +367,7 @@ export default {
           query
         );
 
-        if (status !== 'success') {
+        if (status !== "success") {
           return;
         }
 
@@ -395,7 +395,7 @@ export default {
           queryOpen
         );
 
-        if (openStatus !== 'success') {
+        if (openStatus !== "success") {
           return;
         }
 
@@ -410,7 +410,7 @@ export default {
           queryClosed
         );
 
-        if (closedStatus !== 'success') {
+        if (closedStatus !== "success") {
           return;
         }
 
@@ -447,29 +447,29 @@ export default {
         this.clearState();
         this.fetchWorkflowList();
       },
-      typeof Mocha === 'undefined' ? 200 : 60,
+      typeof Mocha === "undefined" ? 200 : 60,
       { maxWait: 1000 }
     ),
     onFilterChange(event) {
       const target = event.target || event.testTarget; // test hook since Event.target is readOnly and unsettable
-      const name = target.getAttribute('name');
+      const name = target.getAttribute("name");
       const value = target.value;
 
-      this.$emit('onFilterChange', { [name]: value });
+      this.$emit("onFilterChange", { [name]: value });
     },
     onIsCronChange(isCron) {
       if (isCron) {
-        this.$emit('onFilterChange', { isCron: isCron.value });
+        this.$emit("onFilterChange", { isCron: isCron.value });
       }
     },
     onStatusChange(status) {
       if (status) {
-        this.$emit('onFilterChange', { status: status.value });
+        this.$emit("onFilterChange", { status: status.value });
       }
     },
     onFilterModeClick() {
       this.clearState();
-      this.$emit('onFilterModeClick');
+      this.$emit("onFilterModeClick");
     },
     onWorkflowGridScroll(startIndex, endIndex) {
       if (!this.npt && !this.nptAlt) {
@@ -482,7 +482,7 @@ export default {
       const query = { ...this.$route.query };
 
       if (range) {
-        if (typeof range === 'string') {
+        if (typeof range === "string") {
           query.range = range;
           delete query.startTime;
           delete query.endTime;

--- a/client/containers/workflow-list/component.vue
+++ b/client/containers/workflow-list/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/connector.js
+++ b/client/containers/workflow-list/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/constants.js
+++ b/client/containers/workflow-list/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/getter-types.js
+++ b/client/containers/workflow-list/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/getters.js
+++ b/client/containers/workflow-list/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/getters.spec.js
+++ b/client/containers/workflow-list/getters.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-criteria.js
+++ b/client/containers/workflow-list/helpers/get-criteria.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-criteria.spec.js
+++ b/client/containers/workflow-list/helpers/get-criteria.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-fetch-workflow-list-url.js
+++ b/client/containers/workflow-list/helpers/get-fetch-workflow-list-url.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-fetch-workflow-list-url.spec.js
+++ b/client/containers/workflow-list/helpers/get-fetch-workflow-list-url.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-filter-by.js
+++ b/client/containers/workflow-list/helpers/get-filter-by.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-filter-by.spec.js
+++ b/client/containers/workflow-list/helpers/get-filter-by.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-filter-mode-button-label.js
+++ b/client/containers/workflow-list/helpers/get-filter-mode-button-label.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-filter-mode-button-label.spec.js
+++ b/client/containers/workflow-list/helpers/get-filter-mode-button-label.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-formatted-results.js
+++ b/client/containers/workflow-list/helpers/get-formatted-results.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-formatted-results.spec.js
+++ b/client/containers/workflow-list/helpers/get-formatted-results.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-is-cron.js
+++ b/client/containers/workflow-list/helpers/get-is-cron.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-min-start-date.js
+++ b/client/containers/workflow-list/helpers/get-min-start-date.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-min-start-date.spec.js
+++ b/client/containers/workflow-list/helpers/get-min-start-date.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-state.js
+++ b/client/containers/workflow-list/helpers/get-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-state.spec.js
+++ b/client/containers/workflow-list/helpers/get-state.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-status.js
+++ b/client/containers/workflow-list/helpers/get-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/get-status.spec.js
+++ b/client/containers/workflow-list/helpers/get-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/index.js
+++ b/client/containers/workflow-list/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/is-range-valid.js
+++ b/client/containers/workflow-list/helpers/is-range-valid.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/is-range-valid.spec.js
+++ b/client/containers/workflow-list/helpers/is-range-valid.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/is-route-range-valid.js
+++ b/client/containers/workflow-list/helpers/is-route-range-valid.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/is-route-range-valid.spec.js
+++ b/client/containers/workflow-list/helpers/is-route-range-valid.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/toggle-filter-mode.js
+++ b/client/containers/workflow-list/helpers/toggle-filter-mode.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/helpers/toggle-filter-mode.spec.js
+++ b/client/containers/workflow-list/helpers/toggle-filter-mode.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-list/index.js
+++ b/client/containers/workflow-list/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/action-types.js
+++ b/client/containers/workflow-pending/action-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/actions.js
+++ b/client/containers/workflow-pending/actions.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/actions.spec.js
+++ b/client/containers/workflow-pending/actions.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/component.vue
+++ b/client/containers/workflow-pending/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/components/index.js
+++ b/client/containers/workflow-pending/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/components/pending-task-list-item.vue
+++ b/client/containers/workflow-pending/components/pending-task-list-item.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/connector.js
+++ b/client/containers/workflow-pending/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/constants.js
+++ b/client/containers/workflow-pending/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/getter-types.js
+++ b/client/containers/workflow-pending/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/getters.js
+++ b/client/containers/workflow-pending/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/getters.spec.js
+++ b/client/containers/workflow-pending/getters.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/helpers/get-workflow-link.js
+++ b/client/containers/workflow-pending/helpers/get-workflow-link.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/helpers/index.js
+++ b/client/containers/workflow-pending/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/helpers/map-filter-to-getter-type.js
+++ b/client/containers/workflow-pending/helpers/map-filter-to-getter-type.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/helpers/map-pending-task-list.js
+++ b/client/containers/workflow-pending/helpers/map-pending-task-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow-pending/index.js
+++ b/client/containers/workflow-pending/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/component.vue
+++ b/client/containers/workflow/component.vue
@@ -1,6 +1,6 @@
 <script>
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,16 +20,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { RETRY_COUNT_MAX, RETRY_TIMEOUT } from './constants';
+import { RETRY_COUNT_MAX, RETRY_TIMEOUT } from "./constants";
 import {
   getHistoryEvents,
   getHistoryTimelineEvents,
   getSummary,
-} from './helpers';
-import { NOTIFICATION_TYPE_ERROR } from '~constants';
-import { getErrorMessage } from '~helpers';
-import { NavigationBar, NavigationLink } from '~components';
-import { httpService } from '~services';
+} from "./helpers";
+import { NOTIFICATION_TYPE_ERROR } from "~constants";
+import { getErrorMessage } from "~helpers";
+import { NavigationBar, NavigationLink } from "~components";
+import { httpService } from "~services";
 
 export default {
   data() {
@@ -61,34 +61,34 @@ export default {
     };
   },
   props: [
-    'clusterName',
-    'dateFormat',
-    'displayWorkflowId',
-    'domain',
-    'pendingTaskCount',
-    'runId',
-    'taskListName',
-    'timeFormat',
-    'timezone',
-    'workflow',
-    'workflowHistoryEventHighlightList',
-    'workflowHistoryEventHighlightListEnabled',
-    'workflowId',
+    "clusterName",
+    "dateFormat",
+    "displayWorkflowId",
+    "domain",
+    "pendingTaskCount",
+    "runId",
+    "taskListName",
+    "timeFormat",
+    "timezone",
+    "workflow",
+    "workflowHistoryEventHighlightList",
+    "workflowHistoryEventHighlightListEnabled",
+    "workflowId",
   ],
   created() {
     this.unwatch.push(
-      this.$watch('baseAPIURL', this.onBaseApiUrlChange, { immediate: true })
+      this.$watch("baseAPIURL", this.onBaseApiUrlChange, { immediate: true })
     );
     this.unwatch.push(
-      this.$watch('historyUrl', this.onHistoryUrlChange, { immediate: true })
+      this.$watch("historyUrl", this.onHistoryUrlChange, { immediate: true })
     );
   },
   beforeDestroy() {
     this.clearWatches();
   },
   components: {
-    'navigation-bar': NavigationBar,
-    'navigation-link': NavigationLink,
+    "navigation-bar": NavigationBar,
+    "navigation-link": NavigationLink,
   },
   computed: {
     baseAPIURL() {
@@ -155,7 +155,7 @@ export default {
       this.summary.wfStatus = undefined;
       this.summary.workflow = undefined;
 
-      this.$emit('clearWorkflow');
+      this.$emit("clearWorkflow");
     },
     clearWatches() {
       while (this.unwatch.length) {
@@ -177,7 +177,7 @@ export default {
 
       return httpService
         .get(pagedHistoryUrl)
-        .then(res => {
+        .then((res) => {
           // eslint-disable-next-line no-underscore-dangle
           if (this._isDestroyed) {
             return null;
@@ -213,14 +213,14 @@ export default {
           });
 
           if (shouldHighlightEventId) {
-            this.$emit('highlight-event-id', this.$route.query.eventId);
+            this.$emit("highlight-event-id", this.$route.query.eventId);
           }
 
           this.fetchHistoryPageRetryCount = 0;
 
           return this.events;
         })
-        .catch(error => {
+        .catch((error) => {
           // eslint-disable-next-line no-console
           console.error(error);
 
@@ -229,7 +229,7 @@ export default {
             return;
           }
 
-          this.$emit('onNotification', {
+          this.$emit("onNotification", {
             message: getErrorMessage(error),
             type: NOTIFICATION_TYPE_ERROR,
           });
@@ -251,7 +251,7 @@ export default {
       const { taskListName } = this;
 
       if (!taskListName) {
-        return Promise.reject('task list name is required');
+        return Promise.reject("task list name is required");
       }
 
       httpService
@@ -259,10 +259,10 @@ export default {
           `/api/domains/${this.$route.params.domain}/task-lists/${taskListName}`
         )
         .then(
-          taskList => {
+          (taskList) => {
             this.taskList = { name: taskListName, ...taskList };
           },
-          error => {
+          (error) => {
             this.taskList = { name: taskListName };
             this.error =
               (error.json && error.json.message) ||
@@ -286,15 +286,15 @@ export default {
       return httpService
         .get(baseAPIURL)
         .then(
-          wf => {
-            this.$emit('setWorkflow', wf);
+          (wf) => {
+            this.$emit("setWorkflow", wf);
             this.isWorkflowRunning = !wf.workflowExecutionInfo.closeTime;
             this.baseApiUrlRetryCount = 0;
 
             return wf;
           },
-          error => {
-            this.$emit('onNotification', {
+          (error) => {
+            this.$emit("onNotification", {
               message: getErrorMessage(error),
               type: NOTIFICATION_TYPE_ERROR,
             });
@@ -318,10 +318,10 @@ export default {
       }
     },
     onNotification(event) {
-      this.$emit('onNotification', event);
+      this.$emit("onNotification", event);
     },
     onWorkflowHistoryEventParamToggle(event) {
-      this.$emit('onWorkflowHistoryEventParamToggle', event);
+      this.$emit("onWorkflowHistoryEventParamToggle", event);
     },
   },
 };

--- a/client/containers/workflow/component.vue
+++ b/client/containers/workflow/component.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/connector.js
+++ b/client/containers/workflow/connector.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/constants.js
+++ b/client/containers/workflow/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/get-default-state.js
+++ b/client/containers/workflow/get-default-state.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/get-default-state.spec.js
+++ b/client/containers/workflow/get-default-state.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/getter-types.js
+++ b/client/containers/workflow/getter-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/getters.js
+++ b/client/containers/workflow/getters.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/getters.spec.js
+++ b/client/containers/workflow/getters.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/event-full-transforms.js
+++ b/client/containers/workflow/helpers/event-full-transforms.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/event-full-transforms.spec.js
+++ b/client/containers/workflow/helpers/event-full-transforms.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-details.js
+++ b/client/containers/workflow/helpers/get-event-details.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-details.spec.js
+++ b/client/containers/workflow/helpers/get-event-details.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-full-details.js
+++ b/client/containers/workflow/helpers/get-event-full-details.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-full-details.spec.js
+++ b/client/containers/workflow/helpers/get-event-full-details.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-kvps-highlight.js
+++ b/client/containers/workflow/helpers/get-event-kvps-highlight.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-kvps-highlight.spec.js
+++ b/client/containers/workflow/helpers/get-event-kvps-highlight.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-summary.js
+++ b/client/containers/workflow/helpers/get-event-summary.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-event-summary.spec.js
+++ b/client/containers/workflow/helpers/get-event-summary.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-history-events.js
+++ b/client/containers/workflow/helpers/get-history-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-history-timeline-events.js
+++ b/client/containers/workflow/helpers/get-history-timeline-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-summary-workflow-status.js
+++ b/client/containers/workflow/helpers/get-summary-workflow-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-summary-workflow-status.spec.js
+++ b/client/containers/workflow/helpers/get-summary-workflow-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-summary.js
+++ b/client/containers/workflow/helpers/get-summary.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-time-elapsed-display.js
+++ b/client/containers/workflow/helpers/get-time-elapsed-display.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-time-elapsed-display.spec.js
+++ b/client/containers/workflow/helpers/get-time-elapsed-display.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-time-stamp-display.js
+++ b/client/containers/workflow/helpers/get-time-stamp-display.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/get-time-stamp-display.spec.js
+++ b/client/containers/workflow/helpers/get-time-stamp-display.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/index.js
+++ b/client/containers/workflow/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/map-timeline-events.js
+++ b/client/containers/workflow/helpers/map-timeline-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/parent-workflow-link.js
+++ b/client/containers/workflow/helpers/parent-workflow-link.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/parent-workflow-link.spec.js
+++ b/client/containers/workflow/helpers/parent-workflow-link.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/summarize-events.js
+++ b/client/containers/workflow/helpers/summarize-events.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/helpers/workflow-link.js
+++ b/client/containers/workflow/helpers/workflow-link.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/index.js
+++ b/client/containers/workflow/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/mutation-types.js
+++ b/client/containers/workflow/mutation-types.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/mutations.js
+++ b/client/containers/workflow/mutations.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/containers/workflow/mutations.spec.js
+++ b/client/containers/workflow/mutations.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/directives/snapscroll.js
+++ b/client/directives/snapscroll.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/__mocks__/index.js
+++ b/client/helpers/__mocks__/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/combine.js
+++ b/client/helpers/combine.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/delay.js
+++ b/client/helpers/delay.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-datetime-formatted-string.js
+++ b/client/helpers/get-datetime-formatted-string.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-datetime-formatted-string.spec.js
+++ b/client/helpers/get-datetime-formatted-string.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-end-time-iso-string.js
+++ b/client/helpers/get-end-time-iso-string.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-end-time-iso-string.spec.js
+++ b/client/helpers/get-end-time-iso-string.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment-list.js
+++ b/client/helpers/get-environment-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment-list.spec.js
+++ b/client/helpers/get-environment-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment.js
+++ b/client/helpers/get-environment.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-environment.spec.js
+++ b/client/helpers/get-environment.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-error-message.js
+++ b/client/helpers/get-error-message.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-error-message.spec.js
+++ b/client/helpers/get-error-message.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-expiry-date-time-from-now.js
+++ b/client/helpers/get-expiry-date-time-from-now.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-expiry-date-time-from-now.spec.js
+++ b/client/helpers/get-expiry-date-time-from-now.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-json-string-object.js
+++ b/client/helpers/get-json-string-object.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-key-value-pairs.js
+++ b/client/helpers/get-key-value-pairs.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-latest-news-items.js
+++ b/client/helpers/get-latest-news-items.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-latest-news-items.spec.js
+++ b/client/helpers/get-latest-news-items.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-query-string-from-object.js
+++ b/client/helpers/get-query-string-from-object.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-query-string-from-object.spec.js
+++ b/client/helpers/get-query-string-from-object.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-start-time-iso-string.js
+++ b/client/helpers/get-start-time-iso-string.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-start-time-iso-string.spec.js
+++ b/client/helpers/get-start-time-iso-string.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-string-elipsis.js
+++ b/client/helpers/get-string-elipsis.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/get-string-elipsis.spec.js
+++ b/client/helpers/get-string-elipsis.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/has-expired.js
+++ b/client/helpers/has-expired.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/has-expired.spec.js
+++ b/client/helpers/has-expired.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/index.js
+++ b/client/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/inject-moment-duration-format.js
+++ b/client/helpers/inject-moment-duration-format.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/json-try-parse.js
+++ b/client/helpers/json-try-parse.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/map-domain-description.js
+++ b/client/helpers/map-domain-description.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/map-domain-description.spec.js
+++ b/client/helpers/map-domain-description.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/parse-string-to-boolean.js
+++ b/client/helpers/parse-string-to-boolean.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/parse-string-to-boolean.spec.js
+++ b/client/helpers/parse-string-to-boolean.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/short-name.js
+++ b/client/helpers/short-name.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-add-or-update.js
+++ b/client/helpers/workflow-history-event-highlight-list-add-or-update.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-add-or-update.spec.js
+++ b/client/helpers/workflow-history-event-highlight-list-add-or-update.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-find-index-by-id.js
+++ b/client/helpers/workflow-history-event-highlight-list-find-index-by-id.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-find-index-by-id.spec.js
+++ b/client/helpers/workflow-history-event-highlight-list-find-index-by-id.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-remove.js
+++ b/client/helpers/workflow-history-event-highlight-list-remove.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/helpers/workflow-history-event-highlight-list-remove.spec.js
+++ b/client/helpers/workflow-history-event-highlight-list-remove.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/main.js
+++ b/client/main.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain-search/index.vue
+++ b/client/routes/domain-search/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/domain-metrics.vue
+++ b/client/routes/domain/domain-metrics.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/domain-service.js
+++ b/client/routes/domain/domain-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/domain-settings.vue
+++ b/client/routes/domain/domain-settings.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/index.vue
+++ b/client/routes/domain/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/advanced.vue
+++ b/client/routes/domain/workflow-archival/advanced.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/basic.vue
+++ b/client/routes/domain/workflow-archival/basic.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-disabled-messaging/constants.js
+++ b/client/routes/domain/workflow-archival/components/archival-disabled-messaging/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-disabled-messaging/index.vue
+++ b/client/routes/domain/workflow-archival/components/archival-disabled-messaging/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-table-row.vue
+++ b/client/routes/domain/workflow-archival/components/archival-table-row.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/archival-table.vue
+++ b/client/routes/domain/workflow-archival/components/archival-table.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/components/index.js
+++ b/client/routes/domain/workflow-archival/components/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/constants.js
+++ b/client/routes/domain/workflow-archival/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-domain.js
+++ b/client/routes/domain/workflow-archival/helpers/get-domain.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-domain.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-domain.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-history-archival-status.js
+++ b/client/routes/domain/workflow-archival/helpers/get-history-archival-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-history-archival-status.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-history-archival-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-query-params.js
+++ b/client/routes/domain/workflow-archival/helpers/get-query-params.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-query-params.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-query-params.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-range.js
+++ b/client/routes/domain/workflow-archival/helpers/get-range.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-range.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-range.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status-value.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status-value.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status-value.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status-value.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-status.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.js
+++ b/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/get-visibility-archival-status.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/index.js
+++ b/client/routes/domain/workflow-archival/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-archival-enabled.js
+++ b/client/routes/domain/workflow-archival/helpers/is-archival-enabled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-archival-enabled.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/is-archival-enabled.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.js
+++ b/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/is-history-archival-enabled.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.js
+++ b/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/is-visibility-archival-enabled.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.js
+++ b/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/map-archived-workflow-response.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/replace-domain.js
+++ b/client/routes/domain/workflow-archival/helpers/replace-domain.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/replace-domain.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/replace-domain.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/update-query-from-range.js
+++ b/client/routes/domain/workflow-archival/helpers/update-query-from-range.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/helpers/update-query-from-range.spec.js
+++ b/client/routes/domain/workflow-archival/helpers/update-query-from-range.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/index.vue
+++ b/client/routes/domain/workflow-archival/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/workflow-archival-service.js
+++ b/client/routes/domain/workflow-archival/workflow-archival-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/domain/workflow-archival/workflow-archival-service.spec.js
+++ b/client/routes/domain/workflow-archival/workflow-archival-service.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/help/constants.js
+++ b/client/routes/help/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/help/index.vue
+++ b/client/routes/help/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/index.vue
+++ b/client/routes/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-iframe-src.js
+++ b/client/routes/news/helpers/get-iframe-src.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-iframe-src.spec.js
+++ b/client/routes/news/helpers/get-iframe-src.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-updated-iframe-location.js
+++ b/client/routes/news/helpers/get-updated-iframe-location.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/get-updated-iframe-location.spec.js
+++ b/client/routes/news/helpers/get-updated-iframe-location.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/helpers/index.js
+++ b/client/routes/news/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/news/index.vue
+++ b/client/routes/news/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/components/partition-table.vue
+++ b/client/routes/task-list/components/partition-table.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/index.vue
+++ b/client/routes/task-list/index.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/metrics.vue
+++ b/client/routes/task-list/metrics.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/partition.vue
+++ b/client/routes/task-list/partition.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/task-list/pollers.vue
+++ b/client/routes/task-list/pollers.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/constants.js
+++ b/client/routes/workflow/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/get-query-result.js
+++ b/client/routes/workflow/helpers/get-query-result.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const getQueryResult = queryResponse => {
+const getQueryResult = (queryResponse) => {
   return { payloads: queryResponse };
 };
 

--- a/client/routes/workflow/helpers/get-query-result.js
+++ b/client/routes/workflow/helpers/get-query-result.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/helpers/index.js
+++ b/client/routes/workflow/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/query.vue
+++ b/client/routes/workflow/query.vue
@@ -1,6 +1,6 @@
 <script>
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,13 +20,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { getQueryResult } from './helpers';
-import { SelectInput } from '~components';
-import { httpService } from '~services';
+import { getQueryResult } from "./helpers";
+import { SelectInput } from "~components";
+import { httpService } from "~services";
 
 export default {
   components: {
-    'select-input': SelectInput,
+    "select-input": SelectInput,
   },
   data() {
     return {
@@ -39,7 +39,7 @@ export default {
       running: false,
     };
   },
-  props: ['baseAPIURL', 'clusterName', 'taskListName', 'isWorkerRunning'],
+  props: ["baseAPIURL", "clusterName", "taskListName", "isWorkerRunning"],
   created() {
     if (!this.isWorkerRunning) {
       return;
@@ -61,7 +61,7 @@ export default {
           ({ queryResult }) => {
             this.queryResult = getQueryResult(queryResult);
           },
-          e => {
+          (e) => {
             this.error = (e.json && e.json.message) || e.status || e.message;
           }
         )
@@ -75,14 +75,14 @@ export default {
       return httpService
         .get(`${this.baseAPIURL}/query`)
         .then(
-          queries => {
-            this.queries = queries.filter(query => query !== '__stack_trace');
+          (queries) => {
+            this.queries = queries.filter((query) => query !== "__stack_trace");
 
             if (!this.queryName) {
               [this.queryName] = this.queries;
             }
           },
-          error => {
+          (error) => {
             this.error =
               (error.json && error.json.message) ||
               error.status ||

--- a/client/routes/workflow/query.vue
+++ b/client/routes/workflow/query.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/stack-trace.vue
+++ b/client/routes/workflow/stack-trace.vue
@@ -1,6 +1,6 @@
 <script>
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,9 +20,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-import { getQueryResult } from './helpers';
-import { getDatetimeFormattedString } from '~helpers';
-import { httpService } from '~services';
+import { getQueryResult } from "./helpers";
+import { getDatetimeFormattedString } from "~helpers";
+import { httpService } from "~services";
 
 export default {
   data() {
@@ -33,13 +33,13 @@ export default {
     };
   },
   props: [
-    'baseAPIURL',
-    'clusterName',
-    'dateFormat',
-    'isWorkerRunning',
-    'taskListName',
-    'timeFormat',
-    'timezone',
+    "baseAPIURL",
+    "clusterName",
+    "dateFormat",
+    "isWorkerRunning",
+    "taskListName",
+    "timeFormat",
+    "timezone",
   ],
   computed: {
     formattedStackTraceTimestamp() {
@@ -52,7 +52,7 @@ export default {
             timeFormat,
             timezone,
           })
-        : '';
+        : "";
     },
   },
   created() {
@@ -72,7 +72,7 @@ export default {
           this.stackTrace = getQueryResult(queryResult);
           this.stackTraceTimestamp = new Date();
         })
-        .catch(e => {
+        .catch((e) => {
           // eslint-disable-next-line no-console
           console.error(e);
           this.stackTrace = {

--- a/client/routes/workflow/stack-trace.vue
+++ b/client/routes/workflow/stack-trace.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/routes/workflow/summary.vue
+++ b/client/routes/workflow/summary.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/services/feature-flag-service.js
+++ b/client/services/feature-flag-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/services/http-service.js
+++ b/client/services/http-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/services/index.js
+++ b/client/services/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2024 Uber Technologies Inc.
+// Copyright (c) 2020-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/domain-search.test.js
+++ b/client/test/domain-search.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/domain-settings.test.js
+++ b/client/test/domain-settings.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/domain.test.js
+++ b/client/test/domain.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/fixtures.js
+++ b/client/test/fixtures.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/help.test.js
+++ b/client/test/help.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/helpers/get-fixture.js
+++ b/client/test/helpers/get-fixture.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/helpers/index.js
+++ b/client/test/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/index.js
+++ b/client/test/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/LICENSE_FILE_DOES_NOT_EXIST
+++ b/client/test/lint/license/LICENSE_FILE_DOES_NOT_EXIST
@@ -1,5 +1,5 @@
 Modifications Copyright (c) 2024 Uber Technologies Inc.
-Copyright (c) 2021-2024 Temporal Technologies, Inc.
+Copyright (c) 2021-2025 Temporal Technologies, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/client/test/lint/license/LICENSE_FILE_MODIFIED
+++ b/client/test/lint/license/LICENSE_FILE_MODIFIED
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2024 Uber Technologies Inc.
+Copyright (c) 2017-2025 Uber Technologies Inc.
 Portions of the Software are attributed to Copyright (c) 2021-2022 Temporal Technologies Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/LICENSE_FILE_NEW
+++ b/client/test/lint/license/LICENSE_FILE_NEW
@@ -1,4 +1,4 @@
-Copyright (c) 2021-2024 Uber Technologies Inc.
+Copyright (c) 2021-2025 Uber Technologies Inc.
 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/LICENSE_FILE_UNMODIFIED
+++ b/client/test/lint/license/LICENSE_FILE_UNMODIFIED
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2024 Uber Technologies Inc.
+Copyright (c) 2017-2025 Uber Technologies Inc.
 
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/test-license-file-does-not-exist.vue
+++ b/client/test/lint/license/test-license-file-does-not-exist.vue
@@ -1,5 +1,5 @@
 <script>
-// Modifications Copyright (c) 2021-2024 Uber Technologies Inc.
+// Modifications Copyright (c) 2021-2025 Uber Technologies Inc.
 // Copyright (c) 2021-2024 Temporal Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/test-license-file-does-not-exist.vue
+++ b/client/test/lint/license/test-license-file-does-not-exist.vue
@@ -1,6 +1,6 @@
 <script>
 // Modifications Copyright (c) 2021-2025 Uber Technologies Inc.
-// Copyright (c) 2021-2024 Temporal Technologies, Inc.
+// Copyright (c) 2021-2025 Temporal Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,6 @@
 // THE SOFTWARE.
 
 export default {
-  name: 'test-license-file-does-not-exist',
+  name: "test-license-file-does-not-exist",
 };
 </script>

--- a/client/test/lint/license/test-license-file-modified.vue
+++ b/client/test/lint/license/test-license-file-modified.vue
@@ -1,6 +1,6 @@
 <script>
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2021-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2021-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,6 @@
 // THE SOFTWARE.
 
 export default {
-  name: 'test-license-file-modified',
+  name: "test-license-file-modified",
 };
 </script>

--- a/client/test/lint/license/test-license-file-modified.vue
+++ b/client/test/lint/license/test-license-file-modified.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2021-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/test-license-file-new.vue
+++ b/client/test/lint/license/test-license-file-new.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/lint/license/test-license-file-unmodified.vue
+++ b/client/test/lint/license/test-license-file-unmodified.vue
@@ -1,5 +1,5 @@
 <script>
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/scenario.js
+++ b/client/test/scenario.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/task-list.test.js
+++ b/client/test/task-list.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/workflow-list.test.js
+++ b/client/test/workflow-list.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/client/test/workflow.test.js
+++ b/client/test/workflow.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Uber Technologies Inc.
+// Copyright (c) 2024-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/helpers/combine.js
+++ b/server/helpers/combine.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/helpers/index.js
+++ b/server/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/helpers/parse-json-lines.js
+++ b/server/helpers/parse-json-lines.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Uber Technologies Inc.
+// Copyright (c) 2024-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/helpers/parse-json-lines.spec.js
+++ b/server/helpers/parse-json-lines.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Uber Technologies Inc.
+// Copyright (c) 2024-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/configuration.js
+++ b/server/middleware/grpc-client/configuration.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-request/format-long-to-timestamp.js
+++ b/server/middleware/grpc-client/format-request/format-long-to-timestamp.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-request/format-long-to-timestamp.spec.js
+++ b/server/middleware/grpc-client/format-request/format-long-to-timestamp.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-request/format-request-default.js
+++ b/server/middleware/grpc-client/format-request/format-request-default.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-request/format-request-describe-task-list.js
+++ b/server/middleware/grpc-client/format-request/format-request-describe-task-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-request/format-request-get-history.js
+++ b/server/middleware/grpc-client/format-request/format-request-get-history.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-request/format-request-workflow-list.js
+++ b/server/middleware/grpc-client/format-request/format-request-workflow-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-request/index.js
+++ b/server/middleware/grpc-client/format-request/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-duration-to-seconds.js
+++ b/server/middleware/grpc-client/format-response/format-duration-to-seconds.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-enum.js
+++ b/server/middleware/grpc-client/format-response/format-enum.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-enum.spec.js
+++ b/server/middleware/grpc-client/format-response/format-enum.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-failure-details.js
+++ b/server/middleware/grpc-client/format-response/format-failure-details.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-cancel-requested-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-cancel-requested-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-canceled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-canceled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-completed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-completed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-scheduled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-scheduled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-started-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-started-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-timed-out-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-activity-task-timed-out-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-cancel-timer-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-cancel-timer-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-canceled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-canceled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-completed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-completed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-started-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-started-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-terminated-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-terminated-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-timed-out-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-child-workflow-execution-timed-out-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-completed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-completed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-scheduled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-scheduled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-started-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-started-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-timed-out-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-decision-task-timed-out-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-external-workflow-execution-cancel-requested-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-external-workflow-execution-cancel-requested-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-external-workflow-execution-signaled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-external-workflow-execution-signaled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-marker-recorded-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-marker-recorded-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-prev-auto-reset-points.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-prev-auto-reset-points.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-request-cancel-activity-task-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-request-cancel-activity-task-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-request-cancel-external-workflow-execution-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-request-cancel-external-workflow-execution-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-request-cancel-external-workflow-execution-initiated-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-request-cancel-external-workflow-execution-initiated-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-retry-policy.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-retry-policy.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-signal-external-workflow-execution-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-signal-external-workflow-execution-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-signal-external-workflow-execution-initiated-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-signal-external-workflow-execution-initiated-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-start-child-workflow-execution-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-start-child-workflow-execution-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-start-child-workflow-execution-initiated-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-start-child-workflow-execution-initiated-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-timer-canceled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-timer-canceled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-timer-fired-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-timer-fired-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-timer-started-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-timer-started-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-upsert-workflow-search-attributes-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-upsert-workflow-search-attributes-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-cancel-requested-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-cancel-requested-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-canceled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-canceled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-completed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-completed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-continued-as-new-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-continued-as-new-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-failed-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-failed-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-signaled-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-signaled-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-started-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-started-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-terminated-event-attributes.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/format-workflow-execution-terminated-event-attributes.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-details/index.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-details/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-history-event-type.js
+++ b/server/middleware/grpc-client/format-response/format-history-event-type.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-input-payload.js
+++ b/server/middleware/grpc-client/format-response/format-input-payload.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Uber Technologies Inc.
+// Copyright (c) 2024-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-input-payload.spec.js
+++ b/server/middleware/grpc-client/format-response/format-input-payload.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Uber Technologies Inc.
+// Copyright (c) 2024-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-payload-map.js
+++ b/server/middleware/grpc-client/format-response/format-payload-map.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-payload.js
+++ b/server/middleware/grpc-client/format-response/format-payload.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-default.js
+++ b/server/middleware/grpc-client/format-response/format-response-default.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-describe-task-list.js
+++ b/server/middleware/grpc-client/format-response/format-response-describe-task-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-describe-workflow.js
+++ b/server/middleware/grpc-client/format-response/format-response-describe-workflow.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-domain.js
+++ b/server/middleware/grpc-client/format-response/format-response-domain.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-export-history.js
+++ b/server/middleware/grpc-client/format-response/format-response-export-history.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-get-history.js
+++ b/server/middleware/grpc-client/format-response/format-response-get-history.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-list-domains.js
+++ b/server/middleware/grpc-client/format-response/format-response-list-domains.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-query-workflow.js
+++ b/server/middleware/grpc-client/format-response/format-response-query-workflow.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-signal-workflow-execution.js
+++ b/server/middleware/grpc-client/format-response/format-response-signal-workflow-execution.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-terminate-workflow-execution.js
+++ b/server/middleware/grpc-client/format-response/format-response-terminate-workflow-execution.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-response-workflow-list.js
+++ b/server/middleware/grpc-client/format-response/format-response-workflow-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-timestamp-to-datetime.js
+++ b/server/middleware/grpc-client/format-response/format-timestamp-to-datetime.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/format-timestamp-to-long.js
+++ b/server/middleware/grpc-client/format-response/format-timestamp-to-long.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/format-response/index.js
+++ b/server/middleware/grpc-client/format-response/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/grpc-service.js
+++ b/server/middleware/grpc-client/grpc-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/index.js
+++ b/server/middleware/grpc-client/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/transform/cli-transform.js
+++ b/server/middleware/grpc-client/transform/cli-transform.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/transform/cli-transform.spec.js
+++ b/server/middleware/grpc-client/transform/cli-transform.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/transform/index.js
+++ b/server/middleware/grpc-client/transform/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/transform/transform-default.js
+++ b/server/middleware/grpc-client/transform/transform-default.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/transform/with-domain.js
+++ b/server/middleware/grpc-client/transform/with-domain.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/transform/with-pagination.js
+++ b/server/middleware/grpc-client/transform/with-pagination.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/grpc-client/transform/with-workflow-execution.js
+++ b/server/middleware/grpc-client/transform/with-workflow-execution.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/oidc/index.js
+++ b/server/middleware/oidc/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Uber Technologies Inc.
+// Copyright (c) 2024-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/cli-transform.js
+++ b/server/middleware/tchannel-client/helpers/cli-transform.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/format-body.js
+++ b/server/middleware/tchannel-client/helpers/format-body.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/format-method.js
+++ b/server/middleware/tchannel-client/helpers/format-method.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/format-request-name.js
+++ b/server/middleware/tchannel-client/helpers/format-request-name.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/index.js
+++ b/server/middleware/tchannel-client/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/lookup-async.js
+++ b/server/middleware/tchannel-client/helpers/lookup-async.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/make-channels.js
+++ b/server/middleware/tchannel-client/helpers/make-channels.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/make-request.js
+++ b/server/middleware/tchannel-client/helpers/make-request.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/ui-transform.js
+++ b/server/middleware/tchannel-client/helpers/ui-transform.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/with-domain-paging.js
+++ b/server/middleware/tchannel-client/helpers/with-domain-paging.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/with-next-page-token-body-transform.js
+++ b/server/middleware/tchannel-client/helpers/with-next-page-token-body-transform.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/with-verbose-workflow-execution.js
+++ b/server/middleware/tchannel-client/helpers/with-verbose-workflow-execution.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/helpers/with-workflow-execution.js
+++ b/server/middleware/tchannel-client/helpers/with-workflow-execution.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/middleware/tchannel-client/index.js
+++ b/server/middleware/tchannel-client/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/constants.js
+++ b/server/router/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/build-query-string.js
+++ b/server/router/helpers/build-query-string.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/build-query-string.spec.js
+++ b/server/router/helpers/build-query-string.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/delay.js
+++ b/server/router/helpers/delay.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/index.js
+++ b/server/router/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/inject-domain-into-workflow-list.js
+++ b/server/router/helpers/inject-domain-into-workflow-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/is-advanced-visibility-enabled.js
+++ b/server/router/helpers/is-advanced-visibility-enabled.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/is-advanced-visibility-enabled.spec.js
+++ b/server/router/helpers/is-advanced-visibility-enabled.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/list-workflows.js
+++ b/server/router/helpers/list-workflows.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/map-history-response.js
+++ b/server/router/helpers/map-history-response.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/moment-to-long.js
+++ b/server/router/helpers/moment-to-long.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/helpers/replacer.js
+++ b/server/router/helpers/replacer.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/index.js
+++ b/server/router/index.js
@@ -1,5 +1,5 @@
 // Copyright (c) 2017-2025 Uber Technologies Inc.
-// Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020-2025 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-const Router = require('koa-router');
+const Router = require("koa-router");
 
 const {
   clearCacheHandler,
@@ -41,11 +41,11 @@ const {
   workflowQueryTypeHandler,
   workflowSignalHandler,
   workflowTerminateHandler,
-} = require('./routes');
-const { ONE_HOUR_IN_MILLISECONDS } = require('./constants');
-const { listWorkflows } = require('./helpers');
-const { CacheManager } = require('./managers');
-const { ClusterService, DomainService } = require('./services');
+} = require("./routes");
+const { ONE_HOUR_IN_MILLISECONDS } = require("./constants");
+const { listWorkflows } = require("./helpers");
+const { CacheManager } = require("./managers");
+const { ClusterService, DomainService } = require("./services");
 
 const router = new Router();
 
@@ -55,15 +55,15 @@ const clusterService = new ClusterService(clusterCacheManager);
 const domainCacheManager = new CacheManager(ONE_HOUR_IN_MILLISECONDS);
 const domainService = new DomainService(domainCacheManager);
 
-router.get('/api/cluster', clusterHandler(clusterService));
+router.get("/api/cluster", clusterHandler(clusterService));
 
-router.delete('/api/cluster/cache', clearCacheHandler(clusterCacheManager));
+router.delete("/api/cluster/cache", clearCacheHandler(clusterCacheManager));
 
-router.get('/api/domains', domainListHandler(domainService));
+router.get("/api/domains", domainListHandler(domainService));
 
-router.delete('/api/domains/cache', clearCacheHandler(domainCacheManager));
+router.delete("/api/domains/cache", clearCacheHandler(domainCacheManager));
 
-router.get('/api/domains/:domain', domainHandler);
+router.get("/api/domains/:domain", domainHandler);
 
 /**
  * Override this route to perform authorization check
@@ -80,79 +80,79 @@ router.get('/api/domains/:domain', domainHandler);
  *  };
  * })
  */
-router.get('/api/domains/:domain/authorization', domainAuthorizationHandler);
+router.get("/api/domains/:domain/authorization", domainAuthorizationHandler);
 
 router.get(
-  '/api/domains/:domain/workflows/all',
-  listWorkflows.bind(null, { clusterService, state: 'all' })
+  "/api/domains/:domain/workflows/all",
+  listWorkflows.bind(null, { clusterService, state: "all" })
 );
 
 router.get(
-  '/api/domains/:domain/workflows/open',
-  listWorkflows.bind(null, { clusterService, state: 'open' })
+  "/api/domains/:domain/workflows/open",
+  listWorkflows.bind(null, { clusterService, state: "open" })
 );
 
 router.get(
-  '/api/domains/:domain/workflows/closed',
-  listWorkflows.bind(null, { clusterService, state: 'closed' })
+  "/api/domains/:domain/workflows/closed",
+  listWorkflows.bind(null, { clusterService, state: "closed" })
 );
 
 router.get(
-  '/api/domains/:domain/workflows/archived',
+  "/api/domains/:domain/workflows/archived",
   workflowArchivedListHandler
 );
 
-router.get('/api/domains/:domain/workflows/list', workflowListHandler);
+router.get("/api/domains/:domain/workflows/list", workflowListHandler);
 
 router.get(
-  '/api/domains/:domain/workflows/:workflowId/:runId/history',
+  "/api/domains/:domain/workflows/:workflowId/:runId/history",
   workflowHistoryHandler
 );
 
 router.get(
-  '/api/domains/:domain/workflows/:workflowId/:runId/export',
+  "/api/domains/:domain/workflows/:workflowId/:runId/export",
   workflowExportHandler
 );
 
 router.get(
-  '/api/domains/:domain/workflows/:workflowId/:runId/query',
+  "/api/domains/:domain/workflows/:workflowId/:runId/query",
   workflowQueryHandler
 );
 
 router.post(
-  '/api/domains/:domain/workflows/:workflowId/:runId/query/:queryType',
+  "/api/domains/:domain/workflows/:workflowId/:runId/query/:queryType",
   workflowQueryTypeHandler
 );
 
 router.post(
-  '/api/domains/:domain/workflows/:workflowId/:runId/terminate',
+  "/api/domains/:domain/workflows/:workflowId/:runId/terminate",
   workflowTerminateHandler
 );
 
 router.post(
-  '/api/domains/:domain/workflows/:workflowId/:runId/signal/:signal',
+  "/api/domains/:domain/workflows/:workflowId/:runId/signal/:signal",
   workflowSignalHandler
 );
 
 router.get(
-  '/api/domains/:domain/workflows/:workflowId/:runId',
+  "/api/domains/:domain/workflows/:workflowId/:runId",
   workflowHandler
 );
 
 router.get(
-  '/api/domains/:domain/task-lists/:taskList/pollers',
+  "/api/domains/:domain/task-lists/:taskList/pollers",
   tasklistPollerListHandler
 );
 
 router.get(
-  '/api/domains/:domain/task-lists/:taskList/partitions',
+  "/api/domains/:domain/task-lists/:taskList/partitions",
   tasklistPartitionListHandler
 );
 
-router.get('/api/feature-flags/:key', featureFlagHandler);
+router.get("/api/feature-flags/:key", featureFlagHandler);
 
-router.get('/api/domains/:domain/task-lists/:taskListName', tasklistHandler);
+router.get("/api/domains/:domain/task-lists/:taskListName", tasklistHandler);
 
-router.get('/health', healthHandler);
+router.get("/health", healthHandler);
 
 module.exports = router;

--- a/server/router/index.js
+++ b/server/router/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 // Portions of the Software are attributed to Copyright (c) 2020-2024 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/managers/cache-manager.js
+++ b/server/router/managers/cache-manager.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/managers/cache-manager.spec.js
+++ b/server/router/managers/cache-manager.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/managers/index.js
+++ b/server/router/managers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/clear-cache-handler.js
+++ b/server/router/routes/clear-cache-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/cluster-handler.js
+++ b/server/router/routes/cluster-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/domain-authorization-handler.js
+++ b/server/router/routes/domain-authorization-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/domain-handler.js
+++ b/server/router/routes/domain-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/domain-list-handler.js
+++ b/server/router/routes/domain-list-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/feature-flag-handler.js
+++ b/server/router/routes/feature-flag-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/health-handler.js
+++ b/server/router/routes/health-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/index.js
+++ b/server/router/routes/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/tasklist-handler.js
+++ b/server/router/routes/tasklist-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/tasklist-partition-list-handler.js
+++ b/server/router/routes/tasklist-partition-list-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/tasklist-poller-list-handler.js
+++ b/server/router/routes/tasklist-poller-list-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-archived-list-handler.js
+++ b/server/router/routes/workflow-archived-list-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-export-handler.js
+++ b/server/router/routes/workflow-export-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-handler.js
+++ b/server/router/routes/workflow-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-history-handler.js
+++ b/server/router/routes/workflow-history-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-list-handler.js
+++ b/server/router/routes/workflow-list-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-query-handler.js
+++ b/server/router/routes/workflow-query-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-query-type-handler.js
+++ b/server/router/routes/workflow-query-type-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-signal-handler.js
+++ b/server/router/routes/workflow-signal-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/routes/workflow-terminate-handler.js
+++ b/server/router/routes/workflow-terminate-handler.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/cluster-service.js
+++ b/server/router/services/cluster-service.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/cluster-service.spec.js
+++ b/server/router/services/cluster-service.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/constants.js
+++ b/server/router/services/domain-service/constants.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/fetch-domain-list-next-page.js
+++ b/server/router/services/domain-service/helpers/fetch-domain-list-next-page.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/fetch-domain-list-next-page.spec.js
+++ b/server/router/services/domain-service/helpers/fetch-domain-list-next-page.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/fetch-domain-list.js
+++ b/server/router/services/domain-service/helpers/fetch-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/filter-domain-list.js
+++ b/server/router/services/domain-service/helpers/filter-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/filter-domain-list.spec.js
+++ b/server/router/services/domain-service/helpers/filter-domain-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/get-domain-list.js
+++ b/server/router/services/domain-service/helpers/get-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/get-matching-domains.js
+++ b/server/router/services/domain-service/helpers/get-matching-domains.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/get-matching-domains.spec.js
+++ b/server/router/services/domain-service/helpers/get-matching-domains.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/index.js
+++ b/server/router/services/domain-service/helpers/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/sort-domain-list.js
+++ b/server/router/services/domain-service/helpers/sort-domain-list.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/helpers/sort-domain-list.spec.js
+++ b/server/router/services/domain-service/helpers/sort-domain-list.spec.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/domain-service/index.js
+++ b/server/router/services/domain-service/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/router/services/index.js
+++ b/server/router/services/index.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2021-2024 Uber Technologies Inc.
+// Copyright (c) 2021-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/cadence-frontend-simulator.js
+++ b/server/test/cadence-frontend-simulator.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/domain.test.js
+++ b/server/test/domain.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/history.test.js
+++ b/server/test/history.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/mock-grpc.js
+++ b/server/test/mock-grpc.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/mock-tchannel.js
+++ b/server/test/mock-tchannel.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2022-2024 Uber Technologies Inc.
+// Copyright (c) 2022-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/query-workflow.test.js
+++ b/server/test/query-workflow.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/task-list.test.js
+++ b/server/test/task-list.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/workflow-execution.test.js
+++ b/server/test/workflow-execution.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/server/test/workflows.test.js
+++ b/server/test/workflows.test.js
@@ -1,4 +1,4 @@
-// Copyright (c) 2017-2024 Uber Technologies Inc.
+// Copyright (c) 2017-2025 Uber Technologies Inc.
 //
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
## Summary
Update license headers to 2025 manually, since the lint fixer does not work. For v4, we intend to not have license headers altogether, since they are unnecessary
