### PR TITLE
Switch basic and advanced workflows base on a flag

### DIFF
--- a/src/app/api/clusters/[cluster]/route.ts
+++ b/src/app/api/clusters/[cluster]/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { describeCluster } from '@/route-handlers/describe-cluster/describe-cluster';
+import type { RouteParams } from '@/route-handlers/describe-domain/describe-domain.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function GET(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    describeCluster,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/route-handlers/describe-cluster/__tests__/describe-cluster.node.ts
+++ b/src/route-handlers/describe-cluster/__tests__/describe-cluster.node.ts
@@ -1,24 +1,23 @@
 import { NextRequest } from 'next/server';
 
+import type { DescribeClusterResponse as OriginalDescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
 import { GRPCError } from '@/utils/grpc/grpc-error';
 import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
 
 import { describeCluster } from '../describe-cluster';
 import {
-  DescribeClusterResponse,
+  type DescribeClusterResponse,
   type Context,
 } from '../describe-cluster.types';
-import type { DescribeClusterResponse as OriginalDescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
 
 describe('describeCluster', () => {
-
   it('calls describeCluster and returns valid response without membershipInfo', async () => {
     const { res, mockDescribeCluster, mockSuccessResponse } = await setup({});
 
     expect(mockDescribeCluster).toHaveBeenCalledWith({
-      name: 'mock-cluster'
+      name: 'mock-cluster',
     });
-    const { membershipInfo, ...rest } = mockSuccessResponse
+    const { membershipInfo, ...rest } = mockSuccessResponse;
     const routHandleRes: DescribeClusterResponse = rest;
     const responseJson = await res.json();
     expect(responseJson).toEqual(routHandleRes);
@@ -44,17 +43,17 @@ describe('describeCluster', () => {
     const originalEnvObj = globalThis.process.env;
     globalThis.process.env = {
       ...process.env,
-      CADENCE_ADVANCED_VISIBILITY: "true"
-    }
+      CADENCE_ADVANCED_VISIBILITY: 'true',
+    };
 
     const { res, mockDescribeCluster } = await setup({});
 
     expect(mockDescribeCluster).not.toHaveBeenCalled();
 
     const responseJson = await res.json();
-    expect(responseJson.persistenceInfo.visibilityStore.features[0].enabled).toBe(
-      true
-    )
+    expect(
+      responseJson.persistenceInfo.visibilityStore.features[0].enabled
+    ).toBe(true);
     globalThis.process.env = originalEnvObj;
   });
 
@@ -62,31 +61,27 @@ describe('describeCluster', () => {
     const originalEnvObj = globalThis.process.env;
     globalThis.process.env = {
       ...process.env,
-      CADENCE_ADVANCED_VISIBILITY: "not true"
-    }
+      CADENCE_ADVANCED_VISIBILITY: 'not true',
+    };
 
     const { res, mockDescribeCluster } = await setup({});
 
     expect(mockDescribeCluster).not.toHaveBeenCalled();
 
     const responseJson = await res.json();
-    expect(responseJson.persistenceInfo.visibilityStore.features[0].enabled).toBe(
-      false
-    )
+    expect(
+      responseJson.persistenceInfo.visibilityStore.features[0].enabled
+    ).toBe(false);
     globalThis.process.env = originalEnvObj;
   });
 });
 
-async function setup({
-  error,
-}: {
-  error?: true;
-}) {
+async function setup({ error }: { error?: true }) {
   const mockSuccessResponse: OriginalDescribeClusterResponse = {
     persistenceInfo: {},
     membershipInfo: null,
     supportedClientVersions: null,
-  }
+  };
 
   const mockDescribeCluster = jest
     .spyOn(mockGrpcClusterMethods, 'describeCluster')

--- a/src/route-handlers/describe-cluster/__tests__/describe-cluster.node.ts
+++ b/src/route-handlers/describe-cluster/__tests__/describe-cluster.node.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from 'next/server';
+
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import { describeCluster } from '../describe-cluster';
+import {
+  DescribeClusterResponse,
+  type Context,
+} from '../describe-cluster.types';
+import type { DescribeClusterResponse as OriginalDescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
+
+describe('describeCluster', () => {
+
+  it('calls describeCluster and returns valid response without membershipInfo', async () => {
+    const { res, mockDescribeCluster, mockSuccessResponse } = await setup({});
+
+    expect(mockDescribeCluster).toHaveBeenCalledWith({
+      name: 'mock-cluster'
+    });
+    const { membershipInfo, ...rest } = mockSuccessResponse
+    const routHandleRes: DescribeClusterResponse = rest;
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(routHandleRes);
+  });
+
+  it('returns an error when describeCluster errors out', async () => {
+    const { res, mockDescribeCluster } = await setup({
+      error: true,
+    });
+
+    expect(mockDescribeCluster).toHaveBeenCalled();
+
+    expect(res.status).toEqual(500);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Failed to fetch cluster info',
+      })
+    );
+  });
+
+  it('returns static response with advancedVisibilityEnabled true when CADENCE_ADVANCED_VISIBILITY env value is true', async () => {
+    const originalEnvObj = globalThis.process.env;
+    globalThis.process.env = {
+      ...process.env,
+      CADENCE_ADVANCED_VISIBILITY: "true"
+    }
+
+    const { res, mockDescribeCluster } = await setup({});
+
+    expect(mockDescribeCluster).not.toHaveBeenCalled();
+
+    const responseJson = await res.json();
+    expect(responseJson.persistenceInfo.visibilityStore.features[0].enabled).toBe(
+      true
+    )
+    globalThis.process.env = originalEnvObj;
+  });
+
+  it('returns static response with advancedVisibilityEnabled false when CADENCE_ADVANCED_VISIBILITY env value is not true', async () => {
+    const originalEnvObj = globalThis.process.env;
+    globalThis.process.env = {
+      ...process.env,
+      CADENCE_ADVANCED_VISIBILITY: "not true"
+    }
+
+    const { res, mockDescribeCluster } = await setup({});
+
+    expect(mockDescribeCluster).not.toHaveBeenCalled();
+
+    const responseJson = await res.json();
+    expect(responseJson.persistenceInfo.visibilityStore.features[0].enabled).toBe(
+      false
+    )
+    globalThis.process.env = originalEnvObj;
+  });
+});
+
+async function setup({
+  error,
+}: {
+  error?: true;
+}) {
+  const mockSuccessResponse: OriginalDescribeClusterResponse = {
+    persistenceInfo: {},
+    membershipInfo: null,
+    supportedClientVersions: null,
+  }
+
+  const mockDescribeCluster = jest
+    .spyOn(mockGrpcClusterMethods, 'describeCluster')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw new GRPCError('Failed to fetch cluster info');
+      }
+      return mockSuccessResponse;
+    });
+
+  const res = await describeCluster(
+    new NextRequest('http://localhost/api/clusters/:cluster', {
+      method: 'Get',
+    }),
+    {
+      params: {
+        cluster: 'mock-cluster',
+      },
+    },
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockDescribeCluster, mockSuccessResponse };
+}

--- a/src/route-handlers/describe-cluster/describe-cluster.ts
+++ b/src/route-handlers/describe-cluster/describe-cluster.ts
@@ -1,7 +1,6 @@
 import omit from 'lodash/omit';
 import { type NextRequest, NextResponse } from 'next/server';
 
-import { type DescribeClusterResponse as OriginalDescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
 import decodeUrlParams from '@/utils/decode-url-params';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
@@ -20,7 +19,7 @@ export async function describeCluster(
 ) {
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
-  // temporarily solution to disable invoking describeCluster
+  // temporary solution to disable invoking describeCluster
   if (process.env.CADENCE_ADVANCED_VISIBILITY) {
     const res = {
       persistenceInfo: {
@@ -39,7 +38,7 @@ export async function describeCluster(
   }
 
   try {
-    const res: OriginalDescribeClusterResponse =
+    const res =
       await ctx.grpcClusterMethods.describeCluster({
         name: decodedParams.cluster,
       });

--- a/src/route-handlers/describe-cluster/describe-cluster.ts
+++ b/src/route-handlers/describe-cluster/describe-cluster.ts
@@ -1,0 +1,65 @@
+import omit from 'lodash/omit';
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { type DescribeClusterResponse as OriginalDescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
+import decodeUrlParams from '@/utils/decode-url-params';
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import {
+  type DescribeClusterResponse,
+  type Context,
+  type RequestParams,
+  type RouteParams,
+} from './describe-cluster.types';
+
+export async function describeCluster(
+  _: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
+
+  // temporarily solution to disable invoking describeCluster
+  if (process.env.CADENCE_ADVANCED_VISIBILITY) {
+    const res = {
+      persistenceInfo: {
+        visibilityStore: {
+          features: [
+            {
+              key: 'advancedVisibilityEnabled',
+              enabled: process.env.CADENCE_ADVANCED_VISIBILITY === 'true',
+            },
+          ],
+        },
+      },
+      supportedClientVersions: null,
+    };
+    return NextResponse.json(res);
+  }
+
+  try {
+    const res: OriginalDescribeClusterResponse =
+      await ctx.grpcClusterMethods.describeCluster({
+        name: decodedParams.cluster,
+      });
+
+    const sanitizedRes: DescribeClusterResponse = omit(res, 'membershipInfo'); // No need to return host information to client
+
+    return NextResponse.json(sanitizedRes);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: decodedParams, cause: e },
+      'Error fetching cluster info'
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError ? e.message : 'Error fetching cluster info',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/describe-cluster/describe-cluster.ts
+++ b/src/route-handlers/describe-cluster/describe-cluster.ts
@@ -38,10 +38,9 @@ export async function describeCluster(
   }
 
   try {
-    const res =
-      await ctx.grpcClusterMethods.describeCluster({
-        name: decodedParams.cluster,
-      });
+    const res = await ctx.grpcClusterMethods.describeCluster({
+      name: decodedParams.cluster,
+    });
 
     const sanitizedRes: DescribeClusterResponse = omit(res, 'membershipInfo'); // No need to return host information to client
 

--- a/src/route-handlers/describe-cluster/describe-cluster.types.ts
+++ b/src/route-handlers/describe-cluster/describe-cluster.types.ts
@@ -1,0 +1,16 @@
+import { type DescribeClusterResponse as OriginalDescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+export type RouteParams = {
+  cluster: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type Context = DefaultMiddlewaresContext;
+export type DescribeClusterResponse = Omit<
+  OriginalDescribeClusterResponse,
+  'membershipInfo'
+>;

--- a/src/views/domain-workflows/__tests__/domain-workflows.test.tsx
+++ b/src/views/domain-workflows/__tests__/domain-workflows.test.tsx
@@ -1,18 +1,26 @@
-import DomainWorkflows from '../domain-workflows';
-import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-content/domain-page-content.types';
 import { Suspense } from 'react';
+
 import { HttpResponse } from 'msw';
-import { render, screen } from '@/test-utils/rtl';
-import { DescribeClusterResponse } from '@/route-handlers/describe-cluster/describe-cluster.types';
 import { act } from 'react-dom/test-utils';
 
+import { render, screen } from '@/test-utils/rtl';
 
-jest.mock('@/views/domain-workflows-basic/domain-workflows-basic', () => () => <div>Basic Workflows</div>);
-jest.mock('../domain-workflows-header/domain-workflows-header', () => () => <div>Workflows Header</div>);
-jest.mock('../domain-workflows-table/domain-workflows-table', () => () => <div>Workflows Table</div>);
+import { type DescribeClusterResponse } from '@/route-handlers/describe-cluster/describe-cluster.types';
+import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-content/domain-page-content.types';
+
+import DomainWorkflows from '../domain-workflows';
+
+jest.mock('@/views/domain-workflows-basic/domain-workflows-basic', () =>
+  jest.fn(() => <div>Basic Workflows</div>)
+);
+jest.mock('../domain-workflows-header/domain-workflows-header', () =>
+  jest.fn(() => <div>Workflows Header</div>)
+);
+jest.mock('../domain-workflows-table/domain-workflows-table', () =>
+  jest.fn(() => <div>Workflows Table</div>)
+);
 
 describe('DomainWorkflows', () => {
-
   it('should render basic workflows when advanced visibility is disabled', async () => {
     await setup({ isAdvancedVisibility: false });
 
@@ -25,7 +33,6 @@ describe('DomainWorkflows', () => {
     expect(await screen.findByText('Workflows Header')).toBeInTheDocument();
     expect(await screen.findByText('Workflows Table')).toBeInTheDocument();
   });
-
 
   it('should render workflows header and table when advanced visibility is enabled', async () => {
     let renderErrorMessage;
@@ -42,7 +49,6 @@ describe('DomainWorkflows', () => {
     expect(renderErrorMessage).toEqual('Failed to fetch cluster info');
   });
 });
-
 
 async function setup({
   isAdvancedVisibility = false,
@@ -68,29 +74,32 @@ async function setup({
           mockOnce: false,
           ...(error
             ? {
-              httpResolver: () => {
-                return HttpResponse.json(
-                  { message: 'Failed to fetch cluster info' },
-                  { status: 500 }
-                );
-              },
-            }
-            : {
-              jsonResponse: {
-                persistenceInfo: {
-                  visibilityStore: {
-                    features: [{ key: 'advancedVisibilityEnabled', enabled: isAdvancedVisibility }],
-                    backend: '',
-                    settings: []
-                  },
+                httpResolver: () => {
+                  return HttpResponse.json(
+                    { message: 'Failed to fetch cluster info' },
+                    { status: 500 }
+                  );
                 },
-                supportedClientVersions: null
-              } satisfies DescribeClusterResponse,
-            }),
+              }
+            : {
+                jsonResponse: {
+                  persistenceInfo: {
+                    visibilityStore: {
+                      features: [
+                        {
+                          key: 'advancedVisibilityEnabled',
+                          enabled: isAdvancedVisibility,
+                        },
+                      ],
+                      backend: '',
+                      settings: [],
+                    },
+                  },
+                  supportedClientVersions: null,
+                } satisfies DescribeClusterResponse,
+              }),
         },
       ],
     }
   );
-
 }
-

--- a/src/views/domain-workflows/__tests__/domain-workflows.test.tsx
+++ b/src/views/domain-workflows/__tests__/domain-workflows.test.tsx
@@ -1,0 +1,96 @@
+import DomainWorkflows from '../domain-workflows';
+import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-content/domain-page-content.types';
+import { Suspense } from 'react';
+import { HttpResponse } from 'msw';
+import { render, screen } from '@/test-utils/rtl';
+import { DescribeClusterResponse } from '@/route-handlers/describe-cluster/describe-cluster.types';
+import { act } from 'react-dom/test-utils';
+
+
+jest.mock('@/views/domain-workflows-basic/domain-workflows-basic', () => () => <div>Basic Workflows</div>);
+jest.mock('../domain-workflows-header/domain-workflows-header', () => () => <div>Workflows Header</div>);
+jest.mock('../domain-workflows-table/domain-workflows-table', () => () => <div>Workflows Table</div>);
+
+describe('DomainWorkflows', () => {
+
+  it('should render basic workflows when advanced visibility is disabled', async () => {
+    await setup({ isAdvancedVisibility: false });
+
+    expect(await screen.findByText('Basic Workflows')).toBeInTheDocument();
+  });
+
+  it('should render workflows header and table when advanced visibility is enabled', async () => {
+    await setup({ isAdvancedVisibility: true });
+
+    expect(await screen.findByText('Workflows Header')).toBeInTheDocument();
+    expect(await screen.findByText('Workflows Table')).toBeInTheDocument();
+  });
+
+
+  it('should render workflows header and table when advanced visibility is enabled', async () => {
+    let renderErrorMessage;
+    try {
+      await act(async () => {
+        await setup({ error: true });
+      });
+    } catch (error) {
+      if (error instanceof Error) {
+        renderErrorMessage = error.message;
+      }
+    }
+
+    expect(renderErrorMessage).toEqual('Failed to fetch cluster info');
+  });
+});
+
+
+async function setup({
+  isAdvancedVisibility = false,
+  error,
+}: {
+  error?: boolean;
+  isAdvancedVisibility?: boolean;
+}) {
+  const props: DomainPageTabContentProps = {
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+  };
+
+  render(
+    <Suspense>
+      <DomainWorkflows {...props} />
+    </Suspense>,
+    {
+      endpointsMocks: [
+        {
+          path: '/api/clusters/test-cluster',
+          httpMethod: 'GET',
+          mockOnce: false,
+          ...(error
+            ? {
+              httpResolver: () => {
+                return HttpResponse.json(
+                  { message: 'Failed to fetch cluster info' },
+                  { status: 500 }
+                );
+              },
+            }
+            : {
+              jsonResponse: {
+                persistenceInfo: {
+                  visibilityStore: {
+                    features: [{ key: 'advancedVisibilityEnabled', enabled: isAdvancedVisibility }],
+                    backend: '',
+                    settings: []
+                  },
+                },
+                supportedClientVersions: null
+              } satisfies DescribeClusterResponse,
+            }),
+        },
+      ],
+    }
+  );
+
+}
+

--- a/src/views/domain-workflows/domain-workflows.tsx
+++ b/src/views/domain-workflows/domain-workflows.tsx
@@ -9,7 +9,6 @@ import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-
 
 import isClusterAdvancedVisibilityEnabled from './helpers/is-cluster-advanced-visibility-enabled';
 
-
 const DomainWorkflowBasic = dynamic(
   () => import('@/views/domain-workflows-basic/domain-workflows-basic')
 );

--- a/src/views/domain-workflows/domain-workflows.tsx
+++ b/src/views/domain-workflows/domain-workflows.tsx
@@ -1,11 +1,41 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
+import { useSuspenseQuery } from '@tanstack/react-query';
+import dynamic from 'next/dynamic';
+
+import { type DescribeClusterResponse } from '@/route-handlers/describe-cluster/describe-cluster.types';
+import request from '@/utils/request';
 import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-content/domain-page-content.types';
 
-import DomainWorkflowsHeader from './domain-workflows-header/domain-workflows-header';
-import DomainWorkflowsTable from './domain-workflows-table/domain-workflows-table';
+import isClusterAdvancedVisibilityEnabled from './helpers/is-cluster-advanced-visibility-enabled';
+
+
+const DomainWorkflowBasic = dynamic(
+  () => import('@/views/domain-workflows-basic/domain-workflows-basic')
+);
+const DomainWorkflowsHeader = dynamic(
+  () => import('./domain-workflows-header/domain-workflows-header')
+);
+const DomainWorkflowsTable = dynamic(
+  () => import('./domain-workflows-table/domain-workflows-table')
+);
 
 export default function DomainWorkflows(props: DomainPageTabContentProps) {
+  const { data } = useSuspenseQuery<DescribeClusterResponse>({
+    queryKey: ['describeCluster', props],
+    queryFn: () =>
+      request(`/api/clusters/${props.cluster}`).then((res) => res.json()),
+  });
+
+  const isAdvancedVisibilityEnabled = useMemo(() => {
+    return isClusterAdvancedVisibilityEnabled(data);
+  }, [data]);
+
+  if (!isAdvancedVisibilityEnabled) {
+    return (
+      <DomainWorkflowBasic domain={props.domain} cluster={props.cluster} />
+    );
+  }
   return (
     <>
       <DomainWorkflowsHeader domain={props.domain} cluster={props.cluster} />

--- a/src/views/domain-workflows/domain-workflows.tsx
+++ b/src/views/domain-workflows/domain-workflows.tsx
@@ -9,12 +9,14 @@ import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-
 
 import isClusterAdvancedVisibilityEnabled from './helpers/is-cluster-advanced-visibility-enabled';
 
-const DomainWorkflowBasic = dynamic(
+const DomainWorkflowsBasic = dynamic(
   () => import('@/views/domain-workflows-basic/domain-workflows-basic')
 );
+
 const DomainWorkflowsHeader = dynamic(
   () => import('./domain-workflows-header/domain-workflows-header')
 );
+
 const DomainWorkflowsTable = dynamic(
   () => import('./domain-workflows-table/domain-workflows-table')
 );
@@ -32,9 +34,10 @@ export default function DomainWorkflows(props: DomainPageTabContentProps) {
 
   if (!isAdvancedVisibilityEnabled) {
     return (
-      <DomainWorkflowBasic domain={props.domain} cluster={props.cluster} />
+      <DomainWorkflowsBasic domain={props.domain} cluster={props.cluster} />
     );
   }
+
   return (
     <>
       <DomainWorkflowsHeader domain={props.domain} cluster={props.cluster} />

--- a/src/views/domain-workflows/helpers/__tests__/is-cluster-advanced-visibility-enabled.test.ts
+++ b/src/views/domain-workflows/helpers/__tests__/is-cluster-advanced-visibility-enabled.test.ts
@@ -1,0 +1,79 @@
+import isClusterAdvancedVisibilityEnabled from '../is-cluster-advanced-visibility-enabled';
+import type { DescribeClusterResponse } from '@/route-handlers/describe-cluster/describe-cluster.types';
+
+const mockVisibilityStore = {
+  features: [],
+  backend: '',
+  settings: []
+};
+
+describe('isClusterAdvancedVisibilityEnabled', () => {
+  it('should return true when advancedVisibilityEnabled feature is enabled', () => {
+    const cluster: DescribeClusterResponse = {
+      supportedClientVersions: null,
+      persistenceInfo: {
+        visibilityStore: {
+          ...mockVisibilityStore,
+          features: [{ key: 'advancedVisibilityEnabled', enabled: true }],
+        },
+      },
+    };
+    expect(isClusterAdvancedVisibilityEnabled(cluster)).toBe(true);
+  });
+
+  it('should return false when advancedVisibilityEnabled feature is disabled', () => {
+    const cluster: DescribeClusterResponse = {
+      supportedClientVersions: null,
+      persistenceInfo: {
+        visibilityStore: {
+          ...mockVisibilityStore,
+          features: [{ key: 'advancedVisibilityEnabled', enabled: false }],
+        },
+      },
+    };
+    expect(isClusterAdvancedVisibilityEnabled(cluster)).toBe(false);
+  });
+
+  it('should return false when advancedVisibilityEnabled feature is not present', () => {
+    const cluster: DescribeClusterResponse = {
+      supportedClientVersions: null,
+      persistenceInfo: {
+        visibilityStore: {
+          ...mockVisibilityStore,
+          features: [{ key: 'someOtherFeature', enabled: true }],
+        },
+      },
+    };
+    expect(isClusterAdvancedVisibilityEnabled(cluster)).toBe(false);
+  });
+
+  it('should return false when features array is empty', () => {
+    const cluster: DescribeClusterResponse = {
+      supportedClientVersions: null,
+      persistenceInfo: {
+        visibilityStore: {
+          ...mockVisibilityStore,
+          features: [],
+        },
+      },
+    };
+    expect(isClusterAdvancedVisibilityEnabled(cluster)).toBe(false);
+  });
+
+  it('should return false when visibilityStore is undefined', () => {
+    const cluster: DescribeClusterResponse = {
+      supportedClientVersions: null,
+      persistenceInfo: {},
+    };
+    expect(isClusterAdvancedVisibilityEnabled(cluster)).toBe(false);
+  });
+
+  it('should return false when persistenceInfo is undefined', () => {
+    const cluster: DescribeClusterResponse = {
+      supportedClientVersions: null,
+      // @ts-expect-error testing non esisting persistenceInfo
+      persistenceInfo: undefined,
+    };
+    expect(isClusterAdvancedVisibilityEnabled(cluster)).toBe(false);
+  });
+});

--- a/src/views/domain-workflows/helpers/__tests__/is-cluster-advanced-visibility-enabled.test.ts
+++ b/src/views/domain-workflows/helpers/__tests__/is-cluster-advanced-visibility-enabled.test.ts
@@ -1,10 +1,11 @@
-import isClusterAdvancedVisibilityEnabled from '../is-cluster-advanced-visibility-enabled';
 import type { DescribeClusterResponse } from '@/route-handlers/describe-cluster/describe-cluster.types';
+
+import isClusterAdvancedVisibilityEnabled from '../is-cluster-advanced-visibility-enabled';
 
 const mockVisibilityStore = {
   features: [],
   backend: '',
-  settings: []
+  settings: [],
 };
 
 describe('isClusterAdvancedVisibilityEnabled', () => {

--- a/src/views/domain-workflows/helpers/__tests__/is-cluster-advanced-visibility-enabled.test.ts
+++ b/src/views/domain-workflows/helpers/__tests__/is-cluster-advanced-visibility-enabled.test.ts
@@ -72,7 +72,7 @@ describe('isClusterAdvancedVisibilityEnabled', () => {
   it('should return false when persistenceInfo is undefined', () => {
     const cluster: DescribeClusterResponse = {
       supportedClientVersions: null,
-      // @ts-expect-error testing non esisting persistenceInfo
+      // @ts-expect-error testing nonexisting persistenceInfo
       persistenceInfo: undefined,
     };
     expect(isClusterAdvancedVisibilityEnabled(cluster)).toBe(false);

--- a/src/views/domain-workflows/helpers/is-cluster-advanced-visibility-enabled.ts
+++ b/src/views/domain-workflows/helpers/is-cluster-advanced-visibility-enabled.ts
@@ -1,0 +1,14 @@
+import type { DescribeClusterResponse } from '@/route-handlers/describe-cluster/describe-cluster.types';
+
+export default function isClusterAdvancedVisibilityEnabled(
+  cluster: DescribeClusterResponse
+) {
+  const clusterVisibilityFeatures =
+    cluster.persistenceInfo?.visibilityStore?.features || [];
+
+  const advancedVisibilityEnabledFeature = clusterVisibilityFeatures.find(
+    ({ key }) => key === 'advancedVisibilityEnabled'
+  );
+
+  return advancedVisibilityEnabledFeature?.enabled ?? false;
+}


### PR DESCRIPTION
### Summary
Switch between basic and advanced views for `domain workflows page` using flag from `describeCluster` method.

### Changes
- add describeCluster route handler
- add helper to get if advanced visibility is enabled for cluster
- switch between basic and advanced workflows views
- add `CADENCE_ADVANCED_VISIBILITY` to allow bypassing describeCluster invocation. 