### PR TITLE
show lastCompletionResult as json

### DIFF
--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -46,7 +46,7 @@ const workflowHistoryEventDetailsConfig = [
   },
   {
     name: 'Json as PrettyJson',
-    pathRegex: '(input|result|details|Error)$',
+    pathRegex: '(input|result|details|Error|lastCompletionResult)$',
     valueComponent: WorkflowHistoryEventDetailsJson,
     forceWrap: true,
   },


### PR DESCRIPTION
### Summary
Show `lastCompletionResult` with json viewer


### Screenshots
![Screenshot 2025-02-17 at 15 05 28](https://github.com/user-attachments/assets/f869c556-3a0e-4af0-a77c-6645c33252b0)
