### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,13 +10,10 @@ FROM base AS deps
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
-COPY package.json yarn.lock* package-lock.json* pnpm-lock.yaml* ./
-RUN \
-  if [ -f yarn.lock ]; then yarn --frozen-lockfile; \
-  elif [ -f package-lock.json ]; then npm ci; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm i --frozen-lockfile; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+COPY package.json package-lock.json ./
+RUN npm ci
+RUN npm run install-idl
+
 
 
 FROM base AS dev
@@ -37,13 +34,11 @@ COPY . .
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
+# optimize Build size by inclduding only required resources
+ENV NEXT_CONFIG_BUILD_OUTPUT standalone
 
-RUN \
-  if [ -f yarn.lock ]; then yarn run build; \
-  elif [ -f package-lock.json ]; then npm run build; \
-  elif [ -f pnpm-lock.yaml ]; then corepack enable pnpm && pnpm run build; \
-  else echo "Lockfile not found." && exit 1; \
-  fi
+RUN npm run generate:idl
+RUN npm run build
 
 
 # Production image, copy all the files and run next
@@ -72,4 +67,4 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs
 
 
-CMD ["node", "server.js"]
+CMD  "PORT=${CADENCE_WEB_PORT:-8088} exec node server.js"

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,4 @@ COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 USER nextjs
 
 
-CMD  "PORT=${CADENCE_WEB_PORT:-8088} exec node server.js"
+CMD  ["sh","-c", "PORT=${CADENCE_WEB_PORT:-8088} exec node server.js"]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const BUILD_OUTPUT = process.env.NEXT_CONFIG_BUILD_OUTPUT === 'standalone' ? 'standalone' : undefined;
+
 const nextConfig = {
   webpack: (config) => {
     config.resolve.alias = {
@@ -31,6 +33,7 @@ const nextConfig = {
       },
     ];
   },
+  output: BUILD_OUTPUT,
   experimental: {
     instrumentationHook: true,
   },


### PR DESCRIPTION
### Summary
Fix docker build steps

### Changes
- Allow specifying build output using `NEXT_CONFIG_BUILD_OUTPUT` environment variable. This helps setting the build output to `standalone` for optimising docker image size.
- removed `pnpm` & `yarn` conditions and directly use `npm` since we are only using `npm`.
- add `npm run install-idl` & `npm run generate:idl` before building
- set `PORT` environment variable to value of `CADENCE_WEB_PORT` before running `node server.js`.