### PR TITLE
Feature/12004/fix docker build dependecies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,10 +61,11 @@ RUN chown nextjs:nodejs .next
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=builder --chown=nextjs:nodejs /app/src/__generated__/ ./src/__generated__/ 
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
 
-CMD  ["sh","-c", "PORT=${CADENCE_WEB_PORT:-8088} exec node server.js"]
+CMD  ["sh","-c", "CADENCE_WEB_PORT=${CADENCE_WEB_PORT:-8088} PORT=${CADENCE_WEB_PORT} exec node server.js"]

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p ${CADENCE_WEB_PORT} | pino-pretty",
     "build": "NODE_ENV=production && next build",
-    "start": "next start -p ${CADENCE_WEB_PORT-8088}",
+    "start": "next start -p ${CADENCE_WEB_PORT}",
     "lint": "next lint",
     "typecheck": "tsc --noemit",
     "install-idl": "mkdir -p node_modules && cd node_modules && npx --yes tiged https://github.com/cadence-workflow/cadence-idl cadence-idl --force",


### PR DESCRIPTION
### Summary
Manually add generated files as they were not included by next js build by default. Also fix cases were `CADENCE_WEB_PORT` is not provided

### Changes
- add generated directory to docker image
- set `CADENCE_WEB_PORT` default value if it is not provided so that codebase and next.js read the same Port
- remove default port from start script as it causes the server to start with different port than the default code value for `CADENCE_WEB_PORT`. This will force user to provide port before running