### PR TITLE
Add test action to push to NPM

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -1,14 +1,9 @@
-# This is a basic workflow to help you get started with Actions
-
 name: Publish Docker image
 
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
 on:
   release:
-    types: [ published ]
+    types: [published]
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
@@ -17,7 +12,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Push stable version to Docker Hub
-        if: "!github.event.release.prerelease"
+        if: '!github.event.release.prerelease'
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.CADENCE_WEB_DOCKERHUB_USERNAME }}

--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -1,0 +1,20 @@
+name: Publish to NPM (test)
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --provenance --access public --dry-run
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_cadence_web }}


### PR DESCRIPTION
## Summary
Add test action that dry runs a push to NPM, when code is pushed. In a follow up, this will be updated to actually push when a release is published.