### PR TITLE
Better error message on cluster config mismatch

### DIFF
--- a/src/config/dynamic/resolvers/clusters.ts
+++ b/src/config/dynamic/resolvers/clusters.ts
@@ -6,9 +6,9 @@ const getArrayFromCommaSeparatedString = (
 ) => {
   return str?.trim()
     ? str
-        .split(',')
-        .filter((c) => Boolean(c.trim()))
-        .map((c) => c.trim())
+      .split(',')
+      .filter((c) => Boolean(c.trim()))
+      .map((c) => c.trim())
     : defaultValue;
 };
 
@@ -26,6 +26,9 @@ export default function clusters() {
     process.env.CADENCE_GRPC_SERVICES_NAMES,
     ['cadence-frontend']
   );
+  if (clusterNames.length !== peers.length && clusterNames.length !== serviceNames.length) {
+    throw new Error(`Count mismatch in environment variables CADENCE_CLUSTERS_NAMES, CADENCE_GRPC_PEERS & CADENCE_GRPC_SERVICES_NAMES values. Recieved: ${clusterNames}(${clusterNames.length}), ${serviceNames}(${serviceNames.length}) & ${peers}(${peers.length}) respectively.`)
+  }
 
   return clusterNames.map((clusterName, i) => {
     return {

--- a/src/config/dynamic/resolvers/clusters.ts
+++ b/src/config/dynamic/resolvers/clusters.ts
@@ -6,9 +6,9 @@ const getArrayFromCommaSeparatedString = (
 ) => {
   return str?.trim()
     ? str
-      .split(',')
-      .filter((c) => Boolean(c.trim()))
-      .map((c) => c.trim())
+        .split(',')
+        .filter((c) => Boolean(c.trim()))
+        .map((c) => c.trim())
     : defaultValue;
 };
 
@@ -26,8 +26,13 @@ export default function clusters() {
     process.env.CADENCE_GRPC_SERVICES_NAMES,
     ['cadence-frontend']
   );
-  if (clusterNames.length !== peers.length && clusterNames.length !== serviceNames.length) {
-    throw new Error(`Count mismatch in environment variables CADENCE_CLUSTERS_NAMES, CADENCE_GRPC_PEERS & CADENCE_GRPC_SERVICES_NAMES values. Recieved: ${clusterNames}(${clusterNames.length}), ${serviceNames}(${serviceNames.length}) & ${peers}(${peers.length}) respectively.`)
+  if (
+    clusterNames.length !== peers.length &&
+    clusterNames.length !== serviceNames.length
+  ) {
+    throw new Error(
+      `Count mismatch in environment variables CADENCE_CLUSTERS_NAMES, CADENCE_GRPC_PEERS & CADENCE_GRPC_SERVICES_NAMES values. Recieved: ${clusterNames}(${clusterNames.length}), ${serviceNames}(${serviceNames.length}) & ${peers}(${peers.length}) respectively.`
+    );
   }
 
   return clusterNames.map((clusterName, i) => {

--- a/src/utils/config/transform-configs.ts
+++ b/src/utils/config/transform-configs.ts
@@ -24,7 +24,7 @@ export default async function transformConfigs<
           resolverSchema.returnType.safeParse(resolvedValue);
         if (error) {
           throw new Error(
-            `Failed to parse config '${key}' resolved value: ${error.errors[0].message}`
+            `Failed to parse config '${key}' resolved value: ${JSON.stringify(error.errors)}`
           );
         }
         return [key, validatedValue];


### PR DESCRIPTION
### Summary
Making the clusters misconfiguration error more clear & user friendly

### Changes
- Changes throw error message when the cluster configs count is not matching
- Show all validation errors for config resolvers instead of the first error message. The first error message used to say `Required` without any extra details about the field name and path.

### Screenshots

- ![Screenshot 2025-02-25 at 14 25 05](https://github.com/user-attachments/assets/d3294388-63db-4df4-8b42-386cd93533ae)
- ![Screenshot 2025-02-25 at 14 26 30](https://github.com/user-attachments/assets/6d034f79-31e1-42f6-8f6d-ce014e1c7c49)

