### PR TITLE
Make time select in date filter editable

### DIFF
--- a/src/components/date-filter/date-filter.tsx
+++ b/src/components/date-filter/date-filter.tsx
@@ -86,6 +86,13 @@ export default function DateFilter({
         clearable={clearable}
         timeSelectStart
         timeSelectEnd
+        overrides={{
+          TimeSelect: {
+            props: {
+              creatable: true,
+            },
+          },
+        }}
       />
     </FormControl>
   );


### PR DESCRIPTION
The datepicker used allows users to select time range. We populate the time select with time interval of 15 minutes. Adding more granular time options hampers the performance of the component. However, the users often need to specify time intervals that does not align with the options present. This change adds the `creatable` flag to the time select to enable this.

Please note that the `creatable` flag in the  underlying BaseWeb component is not quite intuitive.