### PR TITLE
Change calculations for hasMissingEvents

### DIFF
--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -1,6 +1,7 @@
 import {
   cancelActivityTaskEvent,
   completeActivityTaskEvent,
+  completedActivityTaskEvents,
   failedActivityTaskEvent,
   scheduleActivityTaskEvent,
   startActivityTaskEvent,
@@ -48,27 +49,35 @@ describe('getActivityGroupFromEvents', () => {
     expect(timedoutActivitygroup.label).toBe('');
   });
 
-  it('should return a group with hasMissingEvents set to true when scheduled event is missing', () => {
-    const completeEvents: ActivityHistoryEvent[] = [
+  it('should return a group with hasMissingEvents when any event is missing', () => {
+    const missingCloseEvent: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
       startActivityTaskEvent,
-      completeActivityTaskEvent,
     ];
-    const completedActivitygroup = getActivityGroupFromEvents(completeEvents);
-    expect(completedActivitygroup.hasMissingEvents).toBe(true);
+    const incompleteActivityGroup1 = getActivityGroupFromEvents(missingCloseEvent);
+    expect(incompleteActivityGroup1.hasMissingEvents).toBe(true);
 
-    const failureEvents: ActivityHistoryEvent[] = [
+    const missingScheduleEvent: ActivityHistoryEvent[] = [
       startActivityTaskEvent,
       failedActivityTaskEvent,
     ];
-    const failedActivitygroup = getActivityGroupFromEvents(failureEvents);
-    expect(failedActivitygroup.hasMissingEvents).toBe(true);
+    const incompleteActivityGroup2 = getActivityGroupFromEvents(missingScheduleEvent);
+    expect(incompleteActivityGroup2.hasMissingEvents).toBe(true);
 
-    const timeoutEvents: ActivityHistoryEvent[] = [
-      startActivityTaskEvent,
+    const missingStartEvent: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
       timeoutActivityTaskEvent,
     ];
-    const timedoutActivitygroup = getActivityGroupFromEvents(timeoutEvents);
-    expect(timedoutActivitygroup.hasMissingEvents).toBe(true);
+    const incompleteActivityGroup3 = getActivityGroupFromEvents(missingStartEvent);
+    expect(incompleteActivityGroup3.hasMissingEvents).toBe(true);
+
+    const completedEvents: ActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+    ];
+    const completeActivityGroup = getActivityGroupFromEvents(completedEvents);
+    expect(completeActivityGroup.hasMissingEvents).toBe(false);
   });
 
   it('should return a group with groupType equal to Activity', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -1,7 +1,6 @@
 import {
   cancelActivityTaskEvent,
   completeActivityTaskEvent,
-  completedActivityTaskEvents,
   failedActivityTaskEvent,
   scheduleActivityTaskEvent,
   startActivityTaskEvent,
@@ -54,21 +53,24 @@ describe('getActivityGroupFromEvents', () => {
       scheduleActivityTaskEvent,
       startActivityTaskEvent,
     ];
-    const incompleteActivityGroup1 = getActivityGroupFromEvents(missingCloseEvent);
+    const incompleteActivityGroup1 =
+      getActivityGroupFromEvents(missingCloseEvent);
     expect(incompleteActivityGroup1.hasMissingEvents).toBe(true);
 
     const missingScheduleEvent: ActivityHistoryEvent[] = [
       startActivityTaskEvent,
       failedActivityTaskEvent,
     ];
-    const incompleteActivityGroup2 = getActivityGroupFromEvents(missingScheduleEvent);
+    const incompleteActivityGroup2 =
+      getActivityGroupFromEvents(missingScheduleEvent);
     expect(incompleteActivityGroup2.hasMissingEvents).toBe(true);
 
     const missingStartEvent: ActivityHistoryEvent[] = [
       scheduleActivityTaskEvent,
       timeoutActivityTaskEvent,
     ];
-    const incompleteActivityGroup3 = getActivityGroupFromEvents(missingStartEvent);
+    const incompleteActivityGroup3 =
+      getActivityGroupFromEvents(missingStartEvent);
     expect(incompleteActivityGroup3.hasMissingEvents).toBe(true);
 
     const completedEvents: ActivityHistoryEvent[] = [

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -49,37 +49,46 @@ describe('getActivityGroupFromEvents', () => {
   });
 
   it('should return a group with hasMissingEvents when any event is missing', () => {
-    const missingCloseEvent: ActivityHistoryEvent[] = [
-      scheduleActivityTaskEvent,
-      startActivityTaskEvent,
+    const assertions: Array<{
+      name: string;
+      events: ActivityHistoryEvent[];
+      assertionValue: boolean;
+    }> = [
+      {
+        name: 'missingCloseEvent',
+        events: [scheduleActivityTaskEvent, startActivityTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingScheduleEvent',
+        events: [startActivityTaskEvent, failedActivityTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingTimoutAndCloseEvent',
+        events: [scheduleActivityTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'completeEvents',
+        events: [
+          scheduleActivityTaskEvent,
+          startActivityTaskEvent,
+          completeActivityTaskEvent,
+        ],
+        assertionValue: false,
+      },
+      {
+        name: 'timedoutEvents',
+        events: [scheduleActivityTaskEvent, timeoutActivityTaskEvent],
+        assertionValue: false,
+      },
     ];
-    const incompleteActivityGroup1 =
-      getActivityGroupFromEvents(missingCloseEvent);
-    expect(incompleteActivityGroup1.hasMissingEvents).toBe(true);
 
-    const missingScheduleEvent: ActivityHistoryEvent[] = [
-      startActivityTaskEvent,
-      failedActivityTaskEvent,
-    ];
-    const incompleteActivityGroup2 =
-      getActivityGroupFromEvents(missingScheduleEvent);
-    expect(incompleteActivityGroup2.hasMissingEvents).toBe(true);
-
-    const missingStartEvent: ActivityHistoryEvent[] = [
-      scheduleActivityTaskEvent,
-      timeoutActivityTaskEvent,
-    ];
-    const incompleteActivityGroup3 =
-      getActivityGroupFromEvents(missingStartEvent);
-    expect(incompleteActivityGroup3.hasMissingEvents).toBe(true);
-
-    const completedEvents: ActivityHistoryEvent[] = [
-      scheduleActivityTaskEvent,
-      startActivityTaskEvent,
-      completeActivityTaskEvent,
-    ];
-    const completeActivityGroup = getActivityGroupFromEvents(completedEvents);
-    expect(completeActivityGroup.hasMissingEvents).toBe(false);
+    assertions.forEach(({ name, events, assertionValue }) => {
+      const group = getActivityGroupFromEvents(events);
+      expect([name, group.hasMissingEvents]).toEqual([name, assertionValue]);
+    });
   });
 
   it('should return a group with groupType equal to Activity', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -34,14 +34,13 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
       getChildWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
     expect(incompleteChildWorkflowGroup1.hasMissingEvents).toBe(true);
 
-
-    const missingInitiationFailureAndCloseEvent: ChildWorkflowExecutionHistoryEvent[] = [
-      initiateChildWorkflowEvent,
-    ];
+    const missingInitiationFailureAndCloseEvent: ChildWorkflowExecutionHistoryEvent[] =
+      [initiateChildWorkflowEvent];
     const incompleteChildWorkflowGroup2 =
-      getChildWorkflowExecutionGroupFromEvents(missingInitiationFailureAndCloseEvent);
+      getChildWorkflowExecutionGroupFromEvents(
+        missingInitiationFailureAndCloseEvent
+      );
     expect(incompleteChildWorkflowGroup2.hasMissingEvents).toBe(true);
-
 
     const missingCloseEvent: ChildWorkflowExecutionHistoryEvent[] = [
       initiateChildWorkflowEvent,
@@ -53,22 +52,19 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
 
     const missingStartEvent: ChildWorkflowExecutionHistoryEvent[] = [
       initiateChildWorkflowEvent,
-      completeChildWorkflowEvent
+      completeChildWorkflowEvent,
     ];
-    
+
     const incompleteChildWorkflowGroup4 =
       getChildWorkflowExecutionGroupFromEvents(missingStartEvent);
     expect(incompleteChildWorkflowGroup4.hasMissingEvents).toBe(true);
 
-    const completedFailedInitiationEvent: ChildWorkflowExecutionHistoryEvent[] = [
-      initiateChildWorkflowEvent,
-      initiateFailureChildWorkflowEvent,
-    ];
-    
+    const completedFailedInitiationEvent: ChildWorkflowExecutionHistoryEvent[] =
+      [initiateChildWorkflowEvent, initiateFailureChildWorkflowEvent];
+
     const completedChildWorkflowGroup1 =
       getChildWorkflowExecutionGroupFromEvents(completedFailedInitiationEvent);
     expect(completedChildWorkflowGroup1.hasMissingEvents).toBe(false);
-
   });
 
   it('should return a group with groupType equal to ChildWorkflow', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -27,44 +27,42 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
   });
 
   it('should return a group with hasMissingEvents set to true when any event is missing', () => {
-    const missingInitiatedEvent: ChildWorkflowExecutionHistoryEvent[] = [
-      initiateFailureChildWorkflowEvent,
+    const assertions: Array<{
+      name: string;
+      events: ChildWorkflowExecutionHistoryEvent[];
+      assertionValue: boolean;
+    }> = [
+      {
+        name: 'missingInitiatedEvent',
+        events: [initiateFailureChildWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingInitiationFailureAndCloseEvent',
+        events: [initiateChildWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingCloseEvent',
+        events: [initiateChildWorkflowEvent, startChildWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingStartEvent',
+        events: [initiateChildWorkflowEvent, completeChildWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'completedFailedInitiationEvent',
+        events: [initiateChildWorkflowEvent, initiateFailureChildWorkflowEvent],
+        assertionValue: false,
+      },
     ];
-    const incompleteChildWorkflowGroup1 =
-      getChildWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
-    expect(incompleteChildWorkflowGroup1.hasMissingEvents).toBe(true);
 
-    const missingInitiationFailureAndCloseEvent: ChildWorkflowExecutionHistoryEvent[] =
-      [initiateChildWorkflowEvent];
-    const incompleteChildWorkflowGroup2 =
-      getChildWorkflowExecutionGroupFromEvents(
-        missingInitiationFailureAndCloseEvent
-      );
-    expect(incompleteChildWorkflowGroup2.hasMissingEvents).toBe(true);
-
-    const missingCloseEvent: ChildWorkflowExecutionHistoryEvent[] = [
-      initiateChildWorkflowEvent,
-      startChildWorkflowEvent,
-    ];
-    const incompleteChildWorkflowGroup3 =
-      getChildWorkflowExecutionGroupFromEvents(missingCloseEvent);
-    expect(incompleteChildWorkflowGroup3.hasMissingEvents).toBe(true);
-
-    const missingStartEvent: ChildWorkflowExecutionHistoryEvent[] = [
-      initiateChildWorkflowEvent,
-      completeChildWorkflowEvent,
-    ];
-
-    const incompleteChildWorkflowGroup4 =
-      getChildWorkflowExecutionGroupFromEvents(missingStartEvent);
-    expect(incompleteChildWorkflowGroup4.hasMissingEvents).toBe(true);
-
-    const completedFailedInitiationEvent: ChildWorkflowExecutionHistoryEvent[] =
-      [initiateChildWorkflowEvent, initiateFailureChildWorkflowEvent];
-
-    const completedChildWorkflowGroup1 =
-      getChildWorkflowExecutionGroupFromEvents(completedFailedInitiationEvent);
-    expect(completedChildWorkflowGroup1.hasMissingEvents).toBe(false);
+    assertions.forEach(({ name, events, assertionValue }) => {
+      const group = getChildWorkflowExecutionGroupFromEvents(events);
+      expect([name, group.hasMissingEvents]).toEqual([name, assertionValue]);
+    });
   });
 
   it('should return a group with groupType equal to ChildWorkflow', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -26,45 +26,49 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     expect(group.label).toBe(expectedLabel);
   });
 
-  it('should return a group with hasMissingEvents set to true when initiate event is missing', () => {
-    const intiateFailedEvents: ChildWorkflowExecutionHistoryEvent[] = [
+  it('should return a group with hasMissingEvents set to true when any event is missing', () => {
+    const missingInitiatedEvent: ChildWorkflowExecutionHistoryEvent[] = [
       initiateFailureChildWorkflowEvent,
     ];
-    const intiateFailedChildWorkflowgroup =
-      getChildWorkflowExecutionGroupFromEvents(intiateFailedEvents);
-    expect(intiateFailedChildWorkflowgroup.hasMissingEvents).toBe(true);
+    const incompleteChildWorkflowGroup1 =
+      getChildWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
+    expect(incompleteChildWorkflowGroup1.hasMissingEvents).toBe(true);
 
-    const completeEvents: ChildWorkflowExecutionHistoryEvent[] = [
-      startChildWorkflowEvent,
-      completeChildWorkflowEvent,
-    ];
-    const completedChildWorkflowgroup =
-      getChildWorkflowExecutionGroupFromEvents(completeEvents);
-    expect(completedChildWorkflowgroup.hasMissingEvents).toBe(true);
 
-    const failureEvents: ChildWorkflowExecutionHistoryEvent[] = [
-      startChildWorkflowEvent,
-      failChildWorkflowEvent,
+    const missingInitiationFailureAndCloseEvent: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
     ];
-    const failedChildWorkflowgroup =
-      getChildWorkflowExecutionGroupFromEvents(failureEvents);
-    expect(failedChildWorkflowgroup.hasMissingEvents).toBe(true);
+    const incompleteChildWorkflowGroup2 =
+      getChildWorkflowExecutionGroupFromEvents(missingInitiationFailureAndCloseEvent);
+    expect(incompleteChildWorkflowGroup2.hasMissingEvents).toBe(true);
 
-    const timeoutEvents: ChildWorkflowExecutionHistoryEvent[] = [
-      startChildWorkflowEvent,
-      timeoutChildWorkflowEvent,
-    ];
-    const timedoutChildWorkflowgroup =
-      getChildWorkflowExecutionGroupFromEvents(timeoutEvents);
-    expect(timedoutChildWorkflowgroup.hasMissingEvents).toBe(true);
 
-    const cancelEvents: ChildWorkflowExecutionHistoryEvent[] = [
+    const missingCloseEvent: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
       startChildWorkflowEvent,
-      cancelChildWorkflowEvent,
     ];
-    const cancelChildWorkflowgroup =
-      getChildWorkflowExecutionGroupFromEvents(cancelEvents);
-    expect(cancelChildWorkflowgroup.hasMissingEvents).toBe(true);
+    const incompleteChildWorkflowGroup3 =
+      getChildWorkflowExecutionGroupFromEvents(missingCloseEvent);
+    expect(incompleteChildWorkflowGroup3.hasMissingEvents).toBe(true);
+
+    const missingStartEvent: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      completeChildWorkflowEvent
+    ];
+    
+    const incompleteChildWorkflowGroup4 =
+      getChildWorkflowExecutionGroupFromEvents(missingStartEvent);
+    expect(incompleteChildWorkflowGroup4.hasMissingEvents).toBe(true);
+
+    const completedFailedInitiationEvent: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      initiateFailureChildWorkflowEvent,
+    ];
+    
+    const completedChildWorkflowGroup1 =
+      getChildWorkflowExecutionGroupFromEvents(completedFailedInitiationEvent);
+    expect(completedChildWorkflowGroup1.hasMissingEvents).toBe(false);
+
   });
 
   it('should return a group with groupType equal to ChildWorkflow', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -29,34 +29,34 @@ describe('getDecisionGroupFromEvents', () => {
       startDecisionTaskEvent,
       completeDecisionTaskEvent,
     ];
-    const incompletedDecisionGroup1 = getDecisionGroupFromEvents(missingScheduleEvent);
+    const incompletedDecisionGroup1 =
+      getDecisionGroupFromEvents(missingScheduleEvent);
     expect(incompletedDecisionGroup1.hasMissingEvents).toBe(true);
-
 
     const missingStartEvent: ExtendedDecisionHistoryEvent[] = [
       scheduleDecisionTaskEvent,
       completeDecisionTaskEvent,
     ];
-    const incompletedDecisionGroup2 = getDecisionGroupFromEvents(missingStartEvent);
+    const incompletedDecisionGroup2 =
+      getDecisionGroupFromEvents(missingStartEvent);
     expect(incompletedDecisionGroup2.hasMissingEvents).toBe(true);
-
 
     const missingCompleteEvent: ExtendedDecisionHistoryEvent[] = [
       scheduleDecisionTaskEvent,
       startDecisionTaskEvent,
     ];
-    const incompletedDecisionGroup3 = getDecisionGroupFromEvents(missingCompleteEvent);
+    const incompletedDecisionGroup3 =
+      getDecisionGroupFromEvents(missingCompleteEvent);
     expect(incompletedDecisionGroup3.hasMissingEvents).toBe(true);
-
 
     const completedEvent: ExtendedDecisionHistoryEvent[] = [
       scheduleDecisionTaskEvent,
       startDecisionTaskEvent,
       completeDecisionTaskEvent,
     ];
-    const incompletedDecisionGroup4 = getDecisionGroupFromEvents(completedEvent);
+    const incompletedDecisionGroup4 =
+      getDecisionGroupFromEvents(completedEvent);
     expect(incompletedDecisionGroup4.hasMissingEvents).toBe(false);
-
   });
 
   it('should return a group with groupType equal to Decision', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -24,27 +24,39 @@ describe('getDecisionGroupFromEvents', () => {
     expect(group.label).toBe('Decision Task');
   });
 
-  it('should return a group with hasMissingEvents set to true when scheduled event is missing', () => {
-    const completeEvents: ExtendedDecisionHistoryEvent[] = [
+  it('should return a group with hasMissingEvents set to true when any event is missing', () => {
+    const missingScheduleEvent: ExtendedDecisionHistoryEvent[] = [
       startDecisionTaskEvent,
       completeDecisionTaskEvent,
     ];
-    const completedDecisiongroup = getDecisionGroupFromEvents(completeEvents);
-    expect(completedDecisiongroup.hasMissingEvents).toBe(true);
+    const incompletedDecisionGroup1 = getDecisionGroupFromEvents(missingScheduleEvent);
+    expect(incompletedDecisionGroup1.hasMissingEvents).toBe(true);
 
-    const failureEvents: ExtendedDecisionHistoryEvent[] = [
-      startDecisionTaskEvent,
-      failedDecisionTaskEvent,
-    ];
-    const failedDecisiongroup = getDecisionGroupFromEvents(failureEvents);
-    expect(failedDecisiongroup.hasMissingEvents).toBe(true);
 
-    const timeoutEvents: ExtendedDecisionHistoryEvent[] = [
-      startDecisionTaskEvent,
-      timeoutDecisionTaskEvent,
+    const missingStartEvent: ExtendedDecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      completeDecisionTaskEvent,
     ];
-    const timedoutDecisiongroup = getDecisionGroupFromEvents(timeoutEvents);
-    expect(timedoutDecisiongroup.hasMissingEvents).toBe(true);
+    const incompletedDecisionGroup2 = getDecisionGroupFromEvents(missingStartEvent);
+    expect(incompletedDecisionGroup2.hasMissingEvents).toBe(true);
+
+
+    const missingCompleteEvent: ExtendedDecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+    ];
+    const incompletedDecisionGroup3 = getDecisionGroupFromEvents(missingCompleteEvent);
+    expect(incompletedDecisionGroup3.hasMissingEvents).toBe(true);
+
+
+    const completedEvent: ExtendedDecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      completeDecisionTaskEvent,
+    ];
+    const incompletedDecisionGroup4 = getDecisionGroupFromEvents(completedEvent);
+    expect(incompletedDecisionGroup4.hasMissingEvents).toBe(false);
+
   });
 
   it('should return a group with groupType equal to Decision', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -25,38 +25,51 @@ describe('getDecisionGroupFromEvents', () => {
   });
 
   it('should return a group with hasMissingEvents set to true when any event is missing', () => {
-    const missingScheduleEvent: ExtendedDecisionHistoryEvent[] = [
-      startDecisionTaskEvent,
-      completeDecisionTaskEvent,
+    const assertions: Array<{
+      name: string;
+      events: ExtendedDecisionHistoryEvent[];
+      assertionValue: boolean;
+    }> = [
+      {
+        name: 'missingScheduleEvent',
+        events: [startDecisionTaskEvent, completeDecisionTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingTimoutAndCloseEvent',
+        events: [scheduleDecisionTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingStartEvent',
+        events: [scheduleDecisionTaskEvent, completeDecisionTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingCompleteEvent',
+        events: [scheduleDecisionTaskEvent, startDecisionTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'completeEvents',
+        events: [
+          scheduleDecisionTaskEvent,
+          startDecisionTaskEvent,
+          completeDecisionTaskEvent,
+        ],
+        assertionValue: false,
+      },
+      {
+        name: 'timedoutEvents',
+        events: [scheduleDecisionTaskEvent, timeoutDecisionTaskEvent],
+        assertionValue: false,
+      },
     ];
-    const incompletedDecisionGroup1 =
-      getDecisionGroupFromEvents(missingScheduleEvent);
-    expect(incompletedDecisionGroup1.hasMissingEvents).toBe(true);
 
-    const missingStartEvent: ExtendedDecisionHistoryEvent[] = [
-      scheduleDecisionTaskEvent,
-      completeDecisionTaskEvent,
-    ];
-    const incompletedDecisionGroup2 =
-      getDecisionGroupFromEvents(missingStartEvent);
-    expect(incompletedDecisionGroup2.hasMissingEvents).toBe(true);
-
-    const missingCompleteEvent: ExtendedDecisionHistoryEvent[] = [
-      scheduleDecisionTaskEvent,
-      startDecisionTaskEvent,
-    ];
-    const incompletedDecisionGroup3 =
-      getDecisionGroupFromEvents(missingCompleteEvent);
-    expect(incompletedDecisionGroup3.hasMissingEvents).toBe(true);
-
-    const completedEvent: ExtendedDecisionHistoryEvent[] = [
-      scheduleDecisionTaskEvent,
-      startDecisionTaskEvent,
-      completeDecisionTaskEvent,
-    ];
-    const incompletedDecisionGroup4 =
-      getDecisionGroupFromEvents(completedEvent);
-    expect(incompletedDecisionGroup4.hasMissingEvents).toBe(false);
+    assertions.forEach(({ name, events, assertionValue }) => {
+      const group = getDecisionGroupFromEvents(events);
+      expect([name, group.hasMissingEvents]).toEqual([name, assertionValue]);
+    });
   });
 
   it('should return a group with groupType equal to Decision', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
@@ -22,12 +22,28 @@ describe('getRequestCancelExternalWorkflowExecutionGroupFromEvents', () => {
     expect(group.label).toBe(expectedLabel);
   });
 
-  it('should return a group with hasMissingEvents set to true when initiated event is missing', () => {
-    const requestEvents: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
+  it('should return a group with hasMissingEvents set to true when any event is missing', () => {
+    const missingInitiatedEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
       [requestCancelExternalWorkflowEvent];
-    const requestGroup =
-      getRequestCancelExternalWorkflowExecutionGroupFromEvents(requestEvents);
-    expect(requestGroup.hasMissingEvents).toBe(true);
+
+    const incompletedCancelRequestGroup1 =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
+    expect(incompletedCancelRequestGroup1.hasMissingEvents).toBe(true);
+
+    const missingCloseEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
+      [initiateRequestCancelExternalWorkflowEvent];
+
+    const incompletedCancelRequestGroup2 =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(missingCloseEvent);
+    expect(incompletedCancelRequestGroup2.hasMissingEvents).toBe(true);
+
+    const completedEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
+      [initiateRequestCancelExternalWorkflowEvent, requestCancelExternalWorkflowEvent];
+
+    const completedCancelRequestGroup =
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(completedEvent);
+    expect(completedCancelRequestGroup.hasMissingEvents).toBe(false);
+
   });
 
   it('should return a group with groupType equal to RequestCancelExternalWorkflowExecution', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
@@ -27,23 +27,29 @@ describe('getRequestCancelExternalWorkflowExecutionGroupFromEvents', () => {
       [requestCancelExternalWorkflowEvent];
 
     const incompletedCancelRequestGroup1 =
-      getRequestCancelExternalWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(
+        missingInitiatedEvent
+      );
     expect(incompletedCancelRequestGroup1.hasMissingEvents).toBe(true);
 
     const missingCloseEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
       [initiateRequestCancelExternalWorkflowEvent];
 
     const incompletedCancelRequestGroup2 =
-      getRequestCancelExternalWorkflowExecutionGroupFromEvents(missingCloseEvent);
+      getRequestCancelExternalWorkflowExecutionGroupFromEvents(
+        missingCloseEvent
+      );
     expect(incompletedCancelRequestGroup2.hasMissingEvents).toBe(true);
 
     const completedEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
-      [initiateRequestCancelExternalWorkflowEvent, requestCancelExternalWorkflowEvent];
+      [
+        initiateRequestCancelExternalWorkflowEvent,
+        requestCancelExternalWorkflowEvent,
+      ];
 
     const completedCancelRequestGroup =
       getRequestCancelExternalWorkflowExecutionGroupFromEvents(completedEvent);
     expect(completedCancelRequestGroup.hasMissingEvents).toBe(false);
-
   });
 
   it('should return a group with groupType equal to RequestCancelExternalWorkflowExecution', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-request-cancel-external-workflow-execution-group-from-events.test.ts
@@ -23,33 +23,36 @@ describe('getRequestCancelExternalWorkflowExecutionGroupFromEvents', () => {
   });
 
   it('should return a group with hasMissingEvents set to true when any event is missing', () => {
-    const missingInitiatedEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
-      [requestCancelExternalWorkflowEvent];
+    const assertions: Array<{
+      name: string;
+      events: RequestCancelExternalWorkflowExecutionHistoryEvent[];
+      assertionValue: boolean;
+    }> = [
+      {
+        name: 'missingInitiatedEvent',
+        events: [requestCancelExternalWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingCloseEvent',
+        events: [initiateRequestCancelExternalWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'completedEvent',
+        events: [
+          initiateRequestCancelExternalWorkflowEvent,
+          requestCancelExternalWorkflowEvent,
+        ],
+        assertionValue: false,
+      },
+    ];
 
-    const incompletedCancelRequestGroup1 =
-      getRequestCancelExternalWorkflowExecutionGroupFromEvents(
-        missingInitiatedEvent
-      );
-    expect(incompletedCancelRequestGroup1.hasMissingEvents).toBe(true);
-
-    const missingCloseEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
-      [initiateRequestCancelExternalWorkflowEvent];
-
-    const incompletedCancelRequestGroup2 =
-      getRequestCancelExternalWorkflowExecutionGroupFromEvents(
-        missingCloseEvent
-      );
-    expect(incompletedCancelRequestGroup2.hasMissingEvents).toBe(true);
-
-    const completedEvent: RequestCancelExternalWorkflowExecutionHistoryEvent[] =
-      [
-        initiateRequestCancelExternalWorkflowEvent,
-        requestCancelExternalWorkflowEvent,
-      ];
-
-    const completedCancelRequestGroup =
-      getRequestCancelExternalWorkflowExecutionGroupFromEvents(completedEvent);
-    expect(completedCancelRequestGroup.hasMissingEvents).toBe(false);
+    assertions.forEach(({ name, events, assertionValue }) => {
+      const group =
+        getRequestCancelExternalWorkflowExecutionGroupFromEvents(events);
+      expect([name, group.hasMissingEvents]).toEqual([name, assertionValue]);
+    });
   });
 
   it('should return a group with groupType equal to RequestCancelExternalWorkflowExecution', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -30,20 +30,22 @@ describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
       getSignalExternalWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
     expect(incompletedSignalGroup1.hasMissingEvents).toBe(true);
 
-    const missingCloseEvent: SignalExternalWorkflowExecutionHistoryEvent[] =
-      [initiateSignalExternalWorkflowEvent];
+    const missingCloseEvent: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+    ];
 
     const incompletedSignalGroup2 =
       getSignalExternalWorkflowExecutionGroupFromEvents(missingCloseEvent);
     expect(incompletedSignalGroup2.hasMissingEvents).toBe(true);
 
-    const completedEvent: SignalExternalWorkflowExecutionHistoryEvent[] =
-      [initiateSignalExternalWorkflowEvent, signalExternalWorkflowEvent];
+    const completedEvent: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+      signalExternalWorkflowEvent,
+    ];
 
     const completedSignalGroup =
       getSignalExternalWorkflowExecutionGroupFromEvents(completedEvent);
     expect(completedSignalGroup.hasMissingEvents).toBe(false);
-
   });
 
   it('should return a group with groupType equal to SignalExternalWorkflowExecution', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -22,20 +22,28 @@ describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
     expect(group.label).toBe(expectedLabel);
   });
 
-  it('should return a group with hasMissingEvents set to true when initiate event is missing', () => {
-    const signalEvents: SignalExternalWorkflowExecutionHistoryEvent[] = [
-      signalExternalWorkflowEvent,
-    ];
-    const signalGroup =
-      getSignalExternalWorkflowExecutionGroupFromEvents(signalEvents);
-    expect(signalGroup.hasMissingEvents).toBe(true);
+  it('should return a group with hasMissingEvents set to true when any event is missing', () => {
+    const missingInitiatedEvent: SignalExternalWorkflowExecutionHistoryEvent[] =
+      [signalExternalWorkflowEvent];
 
-    const failEvents: SignalExternalWorkflowExecutionHistoryEvent[] = [
-      failSignalExternalWorkflowEvent,
-    ];
-    const failedGroup =
-      getSignalExternalWorkflowExecutionGroupFromEvents(failEvents);
-    expect(failedGroup.hasMissingEvents).toBe(true);
+    const incompletedSignalGroup1 =
+      getSignalExternalWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
+    expect(incompletedSignalGroup1.hasMissingEvents).toBe(true);
+
+    const missingCloseEvent: SignalExternalWorkflowExecutionHistoryEvent[] =
+      [initiateSignalExternalWorkflowEvent];
+
+    const incompletedSignalGroup2 =
+      getSignalExternalWorkflowExecutionGroupFromEvents(missingCloseEvent);
+    expect(incompletedSignalGroup2.hasMissingEvents).toBe(true);
+
+    const completedEvent: SignalExternalWorkflowExecutionHistoryEvent[] =
+      [initiateSignalExternalWorkflowEvent, signalExternalWorkflowEvent];
+
+    const completedSignalGroup =
+      getSignalExternalWorkflowExecutionGroupFromEvents(completedEvent);
+    expect(completedSignalGroup.hasMissingEvents).toBe(false);
+
   });
 
   it('should return a group with groupType equal to SignalExternalWorkflowExecution', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -23,29 +23,35 @@ describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
   });
 
   it('should return a group with hasMissingEvents set to true when any event is missing', () => {
-    const missingInitiatedEvent: SignalExternalWorkflowExecutionHistoryEvent[] =
-      [signalExternalWorkflowEvent];
-
-    const incompletedSignalGroup1 =
-      getSignalExternalWorkflowExecutionGroupFromEvents(missingInitiatedEvent);
-    expect(incompletedSignalGroup1.hasMissingEvents).toBe(true);
-
-    const missingCloseEvent: SignalExternalWorkflowExecutionHistoryEvent[] = [
-      initiateSignalExternalWorkflowEvent,
+    const assertions: Array<{
+      name: string;
+      events: SignalExternalWorkflowExecutionHistoryEvent[];
+      assertionValue: boolean;
+    }> = [
+      {
+        name: 'missingInitiatedEvent',
+        events: [signalExternalWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingCloseEvent',
+        events: [initiateSignalExternalWorkflowEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'completeEvents',
+        events: [
+          initiateSignalExternalWorkflowEvent,
+          signalExternalWorkflowEvent,
+        ],
+        assertionValue: false,
+      },
     ];
 
-    const incompletedSignalGroup2 =
-      getSignalExternalWorkflowExecutionGroupFromEvents(missingCloseEvent);
-    expect(incompletedSignalGroup2.hasMissingEvents).toBe(true);
-
-    const completedEvent: SignalExternalWorkflowExecutionHistoryEvent[] = [
-      initiateSignalExternalWorkflowEvent,
-      signalExternalWorkflowEvent,
-    ];
-
-    const completedSignalGroup =
-      getSignalExternalWorkflowExecutionGroupFromEvents(completedEvent);
-    expect(completedSignalGroup.hasMissingEvents).toBe(false);
+    assertions.forEach(({ name, events, assertionValue }) => {
+      const group = getSignalExternalWorkflowExecutionGroupFromEvents(events);
+      expect([name, group.hasMissingEvents]).toEqual([name, assertionValue]);
+    });
   });
 
   it('should return a group with groupType equal to SignalExternalWorkflowExecution', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -20,14 +20,30 @@ describe('getTimerGroupFromEvents', () => {
     expect(group.label).toBe(expectedLabel);
   });
 
-  it('should return a group with hasMissingEvents set to true when start event is missing', () => {
-    const fireEvents: TimerHistoryEvent[] = [fireTimerTaskEvent];
-    const firedTimerGroup = getTimerGroupFromEvents(fireEvents);
-    expect(firedTimerGroup.hasMissingEvents).toBe(true);
+  it('should return a group with hasMissingEvents set to true when any event is missing', () => {
+    const missingStartEvent: TimerHistoryEvent[] =
+      [fireTimerTaskEvent];
 
-    const cancelEvents: TimerHistoryEvent[] = [cancelTimerTaskEvent];
-    const canceledTimerGroup = getTimerGroupFromEvents(cancelEvents);
-    expect(canceledTimerGroup.hasMissingEvents).toBe(true);
+    const incompletedTimerGroup1 =
+      getTimerGroupFromEvents(missingStartEvent);
+    expect(incompletedTimerGroup1.hasMissingEvents).toBe(true);
+
+
+    const missingCloseEvent: TimerHistoryEvent[] =
+      [startTimerTaskEvent];
+
+    const incompletedTimerGroup2 =
+      getTimerGroupFromEvents(missingCloseEvent);
+    expect(incompletedTimerGroup2.hasMissingEvents).toBe(true);
+
+    
+    const completedEvent: TimerHistoryEvent[] =
+      [startTimerTaskEvent, cancelTimerTaskEvent];
+
+    const completedTimerGroup =
+      getTimerGroupFromEvents(completedEvent);
+    expect(completedTimerGroup.hasMissingEvents).toBe(false);
+
   });
 
   it('should return a group with groupType equal to Timer', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -21,23 +21,32 @@ describe('getTimerGroupFromEvents', () => {
   });
 
   it('should return a group with hasMissingEvents set to true when any event is missing', () => {
-    const missingStartEvent: TimerHistoryEvent[] = [fireTimerTaskEvent];
-
-    const incompletedTimerGroup1 = getTimerGroupFromEvents(missingStartEvent);
-    expect(incompletedTimerGroup1.hasMissingEvents).toBe(true);
-
-    const missingCloseEvent: TimerHistoryEvent[] = [startTimerTaskEvent];
-
-    const incompletedTimerGroup2 = getTimerGroupFromEvents(missingCloseEvent);
-    expect(incompletedTimerGroup2.hasMissingEvents).toBe(true);
-
-    const completedEvent: TimerHistoryEvent[] = [
-      startTimerTaskEvent,
-      cancelTimerTaskEvent,
+    const assertions: Array<{
+      name: string;
+      events: TimerHistoryEvent[];
+      assertionValue: boolean;
+    }> = [
+      {
+        name: 'missingStartEvent',
+        events: [fireTimerTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'missingCloseEvent',
+        events: [startTimerTaskEvent],
+        assertionValue: true,
+      },
+      {
+        name: 'completeEvents',
+        events: [startTimerTaskEvent, fireTimerTaskEvent],
+        assertionValue: false,
+      },
     ];
 
-    const completedTimerGroup = getTimerGroupFromEvents(completedEvent);
-    expect(completedTimerGroup.hasMissingEvents).toBe(false);
+    assertions.forEach(({ name, events, assertionValue }) => {
+      const group = getTimerGroupFromEvents(events);
+      expect([name, group.hasMissingEvents]).toEqual([name, assertionValue]);
+    });
   });
 
   it('should return a group with groupType equal to Timer', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -21,29 +21,23 @@ describe('getTimerGroupFromEvents', () => {
   });
 
   it('should return a group with hasMissingEvents set to true when any event is missing', () => {
-    const missingStartEvent: TimerHistoryEvent[] =
-      [fireTimerTaskEvent];
+    const missingStartEvent: TimerHistoryEvent[] = [fireTimerTaskEvent];
 
-    const incompletedTimerGroup1 =
-      getTimerGroupFromEvents(missingStartEvent);
+    const incompletedTimerGroup1 = getTimerGroupFromEvents(missingStartEvent);
     expect(incompletedTimerGroup1.hasMissingEvents).toBe(true);
 
+    const missingCloseEvent: TimerHistoryEvent[] = [startTimerTaskEvent];
 
-    const missingCloseEvent: TimerHistoryEvent[] =
-      [startTimerTaskEvent];
-
-    const incompletedTimerGroup2 =
-      getTimerGroupFromEvents(missingCloseEvent);
+    const incompletedTimerGroup2 = getTimerGroupFromEvents(missingCloseEvent);
     expect(incompletedTimerGroup2.hasMissingEvents).toBe(true);
 
-    
-    const completedEvent: TimerHistoryEvent[] =
-      [startTimerTaskEvent, cancelTimerTaskEvent];
+    const completedEvent: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      cancelTimerTaskEvent,
+    ];
 
-    const completedTimerGroup =
-      getTimerGroupFromEvents(completedEvent);
+    const completedTimerGroup = getTimerGroupFromEvents(completedEvent);
     expect(completedTimerGroup.hasMissingEvents).toBe(false);
-
   });
 
   it('should return a group with groupType equal to Timer', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -37,8 +37,9 @@ export default function getActivityGroupFromEvents(
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  const hasMissingEvents =
-    !scheduleEvent || !(timeoutEvent || (startEvent && closeEvent));
+  const hasAllTimeoutEvents = scheduleEvent && timeoutEvent;
+  const hasAllCloseEvents = scheduleEvent && startEvent && closeEvent;
+  const hasMissingEvents = !hasAllTimeoutEvents && !hasAllCloseEvents;
 
   // getting group label
   if (scheduleEvent && scheduleAttr in scheduleEvent) {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -14,28 +14,31 @@ export default function getActivityGroupFromEvents(
   const badges = [];
 
   const scheduleAttr = 'activityTaskScheduledEventAttributes';
+  const timeoutAttr = 'activityTaskTimedOutEventAttributes';
   const startAttr = 'activityTaskStartedEventAttributes';
   const pendingStartAttr = 'pendingActivityTaskStartEventAttributes';
   const closeAttrs = [
     'activityTaskCompletedEventAttributes',
     'activityTaskFailedEventAttributes',
-    'activityTaskTimedOutEventAttributes',
     'activityTaskCanceledEventAttributes',
   ];
 
   let scheduleEvent: ExtendedActivityHistoryEvent | undefined;
+  let timeoutEvent: ExtendedActivityHistoryEvent | undefined;
   let startEvent: ExtendedActivityHistoryEvent | undefined;
   let pendingStartEvent: ExtendedActivityHistoryEvent | undefined;
   let closeEvent: ExtendedActivityHistoryEvent | undefined;
 
   events.forEach((e) => {
     if (e.attributes === scheduleAttr) scheduleEvent = e;
+    if (e.attributes === timeoutAttr) timeoutEvent = e;
     if (e.attributes === startAttr) startEvent = e;
     if (e.attributes === pendingStartAttr) pendingStartEvent = e;
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  const hasMissingEvents = !scheduleEvent || !startEvent || !closeEvent;
+  const hasMissingEvents =
+    !scheduleEvent || !(timeoutEvent || (startEvent && closeEvent));
 
   // getting group label
   if (scheduleEvent && scheduleAttr in scheduleEvent) {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -20,8 +20,8 @@ export default function getActivityGroupFromEvents(
     'activityTaskCompletedEventAttributes',
     'activityTaskFailedEventAttributes',
     'activityTaskTimedOutEventAttributes',
-    'activityTaskCanceledEventAttributes'
-  ]
+    'activityTaskCanceledEventAttributes',
+  ];
 
   let scheduleEvent: ExtendedActivityHistoryEvent | undefined;
   let startEvent: ExtendedActivityHistoryEvent | undefined;
@@ -36,7 +36,7 @@ export default function getActivityGroupFromEvents(
   });
 
   const hasMissingEvents = !scheduleEvent || !startEvent || !closeEvent;
-  
+
   // getting group label
   if (scheduleEvent && scheduleAttr in scheduleEvent) {
     label = `Activity ${scheduleEvent[scheduleAttr]?.activityId}: ${scheduleEvent[scheduleAttr]?.activityType?.name}`;

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -22,7 +22,7 @@ export default function getChildWorkflowExecutionGroupFromEvents(
     'childWorkflowExecutionCanceledEventAttributes',
     'childWorkflowExecutionTimedOutEventAttributes',
     'childWorkflowExecutionTerminatedEventAttributes',
-  ]
+  ];
 
   let initiatedEvent: ChildWorkflowExecutionHistoryEvent | undefined;
   let startFailedEvent: ChildWorkflowExecutionHistoryEvent | undefined;
@@ -36,8 +36,8 @@ export default function getChildWorkflowExecutionGroupFromEvents(
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  const hasMissingEvents = !initiatedEvent || !(startFailedEvent || (startEvent && closeEvent));
-
+  const hasMissingEvents =
+    !initiatedEvent || !(startFailedEvent || (startEvent && closeEvent));
 
   const label = childWorkflowName
     ? `Child Workflow: ${childWorkflowName}`
@@ -45,32 +45,32 @@ export default function getChildWorkflowExecutionGroupFromEvents(
   const groupType = 'ChildWorkflowExecution';
 
   const eventToLabel: HistoryGroupEventToStringMap<ChildWorkflowExecutionHistoryGroup> =
-  {
-    startChildWorkflowExecutionInitiatedEventAttributes: 'Initiated',
-    startChildWorkflowExecutionFailedEventAttributes: 'Initiation failed',
-    childWorkflowExecutionStartedEventAttributes: 'Started',
-    childWorkflowExecutionCompletedEventAttributes: 'Completed',
-    childWorkflowExecutionFailedEventAttributes: 'Failed',
-    childWorkflowExecutionCanceledEventAttributes: 'Canceled',
-    childWorkflowExecutionTimedOutEventAttributes: 'Timed out',
-    childWorkflowExecutionTerminatedEventAttributes: 'Terminated',
-  };
+    {
+      startChildWorkflowExecutionInitiatedEventAttributes: 'Initiated',
+      startChildWorkflowExecutionFailedEventAttributes: 'Initiation failed',
+      childWorkflowExecutionStartedEventAttributes: 'Started',
+      childWorkflowExecutionCompletedEventAttributes: 'Completed',
+      childWorkflowExecutionFailedEventAttributes: 'Failed',
+      childWorkflowExecutionCanceledEventAttributes: 'Canceled',
+      childWorkflowExecutionTimedOutEventAttributes: 'Timed out',
+      childWorkflowExecutionTerminatedEventAttributes: 'Terminated',
+    };
   const eventToStatus: HistoryGroupEventToStatusMap<ChildWorkflowExecutionHistoryGroup> =
-  {
-    startChildWorkflowExecutionInitiatedEventAttributes: (
-      _,
-      events,
-      index
-    ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
-    startChildWorkflowExecutionFailedEventAttributes: 'FAILED',
-    childWorkflowExecutionStartedEventAttributes: (_, events, index) =>
-      index < events.length - 1 ? 'COMPLETED' : 'ONGOING',
-    childWorkflowExecutionCompletedEventAttributes: 'COMPLETED',
-    childWorkflowExecutionFailedEventAttributes: 'FAILED',
-    childWorkflowExecutionCanceledEventAttributes: 'CANCELED',
-    childWorkflowExecutionTimedOutEventAttributes: 'FAILED',
-    childWorkflowExecutionTerminatedEventAttributes: 'FAILED',
-  };
+    {
+      startChildWorkflowExecutionInitiatedEventAttributes: (
+        _,
+        events,
+        index
+      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+      startChildWorkflowExecutionFailedEventAttributes: 'FAILED',
+      childWorkflowExecutionStartedEventAttributes: (_, events, index) =>
+        index < events.length - 1 ? 'COMPLETED' : 'ONGOING',
+      childWorkflowExecutionCompletedEventAttributes: 'COMPLETED',
+      childWorkflowExecutionFailedEventAttributes: 'FAILED',
+      childWorkflowExecutionCanceledEventAttributes: 'CANCELED',
+      childWorkflowExecutionTimedOutEventAttributes: 'FAILED',
+      childWorkflowExecutionTerminatedEventAttributes: 'FAILED',
+    };
 
   return {
     label,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -36,8 +36,9 @@ export default function getChildWorkflowExecutionGroupFromEvents(
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  const hasMissingEvents =
-    !initiatedEvent || !(startFailedEvent || (startEvent && closeEvent));
+  const hasAllFailureEvents = initiatedEvent && startFailedEvent;
+  const hasAllCloseEvents = initiatedEvent && startEvent && closeEvent;
+  const hasMissingEvents = !hasAllFailureEvents && !hasAllCloseEvents;
 
   const label = childWorkflowName
     ? `Child Workflow: ${childWorkflowName}`

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -16,25 +16,28 @@ export default function getDecisionGroupFromEvents(
   const pendingScheduleAttr = 'pendingDecisionTaskScheduleEventAttributes';
   const scheduleAttr = 'decisionTaskScheduledEventAttributes';
   const startAttr = 'decisionTaskStartedEventAttributes';
+  const timeoutAttr = 'decisionTaskTimedOutEventAttributes';
   const closeAttrs = [
     'decisionTaskCompletedEventAttributes',
     'decisionTaskFailedEventAttributes',
-    'decisionTaskTimedOutEventAttributes',
   ];
 
   let scheduleEvent: ExtendedDecisionHistoryEvent | undefined;
   let pendingScheduleEvent: ExtendedDecisionHistoryEvent | undefined;
+  let timeoutEvent: ExtendedDecisionHistoryEvent | undefined;
   let startEvent: ExtendedDecisionHistoryEvent | undefined;
   let closeEvent: ExtendedDecisionHistoryEvent | undefined;
 
   events.forEach((e) => {
     if (e.attributes === pendingScheduleAttr) pendingScheduleEvent = e;
     if (e.attributes === scheduleAttr) scheduleEvent = e;
+    if (e.attributes === timeoutAttr) timeoutEvent = e;
     if (e.attributes === startAttr) startEvent = e;
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  const hasMissingEvents = !scheduleEvent || !startEvent || !closeEvent;
+  const hasMissingEvents =
+    !scheduleEvent || !(timeoutEvent || (startEvent && closeEvent));
 
   let retryAttemptNumber = 0;
   if (

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -20,7 +20,7 @@ export default function getDecisionGroupFromEvents(
     'decisionTaskCompletedEventAttributes',
     'decisionTaskFailedEventAttributes',
     'decisionTaskTimedOutEventAttributes',
-  ]
+  ];
 
   let scheduleEvent: ExtendedDecisionHistoryEvent | undefined;
   let pendingScheduleEvent: ExtendedDecisionHistoryEvent | undefined;
@@ -34,7 +34,7 @@ export default function getDecisionGroupFromEvents(
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  const hasMissingEvents =  !scheduleEvent || !startEvent || !closeEvent;
+  const hasMissingEvents = !scheduleEvent || !startEvent || !closeEvent;
 
   let retryAttemptNumber = 0;
   if (

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -10,37 +10,39 @@ export default function getDecisionGroupFromEvents(
   events: ExtendedDecisionHistoryEvent[]
 ): DecisionHistoryGroup {
   const label = 'Decision Task';
-  let hasMissingEvents = false;
   const groupType = 'Decision';
   const badges = [];
 
-  const firstEvent = events[0];
+  const pendingScheduleAttr = 'pendingDecisionTaskScheduleEventAttributes';
   const scheduleAttr = 'decisionTaskScheduledEventAttributes';
-  const pendingStartAttr = 'pendingDecisionTaskScheduleEventAttributes';
+  const startAttr = 'decisionTaskStartedEventAttributes';
+  const closeAttrs = [
+    'decisionTaskCompletedEventAttributes',
+    'decisionTaskFailedEventAttributes',
+    'decisionTaskTimedOutEventAttributes',
+  ]
 
   let scheduleEvent: ExtendedDecisionHistoryEvent | undefined;
   let pendingScheduleEvent: ExtendedDecisionHistoryEvent | undefined;
+  let startEvent: ExtendedDecisionHistoryEvent | undefined;
+  let closeEvent: ExtendedDecisionHistoryEvent | undefined;
 
   events.forEach((e) => {
+    if (e.attributes === pendingScheduleAttr) pendingScheduleEvent = e;
     if (e.attributes === scheduleAttr) scheduleEvent = e;
-    if (e.attributes === pendingStartAttr) pendingScheduleEvent = e;
+    if (e.attributes === startAttr) startEvent = e;
+    if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  if (
-    firstEvent.attributes !== 'decisionTaskScheduledEventAttributes' &&
-    firstEvent.attributes !== 'pendingDecisionTaskScheduleEventAttributes'
-  ) {
-    hasMissingEvents = true;
-  }
+  const hasMissingEvents =  !scheduleEvent || !startEvent || !closeEvent;
 
   let retryAttemptNumber = 0;
-
   if (
     pendingScheduleEvent &&
-    pendingStartAttr in pendingScheduleEvent &&
-    pendingScheduleEvent[pendingStartAttr]?.attempt
+    pendingScheduleAttr in pendingScheduleEvent &&
+    pendingScheduleEvent[pendingScheduleAttr]?.attempt
   ) {
-    retryAttemptNumber = pendingScheduleEvent[pendingStartAttr].attempt;
+    retryAttemptNumber = pendingScheduleEvent[pendingScheduleAttr].attempt;
   }
 
   if (

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -36,8 +36,9 @@ export default function getDecisionGroupFromEvents(
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-  const hasMissingEvents =
-    !scheduleEvent || !(timeoutEvent || (startEvent && closeEvent));
+  const hasAllTimeoutEvents = scheduleEvent && timeoutEvent;
+  const hasAllCloseEvents = scheduleEvent && startEvent && closeEvent;
+  const hasMissingEvents = !hasAllTimeoutEvents && !hasAllCloseEvents;
 
   let retryAttemptNumber = 0;
   if (

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-request-cancel-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-request-cancel-external-workflow-execution-group-from-events.ts
@@ -10,36 +10,42 @@ export default function getRequestCancelExternalWorkflowExecutionGroupFromEvents
   events: RequestCancelExternalWorkflowExecutionHistoryEvent[]
 ): RequestCancelExternalWorkflowExecutionHistoryGroup {
   const label = 'Request Cancel External Workflow';
-  let hasMissingEvents = false;
   const groupType = 'RequestCancelExternalWorkflowExecution';
 
-  const firstEvent = events[0];
+  const initiatedAttr = 'requestCancelExternalWorkflowExecutionInitiatedEventAttributes';
+  const closeAttrs = [
+    'requestCancelExternalWorkflowExecutionFailedEventAttributes',
+    'externalWorkflowExecutionCancelRequestedEventAttributes',
+  ]
 
-  if (
-    firstEvent.attributes !==
-    'requestCancelExternalWorkflowExecutionInitiatedEventAttributes'
-  ) {
-    hasMissingEvents = true;
-  }
+  let initiatedEvent: RequestCancelExternalWorkflowExecutionHistoryEvent | undefined;
+  let closeEvent: RequestCancelExternalWorkflowExecutionHistoryEvent | undefined;
+
+  events.forEach((e) => {
+    if (e.attributes === initiatedAttr) initiatedEvent = e;
+    if (closeAttrs.includes(e.attributes)) closeEvent = e;
+  });
+
+  const hasMissingEvents = !initiatedEvent || !closeEvent;
 
   const eventToLabel: HistoryGroupEventToStringMap<RequestCancelExternalWorkflowExecutionHistoryGroup> =
-    {
-      requestCancelExternalWorkflowExecutionInitiatedEventAttributes:
-        'Initiated',
-      requestCancelExternalWorkflowExecutionFailedEventAttributes: 'Failed',
-      externalWorkflowExecutionCancelRequestedEventAttributes: 'Requested',
-    };
+  {
+    requestCancelExternalWorkflowExecutionInitiatedEventAttributes:
+      'Initiated',
+    requestCancelExternalWorkflowExecutionFailedEventAttributes: 'Failed',
+    externalWorkflowExecutionCancelRequestedEventAttributes: 'Requested',
+  };
 
   const eventToStatus: HistoryGroupEventToStatusMap<RequestCancelExternalWorkflowExecutionHistoryGroup> =
-    {
-      requestCancelExternalWorkflowExecutionInitiatedEventAttributes: (
-        _,
-        events,
-        index
-      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
-      requestCancelExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
-      externalWorkflowExecutionCancelRequestedEventAttributes: 'COMPLETED',
-    };
+  {
+    requestCancelExternalWorkflowExecutionInitiatedEventAttributes: (
+      _,
+      events,
+      index
+    ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+    requestCancelExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
+    externalWorkflowExecutionCancelRequestedEventAttributes: 'COMPLETED',
+  };
 
   return {
     label,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-request-cancel-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-request-cancel-external-workflow-execution-group-from-events.ts
@@ -12,14 +12,19 @@ export default function getRequestCancelExternalWorkflowExecutionGroupFromEvents
   const label = 'Request Cancel External Workflow';
   const groupType = 'RequestCancelExternalWorkflowExecution';
 
-  const initiatedAttr = 'requestCancelExternalWorkflowExecutionInitiatedEventAttributes';
+  const initiatedAttr =
+    'requestCancelExternalWorkflowExecutionInitiatedEventAttributes';
   const closeAttrs = [
     'requestCancelExternalWorkflowExecutionFailedEventAttributes',
     'externalWorkflowExecutionCancelRequestedEventAttributes',
-  ]
+  ];
 
-  let initiatedEvent: RequestCancelExternalWorkflowExecutionHistoryEvent | undefined;
-  let closeEvent: RequestCancelExternalWorkflowExecutionHistoryEvent | undefined;
+  let initiatedEvent:
+    | RequestCancelExternalWorkflowExecutionHistoryEvent
+    | undefined;
+  let closeEvent:
+    | RequestCancelExternalWorkflowExecutionHistoryEvent
+    | undefined;
 
   events.forEach((e) => {
     if (e.attributes === initiatedAttr) initiatedEvent = e;
@@ -29,23 +34,23 @@ export default function getRequestCancelExternalWorkflowExecutionGroupFromEvents
   const hasMissingEvents = !initiatedEvent || !closeEvent;
 
   const eventToLabel: HistoryGroupEventToStringMap<RequestCancelExternalWorkflowExecutionHistoryGroup> =
-  {
-    requestCancelExternalWorkflowExecutionInitiatedEventAttributes:
-      'Initiated',
-    requestCancelExternalWorkflowExecutionFailedEventAttributes: 'Failed',
-    externalWorkflowExecutionCancelRequestedEventAttributes: 'Requested',
-  };
+    {
+      requestCancelExternalWorkflowExecutionInitiatedEventAttributes:
+        'Initiated',
+      requestCancelExternalWorkflowExecutionFailedEventAttributes: 'Failed',
+      externalWorkflowExecutionCancelRequestedEventAttributes: 'Requested',
+    };
 
   const eventToStatus: HistoryGroupEventToStatusMap<RequestCancelExternalWorkflowExecutionHistoryGroup> =
-  {
-    requestCancelExternalWorkflowExecutionInitiatedEventAttributes: (
-      _,
-      events,
-      index
-    ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
-    requestCancelExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
-    externalWorkflowExecutionCancelRequestedEventAttributes: 'COMPLETED',
-  };
+    {
+      requestCancelExternalWorkflowExecutionInitiatedEventAttributes: (
+        _,
+        events,
+        index
+      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+      requestCancelExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
+      externalWorkflowExecutionCancelRequestedEventAttributes: 'COMPLETED',
+    };
 
   return {
     label,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
@@ -10,42 +10,46 @@ export default function getSignalExternalWorkflowExecutionGroupFromEvents(
   events: SignalExternalWorkflowExecutionHistoryEvent[]
 ): SignalExternalWorkflowExecutionHistoryGroup {
   let label = '';
-  let hasMissingEvents = false;
   const groupType = 'SignalExternalWorkflowExecution';
 
-  const initiationEventAttr =
+  const initiatedAttr =
     'signalExternalWorkflowExecutionInitiatedEventAttributes';
-  const initiationEvent = events.find(
-    ({ attributes }) => attributes === initiationEventAttr
-  );
-  const firstEvent = events[0];
 
-  if (initiationEvent) {
-    label = `External Workflow Signal: ${initiationEvent[initiationEventAttr]?.signalName}`;
+  const closeAttrs = [
+    'signalExternalWorkflowExecutionFailedEventAttributes',
+    'externalWorkflowExecutionSignaledEventAttributes',
+  ]
+
+  let initiatedEvent: SignalExternalWorkflowExecutionHistoryEvent | undefined;
+  let closeEvent: SignalExternalWorkflowExecutionHistoryEvent | undefined;
+
+  events.forEach((e) => {
+    if (e.attributes === initiatedAttr) initiatedEvent = e;
+    if (closeAttrs.includes(e.attributes)) closeEvent = e;
+  });
+
+  const hasMissingEvents = !initiatedEvent || !closeEvent;
+
+  if (initiatedEvent) {
+    label = `External Workflow Signal: ${initiatedEvent[initiatedAttr]?.signalName}`;
   }
 
-  if (
-    firstEvent.attributes !==
-    'signalExternalWorkflowExecutionInitiatedEventAttributes'
-  ) {
-    hasMissingEvents = true;
-  }
   const eventToLabel: HistoryGroupEventToStringMap<SignalExternalWorkflowExecutionHistoryGroup> =
-    {
-      signalExternalWorkflowExecutionInitiatedEventAttributes: 'Initiated',
-      signalExternalWorkflowExecutionFailedEventAttributes: 'Failed',
-      externalWorkflowExecutionSignaledEventAttributes: 'Signaled',
-    };
+  {
+    signalExternalWorkflowExecutionInitiatedEventAttributes: 'Initiated',
+    signalExternalWorkflowExecutionFailedEventAttributes: 'Failed',
+    externalWorkflowExecutionSignaledEventAttributes: 'Signaled',
+  };
   const eventToStatus: HistoryGroupEventToStatusMap<SignalExternalWorkflowExecutionHistoryGroup> =
-    {
-      signalExternalWorkflowExecutionInitiatedEventAttributes: (
-        _,
-        events,
-        index
-      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
-      signalExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
-      externalWorkflowExecutionSignaledEventAttributes: 'COMPLETED',
-    };
+  {
+    signalExternalWorkflowExecutionInitiatedEventAttributes: (
+      _,
+      events,
+      index
+    ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+    signalExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
+    externalWorkflowExecutionSignaledEventAttributes: 'COMPLETED',
+  };
 
   return {
     label,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
@@ -18,7 +18,7 @@ export default function getSignalExternalWorkflowExecutionGroupFromEvents(
   const closeAttrs = [
     'signalExternalWorkflowExecutionFailedEventAttributes',
     'externalWorkflowExecutionSignaledEventAttributes',
-  ]
+  ];
 
   let initiatedEvent: SignalExternalWorkflowExecutionHistoryEvent | undefined;
   let closeEvent: SignalExternalWorkflowExecutionHistoryEvent | undefined;
@@ -35,21 +35,21 @@ export default function getSignalExternalWorkflowExecutionGroupFromEvents(
   }
 
   const eventToLabel: HistoryGroupEventToStringMap<SignalExternalWorkflowExecutionHistoryGroup> =
-  {
-    signalExternalWorkflowExecutionInitiatedEventAttributes: 'Initiated',
-    signalExternalWorkflowExecutionFailedEventAttributes: 'Failed',
-    externalWorkflowExecutionSignaledEventAttributes: 'Signaled',
-  };
+    {
+      signalExternalWorkflowExecutionInitiatedEventAttributes: 'Initiated',
+      signalExternalWorkflowExecutionFailedEventAttributes: 'Failed',
+      externalWorkflowExecutionSignaledEventAttributes: 'Signaled',
+    };
   const eventToStatus: HistoryGroupEventToStatusMap<SignalExternalWorkflowExecutionHistoryGroup> =
-  {
-    signalExternalWorkflowExecutionInitiatedEventAttributes: (
-      _,
-      events,
-      index
-    ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
-    signalExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
-    externalWorkflowExecutionSignaledEventAttributes: 'COMPLETED',
-  };
+    {
+      signalExternalWorkflowExecutionInitiatedEventAttributes: (
+        _,
+        events,
+        index
+      ) => (index < events.length - 1 ? 'COMPLETED' : 'WAITING'),
+      signalExternalWorkflowExecutionFailedEventAttributes: 'FAILED',
+      externalWorkflowExecutionSignaledEventAttributes: 'COMPLETED',
+    };
 
   return {
     label,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
@@ -12,12 +12,28 @@ export default function getTimerGroupFromEvents(
   const firstEvent = events[0];
 
   const label = `Timer ${firstEvent[firstEvent.attributes]?.timerId}`; // TODO add duration
-  let hasMissingEvents = false;
   const groupType = 'Timer';
 
-  if (firstEvent.attributes !== 'timerStartedEventAttributes') {
-    hasMissingEvents = true;
-  }
+  const startedAttr =
+    'timerStartedEventAttributes';
+
+  const closeAttrs = [
+    'timerFiredEventAttributes',
+    'timerCanceledEventAttributes',
+  ]
+
+  let startedEvent: TimerHistoryEvent | undefined;
+  let closeEvent: TimerHistoryEvent | undefined;
+
+  events.forEach((e) => {
+    if (e.attributes === startedAttr) startedEvent = e;
+    if (closeAttrs.includes(e.attributes)) closeEvent = e;
+  });
+
+
+  const hasMissingEvents = !startedEvent || !closeEvent;
+
+
   const eventToLabel: HistoryGroupEventToStringMap<TimerHistoryGroup> = {
     timerStartedEventAttributes: 'Started',
     timerFiredEventAttributes: 'Fired',

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
@@ -14,13 +14,12 @@ export default function getTimerGroupFromEvents(
   const label = `Timer ${firstEvent[firstEvent.attributes]?.timerId}`; // TODO add duration
   const groupType = 'Timer';
 
-  const startedAttr =
-    'timerStartedEventAttributes';
+  const startedAttr = 'timerStartedEventAttributes';
 
   const closeAttrs = [
     'timerFiredEventAttributes',
     'timerCanceledEventAttributes',
-  ]
+  ];
 
   let startedEvent: TimerHistoryEvent | undefined;
   let closeEvent: TimerHistoryEvent | undefined;
@@ -30,9 +29,7 @@ export default function getTimerGroupFromEvents(
     if (closeAttrs.includes(e.attributes)) closeEvent = e;
   });
 
-
   const hasMissingEvents = !startedEvent || !closeEvent;
-
 
   const eventToLabel: HistoryGroupEventToStringMap<TimerHistoryGroup> = {
     timerStartedEventAttributes: 'Started',


### PR DESCRIPTION
### Summary
Change the way for calculating `hasMissingEvents` to be true if any of the complete expected set of events is missing in the group. Previously this flag was calculated as true if the first event of the group is missing.

This is part of a bigger change for showing loading indicators if the whole group events is not fetched yet.