### PR TITLE
Create useThrottledState

### DIFF
--- a/src/hooks/__tests__/use-throttled-state.test.tsx
+++ b/src/hooks/__tests__/use-throttled-state.test.tsx
@@ -66,7 +66,9 @@ describe('useThrottledState', () => {
   });
 
   it('should throttle updating state', async () => {
-    const { result } = renderHook(() => useThrottledState(0, 10000));
+    const { result } = renderHook(() =>
+      useThrottledState(0, 10000, defaultThrottleSettings)
+    );
     const setState = result.current[1];
 
     act(() => {

--- a/src/hooks/__tests__/use-throttled-state.test.tsx
+++ b/src/hooks/__tests__/use-throttled-state.test.tsx
@@ -1,0 +1,95 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import throttle from 'lodash/throttle';
+
+import useThrottledState from '../use-throttled-state';
+
+jest.mock('lodash/throttle', () => {
+  const original = jest.requireActual('lodash/throttle');
+  return jest.fn(original);
+});
+const mockedThrottle = throttle as jest.Mock;
+
+const defaultThrottleSettings = { leading: false, trailing: true };
+
+describe('useThrottledState', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedThrottle.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('should initialize with the given value', () => {
+    const { result } = renderHook(() => useThrottledState(0));
+    expect(result.current[0]).toBe(0);
+  });
+
+  it('should pass the correct settings to throttle', () => {
+    renderHook(() => useThrottledState(0, 1, defaultThrottleSettings));
+    expect(mockedThrottle).toHaveBeenCalledWith(expect.any(Function), 1, {
+      leading: false,
+      trailing: true,
+    });
+  });
+
+  it('should immediately update if executeImmediately is true', () => {
+    const { result } = renderHook(() =>
+      useThrottledState(0, 10000, defaultThrottleSettings)
+    );
+    const setState = result.current[1];
+
+    act(() => {
+      setState((prev) => prev + 1, true);
+    });
+
+    expect(result.current[0]).toBe(1);
+  });
+
+  it('should return the latest value if rerendered externaly', async () => {
+    const { result, rerender } = renderHook(() =>
+      useThrottledState(0, 10000, defaultThrottleSettings)
+    );
+    const setState = result.current[1];
+
+    act(() => {
+      setState((prev) => prev + 1);
+      setState((prev) => prev + 1);
+      setState((prev) => prev + 1);
+    });
+
+    expect(result.current[0]).toBe(0);
+    rerender();
+    expect(result.current[0]).toBe(3);
+  });
+
+  it('should throttle updating state', async () => {
+    const { result } = renderHook(() => useThrottledState(0, 10000));
+    const setState = result.current[1];
+
+    act(() => {
+      setState((prev) => prev + 1);
+      setState((prev) => prev + 1);
+      setState((prev) => prev + 1);
+    });
+
+    expect(result.current[0]).toBe(0);
+    jest.advanceTimersByTime(10000);
+    await waitFor(() => expect(result.current[0]).toBe(3));
+  });
+
+  it('should throw an error if non-function is passed to setState', () => {
+    const { result } = renderHook(() => useThrottledState(0));
+    const setState = result.current[1];
+
+    expect(() => {
+      act(() => {
+        //@ts-expect-error testing non functional arguments error
+        setState(1);
+      });
+    }).toThrow(
+      'useThrottledState setter function requires function as first argument'
+    );
+  });
+});

--- a/src/hooks/__tests__/use-throttled-state.test.tsx
+++ b/src/hooks/__tests__/use-throttled-state.test.tsx
@@ -28,10 +28,11 @@ describe('useThrottledState', () => {
 
   it('should pass the correct settings to throttle', () => {
     renderHook(() => useThrottledState(0, 1, defaultThrottleSettings));
-    expect(mockedThrottle).toHaveBeenCalledWith(expect.any(Function), 1, {
-      leading: false,
-      trailing: true,
-    });
+    expect(mockedThrottle).toHaveBeenCalledWith(
+      expect.any(Function),
+      1,
+      defaultThrottleSettings
+    );
   });
 
   it('should immediately update if executeImmediately is true', () => {

--- a/src/hooks/use-throttled-state.tsx
+++ b/src/hooks/use-throttled-state.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useState, useRef, useMemo, useEffect } from 'react';
+
+import type { ThrottleSettings } from 'lodash';
+import throttle from 'lodash/throttle';
+
+export default function useThrottledState<State>(
+  initValue: State,
+  throttleMillis = 700,
+  throttleOptions: ThrottleSettings = {}
+) {
+  const { leading, trailing } = throttleOptions;
+  const stateRef = useRef(initValue);
+  const [, setState] = useState<State>(initValue);
+
+  const throttledSetState = useMemo(
+    () => throttle(setState, throttleMillis, { leading, trailing }),
+    [setState, throttleMillis, leading, trailing]
+  );
+
+  // clear previous throttled events
+  useEffect(() => {
+    return () => throttledSetState.cancel();
+  }, [throttledSetState]);
+
+  const refSetState = useCallback(
+    (callback: (arg: State) => State, executeImmediately?: boolean): void => {
+      if (typeof callback !== 'function')
+        throw new Error(
+          'useThrottledState setter function requires function as first argument'
+        );
+      const newVal = callback(stateRef.current);
+      stateRef.current = newVal;
+      throttledSetState(newVal);
+      if (executeImmediately) {
+        throttledSetState.flush();
+      }
+    },
+    [throttledSetState]
+  );
+
+  return [stateRef.current, refSetState] as const;
+}


### PR DESCRIPTION
### Summary
Creating a hook to handle high rate state changes performantly. This hook make sure to always have a state that represents the latest changes using a `ref` while throttling the state re-renders base on the throttle period.


This change is part of i bigger change for fixing history group status, and this hook is used to keep the state of the currently viewed history groups.