### PR TITLE
Add support for multiple statuses to ListWorkflows route handler

### DIFF
--- a/src/route-handlers/list-workflows/helpers/__tests__/get-list-workflow-executions-query.test.ts
+++ b/src/route-handlers/list-workflows/helpers/__tests__/get-list-workflow-executions-query.test.ts
@@ -1,10 +1,14 @@
 import getListWorkflowExecutionsQuery from '../get-list-workflow-executions-query';
 
 describe('getListWorkflowExecutionsQuery', () => {
-  it('should return query', () => {
+  it('should return query to show various open and closed workflows', () => {
     const query = getListWorkflowExecutionsQuery({
       search: 'mocksearchterm',
-      workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED',
+      workflowStatuses: [
+        'WORKFLOW_EXECUTION_CLOSE_STATUS_TERMINATED',
+        'WORKFLOW_EXECUTION_CLOSE_STATUS_CANCELED',
+        'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID',
+      ],
       sortColumn: 'CloseTime',
       sortOrder: 'ASC',
       timeColumn: 'StartTime',
@@ -13,17 +17,6 @@ describe('getListWorkflowExecutionsQuery', () => {
     });
     expect(query).toEqual(
       '(WorkflowType = "mocksearchterm" OR WorkflowID = "mocksearchterm" OR RunID = "mocksearchterm") AND CloseStatus = 3 AND StartTime > "1712066100000000" AND StartTime <= "1712096100000000" ORDER BY CloseTime ASC'
-    );
-  });
-
-  it('should return query for running status', () => {
-    const query = getListWorkflowExecutionsQuery({
-      search: 'mocksearchterm',
-      timeColumn: 'StartTime',
-      workflowStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID',
-    });
-    expect(query).toEqual(
-      '(WorkflowType = "mocksearchterm" OR WorkflowID = "mocksearchterm" OR RunID = "mocksearchterm") AND CloseTime = missing ORDER BY StartTime DESC'
     );
   });
 

--- a/src/route-handlers/list-workflows/helpers/__tests__/get-list-workflow-executions-query.test.ts
+++ b/src/route-handlers/list-workflows/helpers/__tests__/get-list-workflow-executions-query.test.ts
@@ -16,7 +16,9 @@ describe('getListWorkflowExecutionsQuery', () => {
       timeRangeEnd: '1712096100000000',
     });
     expect(query).toEqual(
-      '(WorkflowType = "mocksearchterm" OR WorkflowID = "mocksearchterm" OR RunID = "mocksearchterm") AND CloseStatus = 3 AND StartTime > "1712066100000000" AND StartTime <= "1712096100000000" ORDER BY CloseTime ASC'
+      '(WorkflowType = "mocksearchterm" OR WorkflowID = "mocksearchterm" OR RunID = "mocksearchterm") AND ' +
+        '(CloseStatus = 3 OR CloseStatus = 2 OR CloseTime = missing) AND ' +
+        'StartTime > "1712066100000000" AND StartTime <= "1712096100000000" ORDER BY CloseTime ASC'
     );
   });
 

--- a/src/route-handlers/list-workflows/helpers/get-list-workflow-executions-query.ts
+++ b/src/route-handlers/list-workflows/helpers/get-list-workflow-executions-query.ts
@@ -42,7 +42,7 @@ export default function getListWorkflowExecutionsQuery({
   });
 
   if (workflowStatusQueries.length > 0) {
-    searchQueries.push(`(${workflowStatusQueries.join(' AND ')})`);
+    searchQueries.push(`(${workflowStatusQueries.join(' OR ')})`);
   }
 
   if (timeRangeStart) {

--- a/src/route-handlers/list-workflows/helpers/get-list-workflow-executions-query.ts
+++ b/src/route-handlers/list-workflows/helpers/get-list-workflow-executions-query.ts
@@ -6,7 +6,7 @@ import { type TimeColumn } from '../list-workflows.types';
 
 export default function getListWorkflowExecutionsQuery({
   search,
-  workflowStatus,
+  workflowStatuses,
   sortColumn,
   sortOrder,
   timeColumn,
@@ -14,7 +14,7 @@ export default function getListWorkflowExecutionsQuery({
   timeRangeEnd,
 }: {
   search?: string;
-  workflowStatus?: WorkflowStatus;
+  workflowStatuses?: Array<WorkflowStatus>;
   sortColumn?: string;
   sortOrder?: SortOrder;
   timeColumn: TimeColumn;
@@ -28,16 +28,21 @@ export default function getListWorkflowExecutionsQuery({
     );
   }
 
-  if (workflowStatus) {
-    if (workflowStatus === WORKFLOW_STATUSES.running) {
-      searchQueries.push('CloseTime = missing');
+  const workflowStatusQueries: Array<string> = [];
+  workflowStatuses?.forEach((status) => {
+    if (status === WORKFLOW_STATUSES.running) {
+      workflowStatusQueries.push('CloseTime = missing');
     } else {
-      searchQueries.push(
-        // Query CloseStatus is 0-indexed (and excludes INVALID)
+      workflowStatusQueries.push(
+        // Numerical query CloseStatus is 0-indexed (and excludes INVALID)
         // https://cadenceworkflow.io/docs/concepts/search-workflows/#query-capabilities
-        `CloseStatus = ${Object.values(WORKFLOW_STATUSES).indexOf(workflowStatus) - 1}`
+        `CloseStatus = ${Object.values(WORKFLOW_STATUSES).indexOf(status) - 1}`
       );
     }
+  });
+
+  if (workflowStatusQueries.length > 0) {
+    searchQueries.push(`(${workflowStatusQueries.join(' AND ')})`);
   }
 
   if (timeRangeStart) {

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import queryString from 'query-string';
 
 import decodeUrlParams from '@/utils/decode-url-params';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
@@ -22,7 +23,7 @@ export async function listWorkflows(
   const decodedParams = decodeUrlParams(requestParams.params) as RouteParams;
 
   const { data: queryParams, error } = listWorkflowsQueryParamSchema.safeParse(
-    Object.fromEntries(request.nextUrl.searchParams)
+    queryString.parse(request.nextUrl.searchParams.toString())
   );
   if (error) {
     return NextResponse.json(

--- a/src/route-handlers/list-workflows/list-workflows.ts
+++ b/src/route-handlers/list-workflows/list-workflows.ts
@@ -45,7 +45,7 @@ export async function listWorkflows(
         ? queryParams.query
         : getListWorkflowExecutionsQuery({
             search: queryParams.search,
-            workflowStatus: queryParams.status,
+            workflowStatuses: queryParams.statuses,
             sortColumn: queryParams.sortColumn,
             sortOrder: queryParams.sortOrder,
             timeColumn: queryParams.timeColumn,

--- a/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
+++ b/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
@@ -16,10 +16,12 @@ const listWorkflowsQueryParamSchema = z
     inputType: z.enum(['search', 'query']),
     search: z.string().trim().optional(),
     query: z.string().optional(),
-    status: z
-      .custom<WorkflowStatus>(isWorkflowStatus, {
-        message: 'Invalid workflow status',
-      })
+    statuses: z
+      .array(
+        z.custom<WorkflowStatus>(isWorkflowStatus, {
+          message: 'Invalid workflow status',
+        })
+      )
       .optional(),
     timeColumn: z
       .enum(['StartTime', 'CloseTime'])

--- a/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
+++ b/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
@@ -4,6 +4,11 @@ import { SORT_ORDERS } from '@/utils/sort-by';
 import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
+// TODO: this should go in a shared location
+const workflowStatusSchema = z.custom<WorkflowStatus>(isWorkflowStatus, {
+  message: 'Invalid workflow status',
+});
+
 const listWorkflowsQueryParamSchema = z
   .object({
     pageSize: z
@@ -17,11 +22,10 @@ const listWorkflowsQueryParamSchema = z
     search: z.string().trim().optional(),
     query: z.string().optional(),
     statuses: z
-      .array(
-        z.custom<WorkflowStatus>(isWorkflowStatus, {
-          message: 'Invalid workflow status',
-        })
-      )
+      .union([
+        workflowStatusSchema.transform((status) => [status]),
+        z.array(workflowStatusSchema),
+      ])
       .optional(),
     timeColumn: z
       .enum(['StartTime', 'CloseTime'])

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    status,
+    statuses,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,
@@ -39,7 +39,7 @@ export default function useListWorkflows({
         }
       : {
           search,
-          status,
+          statuses,
           sortColumn,
           sortOrder,
           timeRangeStart: timeRangeStart?.toISOString(),

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    statuses,
+    status,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,
@@ -39,7 +39,8 @@ export default function useListWorkflows({
         }
       : {
           search,
-          statuses,
+          // Temporary change, this will be removed in a follow-up
+          statuses: status ? [status] : [],
           sortColumn,
           sortOrder,
           timeRangeStart: timeRangeStart?.toISOString(),

--- a/src/views/shared/hooks/use-list-workflows.types.ts
+++ b/src/views/shared/hooks/use-list-workflows.types.ts
@@ -14,7 +14,7 @@ export type UseListWorkflowsParams = ListWorkflowsRouteParams & {
   inputType: WorkflowsHeaderInputType;
   listType: ListType;
   search?: string;
-  status?: WorkflowStatus;
+  statuses?: Array<WorkflowStatus>;
   timeRangeStart?: Date;
   timeRangeEnd?: Date;
   sortColumn?: string;

--- a/src/views/shared/hooks/use-list-workflows.types.ts
+++ b/src/views/shared/hooks/use-list-workflows.types.ts
@@ -14,7 +14,7 @@ export type UseListWorkflowsParams = ListWorkflowsRouteParams & {
   inputType: WorkflowsHeaderInputType;
   listType: ListType;
   search?: string;
-  statuses?: Array<WorkflowStatus>;
+  status?: WorkflowStatus;
   timeRangeStart?: Date;
   timeRangeEnd?: Date;
   sortColumn?: string;


### PR DESCRIPTION
## Summary
- Use queryString to parse query params (Object.fromEntries() does not work with array query params)
- Modify query params schema to support multiple statuses (and also transform the input in case there is only one query param)
- Modify the ListWorkflowExecutions query to support multiple workflow statuses
- Temporary: Pass an array of single status in useListWorkflows hook

## Test plan
Unit tests + ran locally: https://github.com/cadence-workflow/cadence-web/pull/844
