### PR TITLE
Add ListFilterMulti component

### DIFF
--- a/src/components/list-filter-multi/__tests__/list-filter-multi.test.tsx
+++ b/src/components/list-filter-multi/__tests__/list-filter-multi.test.tsx
@@ -55,7 +55,7 @@ describe(ListFilterMulti.name, () => {
       override: ['opt2'],
     });
 
-    const clearButton = screen.getByLabelText('Clear value');
+    const clearButton = screen.getByLabelText('Clear all');
     await user.click(clearButton);
 
     expect(mockOnChangeValues).toHaveBeenCalledWith(undefined);

--- a/src/components/list-filter-multi/__tests__/list-filter-multi.test.tsx
+++ b/src/components/list-filter-multi/__tests__/list-filter-multi.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { render, screen, userEvent } from '@/test-utils/rtl';
+import { userEvent, render, screen } from '@/test-utils/rtl';
 
-import ListFilter from '../list-filter';
+import ListFilterMulti from '../list-filter-multi';
 
 const MOCK_LIST_FILTER_LABELS = {
   opt1: 'Option 1',
@@ -12,7 +12,7 @@ const MOCK_LIST_FILTER_LABELS = {
 
 type MockListFilterOption = keyof typeof MOCK_LIST_FILTER_LABELS;
 
-describe(ListFilter.name, () => {
+describe(ListFilterMulti.name, () => {
   it('renders without errors', () => {
     setup({});
     expect(screen.getByRole('combobox')).toBeInTheDocument();
@@ -32,42 +32,48 @@ describe(ListFilter.name, () => {
   });
 
   it('calls the setQueryParams function when an option is selected', async () => {
-    const { user, mockOnChangeValue } = setup({});
+    const { user, mockOnChangeValues } = setup({});
 
     const selectFilter = screen.getByRole('combobox');
     await user.click(selectFilter);
 
-    const option = screen.getByText('Option 1');
-    await user.click(option);
+    const option1 = screen.getByText('Option 1');
+    await user.click(option1);
 
-    expect(mockOnChangeValue).toHaveBeenCalledWith('opt1');
+    expect(mockOnChangeValues).toHaveBeenCalledWith(['opt1']);
+
+    await user.click(selectFilter);
+
+    const option2 = screen.getByText('Option 2');
+    await user.click(option2);
+
+    expect(mockOnChangeValues).toHaveBeenCalledWith(['opt2']);
   });
 
   it('calls the setQueryParams function when the filter is cleared', async () => {
-    const { user, mockOnChangeValue } = setup({
-      override: 'opt2',
+    const { user, mockOnChangeValues } = setup({
+      override: ['opt2'],
     });
 
     const clearButton = screen.getByLabelText('Clear value');
     await user.click(clearButton);
 
-    expect(mockOnChangeValue).toHaveBeenCalledWith(undefined);
+    expect(mockOnChangeValues).toHaveBeenCalledWith(undefined);
   });
 });
 
-function setup({ override }: { override?: MockListFilterOption }) {
-  const mockOnChangeValue = jest.fn();
+function setup({ override }: { override?: Array<MockListFilterOption> }) {
+  const mockOnChangeValues = jest.fn();
   const user = userEvent.setup();
-
   render(
-    <ListFilter
+    <ListFilterMulti
       label="Mock label"
       placeholder="Mock placeholder"
-      value={override ?? undefined}
-      onChangeValue={mockOnChangeValue}
+      values={override ?? undefined}
+      onChangeValues={mockOnChangeValues}
       labelMap={MOCK_LIST_FILTER_LABELS}
     />
   );
 
-  return { user, mockOnChangeValue };
+  return { user, mockOnChangeValues };
 }

--- a/src/components/list-filter-multi/list-filter-multi.styles.ts
+++ b/src/components/list-filter-multi/list-filter-multi.styles.ts
@@ -1,0 +1,18 @@
+import { type Theme } from 'baseui';
+import type { FormControlOverrides } from 'baseui/form-control/types';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  selectFormControl: {
+    Label: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        ...$theme.typography.LabelXSmall,
+      }),
+    },
+    ControlContainer: {
+      style: (): StyleObject => ({
+        margin: '0px',
+      }),
+    },
+  } satisfies FormControlOverrides,
+};

--- a/src/components/list-filter-multi/list-filter-multi.tsx
+++ b/src/components/list-filter-multi/list-filter-multi.tsx
@@ -1,0 +1,42 @@
+'use client';
+import React from 'react';
+
+import { FormControl } from 'baseui/form-control';
+import { Select, SIZE } from 'baseui/select';
+
+import getOptionsFromLabelMap from '../list-filter/helpers/get-options-from-label-map';
+
+import { overrides } from './list-filter-multi.styles';
+import { type Props } from './list-filter-multi.types';
+
+export default function ListFilterMulti<T extends string>({
+  values,
+  onChangeValues,
+  labelMap,
+  label,
+  placeholder,
+}: Props<T>) {
+  const options = getOptionsFromLabelMap(labelMap);
+  const optionsValues = values?.map((value) => ({
+    id: value,
+    label: labelMap[value],
+  }));
+
+  return (
+    <FormControl label={label} overrides={overrides.selectFormControl}>
+      <Select
+        size={SIZE.compact}
+        value={optionsValues}
+        options={options}
+        onChange={(params) =>
+          onChangeValues(
+            params.value.length > 0
+              ? params.value.map((v) => v.id as T)
+              : undefined
+          )
+        }
+        placeholder={placeholder}
+      />
+    </FormControl>
+  );
+}

--- a/src/components/list-filter-multi/list-filter-multi.tsx
+++ b/src/components/list-filter-multi/list-filter-multi.tsx
@@ -25,6 +25,7 @@ export default function ListFilterMulti<T extends string>({
   return (
     <FormControl label={label} overrides={overrides.selectFormControl}>
       <Select
+        multi
         size={SIZE.compact}
         value={optionsValues}
         options={options}

--- a/src/components/list-filter-multi/list-filter-multi.types.ts
+++ b/src/components/list-filter-multi/list-filter-multi.types.ts
@@ -1,0 +1,7 @@
+export type Props<T extends string> = {
+  values: Array<T> | undefined;
+  onChangeValues: (values: Array<T> | undefined) => void;
+  labelMap: Record<T, string>;
+  label: string;
+  placeholder: string;
+};

--- a/src/components/list-filter/list-filter.tsx
+++ b/src/components/list-filter/list-filter.tsx
@@ -16,7 +16,9 @@ export default function ListFilter<T extends string>({
   placeholder,
 }: Props<T>) {
   const options = getOptionsFromLabelMap(labelMap);
-  const optionValue = options.filter((option) => option.id === value);
+  const optionValue = value
+    ? [{ id: value, label: labelMap[value] }]
+    : undefined;
 
   return (
     <FormControl label={label} overrides={overrides.selectFormControl}>

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    statuses,
+    status,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    status,
+    statuses,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,

--- a/src/views/shared/hooks/use-list-workflows.types.ts
+++ b/src/views/shared/hooks/use-list-workflows.types.ts
@@ -14,7 +14,7 @@ export type UseListWorkflowsParams = ListWorkflowsRouteParams & {
   inputType: WorkflowsHeaderInputType;
   listType: ListType;
   search?: string;
-  status?: WorkflowStatus;
+  statuses?: Array<WorkflowStatus>;
   timeRangeStart?: Date;
   timeRangeEnd?: Date;
   sortColumn?: string;

--- a/src/views/shared/hooks/use-list-workflows.types.ts
+++ b/src/views/shared/hooks/use-list-workflows.types.ts
@@ -14,7 +14,7 @@ export type UseListWorkflowsParams = ListWorkflowsRouteParams & {
   inputType: WorkflowsHeaderInputType;
   listType: ListType;
   search?: string;
-  statuses?: Array<WorkflowStatus>;
+  status?: WorkflowStatus;
   timeRangeStart?: Date;
   timeRangeEnd?: Date;
   sortColumn?: string;


### PR DESCRIPTION
## Summary
- Add ListFilterMulti component that supports setting array values
- Fixes to ListFilter tests to use userEvent instead of fireEvent
- Fixes to ListFilter so that it uses the mapper to generate the Select value, instead of iterating through the mapper array

## Test plan
Unit tests + ran locally: https://github.com/cadence-workflow/cadence-web/pull/844