### PR TITLE
Support setting multiple workflow statuses in Domain Workflows page

### DIFF
--- a/src/views/domain-page/__fixtures__/domain-page-query-params.ts
+++ b/src/views/domain-page/__fixtures__/domain-page-query-params.ts
@@ -4,7 +4,7 @@ import type domainPageQueryParamsConfig from '@/views/domain-page/config/domain-
 export const mockDomainPageQueryParamsValues = {
   inputType: 'search',
   search: '',
-  status: undefined,
+  statuses: undefined,
   timeRangeStart: undefined,
   timeRangeEnd: undefined,
   sortColumn: 'startTime',
@@ -15,7 +15,7 @@ export const mockDomainPageQueryParamsValues = {
   statusBasic: undefined,
   inputTypeArchival: 'search',
   searchArchival: '',
-  statusArchival: undefined,
+  statusesArchival: undefined,
   timeRangeStartArchival: undefined,
   timeRangeEndArchival: undefined,
   sortColumnArchival: 'startTime',

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -51,6 +51,7 @@ const domainPageQueryParamsConfig: [
   },
   {
     key: 'statuses',
+    queryParamKey: 'status',
     isMultiValue: true,
     parseValue: (value: Array<string>) =>
       value.every(isWorkflowStatus) ? value : undefined,
@@ -107,7 +108,7 @@ const domainPageQueryParamsConfig: [
   },
   {
     key: 'statusesArchival',
-    queryParamKey: 'astatuses',
+    queryParamKey: 'astatus',
     isMultiValue: true,
     parseValue: (value: Array<string>) =>
       value.every(

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -115,7 +115,7 @@ const domainPageQueryParamsConfig: [
           isWorkflowStatus(status) &&
           status !== 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
       )
-        ? value
+        ? (value as Array<WorkflowStatusClosed>)
         : undefined,
   },
   {

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -1,4 +1,7 @@
-import { type PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
+import {
+  type PageQueryParamMultiValue,
+  type PageQueryParam,
+} from '@/hooks/use-page-query-params/use-page-query-params.types';
 import parseDateQueryParam from '@/utils/datetime/parse-date-query-param';
 import { type SortOrder } from '@/utils/sort-by';
 import { type WorkflowStatusClosed } from '@/views/domain-workflows-archival/domain-workflows-archival-header/domain-workflows-archival-header.types';
@@ -12,7 +15,7 @@ const domainPageQueryParamsConfig: [
   PageQueryParam<'inputType', WorkflowsHeaderInputType>,
   // Search input
   PageQueryParam<'search', string>,
-  PageQueryParam<'status', WorkflowStatus | undefined>,
+  PageQueryParamMultiValue<'statuses', Array<WorkflowStatus> | undefined>,
   PageQueryParam<'timeRangeStart', Date | undefined>,
   PageQueryParam<'timeRangeEnd', Date | undefined>,
   PageQueryParam<'sortColumn', string>,
@@ -26,7 +29,10 @@ const domainPageQueryParamsConfig: [
   // Archival inputs
   PageQueryParam<'inputTypeArchival', WorkflowsHeaderInputType>,
   PageQueryParam<'searchArchival', string>,
-  PageQueryParam<'statusArchival', WorkflowStatusClosed | undefined>,
+  PageQueryParamMultiValue<
+    'statusesArchival',
+    Array<WorkflowStatusClosed> | undefined
+  >,
   PageQueryParam<'timeRangeStartArchival', Date | undefined>,
   PageQueryParam<'timeRangeEndArchival', Date | undefined>,
   PageQueryParam<'sortColumnArchival', string>,
@@ -44,9 +50,10 @@ const domainPageQueryParamsConfig: [
     defaultValue: '',
   },
   {
-    key: 'status',
-    parseValue: (value: string) =>
-      isWorkflowStatus(value) ? value : undefined,
+    key: 'statuses',
+    isMultiValue: true,
+    parseValue: (value: Array<string>) =>
+      value.every(isWorkflowStatus) ? value : undefined,
   },
   {
     key: 'timeRangeStart',
@@ -99,11 +106,15 @@ const domainPageQueryParamsConfig: [
     defaultValue: '',
   },
   {
-    key: 'statusArchival',
+    key: 'statusesArchival',
     queryParamKey: 'astatus',
-    parseValue: (value: string) =>
-      isWorkflowStatus(value) &&
-      value !== 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
+    isMultiValue: true,
+    parseValue: (value: Array<string>) =>
+      value.every(
+        (status) =>
+          isWorkflowStatus(status) &&
+          status !== 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
+      )
         ? value
         : undefined,
   },

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -107,7 +107,7 @@ const domainPageQueryParamsConfig: [
   },
   {
     key: 'statusesArchival',
-    queryParamKey: 'astatus',
+    queryParamKey: 'astatuses',
     isMultiValue: true,
     parseValue: (value: Array<string>) =>
       value.every(

--- a/src/views/domain-workflows-archival/config/domain-workflows-archival-filters.config.ts
+++ b/src/views/domain-workflows-archival/config/domain-workflows-archival-filters.config.ts
@@ -3,7 +3,7 @@ import { createElement } from 'react';
 import { omit } from 'lodash';
 
 import DateFilter from '@/components/date-filter/date-filter';
-import ListFilter from '@/components/list-filter/list-filter';
+import ListFilterMulti from '@/components/list-filter-multi/list-filter-multi';
 import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
 import type domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-query-params.config';
 import { WORKFLOW_STATUS_NAMES } from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
@@ -13,7 +13,7 @@ import { type WorkflowStatusClosed } from '../domain-workflows-archival-header/d
 const domainWorkflowsArchivalFiltersConfig: [
   PageFilterConfig<
     typeof domainPageQueryParamsConfig,
-    { statusArchival: WorkflowStatusClosed | undefined }
+    { statusesArchival: Array<WorkflowStatusClosed> | undefined }
   >,
   PageFilterConfig<
     typeof domainPageQueryParamsConfig,
@@ -24,15 +24,15 @@ const domainWorkflowsArchivalFiltersConfig: [
   >,
 ] = [
   {
-    id: 'status',
+    id: 'statuses',
     getValue: (v) => v,
     formatValue: (v) => v,
     component: ({ value, setValue }) =>
-      createElement(ListFilter<WorkflowStatusClosed>, {
+      createElement(ListFilterMulti<WorkflowStatusClosed>, {
         label: 'Status',
         placeholder: 'Show all statuses',
-        value: value.statusArchival,
-        onChangeValue: (v) => setValue({ statusArchival: v }),
+        values: value.statusesArchival,
+        onChangeValues: (v) => setValue({ statusesArchival: v }),
         labelMap: omit(
           WORKFLOW_STATUS_NAMES,
           'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'

--- a/src/views/domain-workflows-archival/domain-workflows-archival-header/domain-workflows-archival-header.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-header/domain-workflows-archival-header.tsx
@@ -28,7 +28,7 @@ export default function DomainWorkflowsArchivalHeader({
     listType: 'archived',
     inputType: queryParams.inputTypeArchival,
     search: queryParams.searchArchival,
-    status: queryParams.statusArchival,
+    statuses: queryParams.statusesArchival,
     timeRangeStart: queryParams.timeRangeStartArchival,
     timeRangeEnd: queryParams.timeRangeEndArchival,
     sortColumn: queryParams.sortColumnArchival,

--- a/src/views/domain-workflows-archival/domain-workflows-archival-table/domain-workflows-archival-table.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival-table/domain-workflows-archival-table.tsx
@@ -38,7 +38,7 @@ export default function DomainWorkflowsArchivalTable({
     pageSize: DOMAIN_WORKFLOWS_ARCHIVAL_PAGE_SIZE,
     inputType: queryParams.inputTypeArchival,
     search: queryParams.searchArchival,
-    status: queryParams.statusArchival,
+    statuses: queryParams.statusesArchival,
     timeRangeStart: queryParams.timeRangeStartArchival,
     timeRangeEnd: queryParams.timeRangeEndArchival,
     sortColumn: queryParams.sortColumnArchival,

--- a/src/views/domain-workflows/config/domain-workflows-filters.config.ts
+++ b/src/views/domain-workflows/config/domain-workflows-filters.config.ts
@@ -1,7 +1,7 @@
 import { createElement } from 'react';
 
 import DateFilter from '@/components/date-filter/date-filter';
-import ListFilter from '@/components/list-filter/list-filter';
+import ListFilterMulti from '@/components/list-filter-multi/list-filter-multi';
 import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
 import type domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-query-params.config';
 import { WORKFLOW_STATUS_NAMES } from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
@@ -10,7 +10,7 @@ import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow
 const domainWorkflowsFiltersConfig: [
   PageFilterConfig<
     typeof domainPageQueryParamsConfig,
-    { status: WorkflowStatus | undefined }
+    { statuses: Array<WorkflowStatus> | undefined }
   >,
   PageFilterConfig<
     typeof domainPageQueryParamsConfig,
@@ -18,15 +18,15 @@ const domainWorkflowsFiltersConfig: [
   >,
 ] = [
   {
-    id: 'status',
-    getValue: (v) => ({ status: v.status }),
+    id: 'statuses',
+    getValue: (v) => ({ statuses: v.statuses }),
     formatValue: (v) => v,
     component: ({ value, setValue }) =>
-      createElement(ListFilter<WorkflowStatus>, {
+      createElement(ListFilterMulti<WorkflowStatus>, {
         label: 'Status',
         placeholder: 'Show all statuses',
-        value: value.status,
-        onChangeValue: (v) => setValue({ status: v }),
+        values: value.statuses,
+        onChangeValues: (v) => setValue({ statuses: v }),
         labelMap: WORKFLOW_STATUS_NAMES,
       }),
   },

--- a/src/views/domain-workflows/domain-workflows-header/domain-workflows-header.tsx
+++ b/src/views/domain-workflows/domain-workflows-header/domain-workflows-header.tsx
@@ -19,7 +19,7 @@ export default function DomainWorkflowsHeader({ domain, cluster }: Props) {
     pageSize: DOMAIN_WORKFLOWS_PAGE_SIZE,
     inputType: queryParams.inputType,
     search: queryParams.search,
-    status: queryParams.status,
+    statuses: queryParams.statuses,
     timeRangeStart: queryParams.timeRangeStart,
     timeRangeEnd: queryParams.timeRangeEnd,
     sortColumn: queryParams.sortColumn,

--- a/src/views/domain-workflows/domain-workflows-table/domain-workflows-table.tsx
+++ b/src/views/domain-workflows/domain-workflows-table/domain-workflows-table.tsx
@@ -35,7 +35,7 @@ export default function DomainWorkflowsTable({ domain, cluster }: Props) {
     pageSize: DOMAIN_WORKFLOWS_PAGE_SIZE,
     inputType: queryParams.inputType,
     search: queryParams.search,
-    status: queryParams.status,
+    statuses: queryParams.statuses,
     timeRangeStart: queryParams.timeRangeStart,
     timeRangeEnd: queryParams.timeRangeEnd,
     sortColumn: queryParams.sortColumn,
@@ -53,7 +53,7 @@ export default function DomainWorkflowsTable({ domain, cluster }: Props) {
       error,
       areSearchParamsAbsent:
         !queryParams.search &&
-        !queryParams.status &&
+        !queryParams.statuses &&
         !queryParams.timeRangeStart &&
         !queryParams.timeRangeEnd,
     });

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    status,
+    statuses,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,
@@ -39,8 +39,7 @@ export default function useListWorkflows({
         }
       : {
           search,
-          // Temporary change, this will be removed in a follow-up
-          statuses: status ? [status] : [],
+          statuses,
           sortColumn,
           sortOrder,
           timeRangeStart: timeRangeStart?.toISOString(),

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    statuses,
+    status,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    status,
+    statuses,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -23,7 +23,7 @@ export default function useListWorkflows({
   const {
     inputType,
     search,
-    statuses,
+    status,
     timeRangeStart,
     timeRangeEnd,
     sortColumn,
@@ -39,7 +39,8 @@ export default function useListWorkflows({
         }
       : {
           search,
-          statuses,
+          // Temporary change, this will be removed in a follow-up
+          statuses: status ? [status] : [],
           sortColumn,
           sortOrder,
           timeRangeStart: timeRangeStart?.toISOString(),

--- a/src/views/shared/hooks/use-list-workflows.types.ts
+++ b/src/views/shared/hooks/use-list-workflows.types.ts
@@ -14,7 +14,7 @@ export type UseListWorkflowsParams = ListWorkflowsRouteParams & {
   inputType: WorkflowsHeaderInputType;
   listType: ListType;
   search?: string;
-  status?: WorkflowStatus;
+  statuses?: Array<WorkflowStatus>;
   timeRangeStart?: Date;
   timeRangeEnd?: Date;
   sortColumn?: string;

--- a/src/views/shared/hooks/use-list-workflows.types.ts
+++ b/src/views/shared/hooks/use-list-workflows.types.ts
@@ -14,7 +14,7 @@ export type UseListWorkflowsParams = ListWorkflowsRouteParams & {
   inputType: WorkflowsHeaderInputType;
   listType: ListType;
   search?: string;
-  statuses?: Array<WorkflowStatus>;
+  status?: WorkflowStatus;
   timeRangeStart?: Date;
   timeRangeEnd?: Date;
   sortColumn?: string;

--- a/src/views/shared/workflows-header/__tests__/workflows-header.test.tsx
+++ b/src/views/shared/workflows-header/__tests__/workflows-header.test.tsx
@@ -12,12 +12,12 @@ import WorkflowsHeader from '../workflows-header';
 const mockFiltersConfig: [
   PageFilterConfig<
     typeof domainPageQueryParamsConfig,
-    { status: WorkflowStatus | undefined }
+    { statuses: Array<WorkflowStatus> | undefined }
   >,
 ] = [
   {
     id: 'filter1',
-    getValue: (queryParams) => ({ status: queryParams.status }),
+    getValue: (queryParams) => ({ statuses: queryParams.statuses }),
     formatValue: (v) => v,
     component: () => <div>filter</div>,
   },


### PR DESCRIPTION
## Summary
- Modify Domain Page query params to change "statuses" to a multi-value page query param
- Update useListWorkflows to read and pass multiple statuses
- Update filters to use ListFilterMulti component

## Test plan
Ran locally.

<img width="1651" alt="Screenshot 2025-03-03 at 12 38 07 PM" src="https://github.com/user-attachments/assets/0ef6bfd0-02f6-4010-965f-cf75c33ffea6" />

<img width="1647" alt="image" src="https://github.com/user-attachments/assets/5eea9b35-2c6d-4fee-aeb3-1a2ab88bde40" />

