### PR TITLE
Add cancel request state to pending start

### DIFF
--- a/src/utils/data-formatters/format-pending-workflow-history-event/__tests__/index.test.ts
+++ b/src/utils/data-formatters/format-pending-workflow-history-event/__tests__/index.test.ts
@@ -3,6 +3,7 @@ import { ZodError } from 'zod';
 import logger from '@/utils/logger';
 import {
   pendingActivityTaskStartEvent,
+  pendingActivityTaskStartEventWithCancelRequestedState,
   pendingActivityTaskStartEventWithStartedState,
   pendingDecisionTaskStartEvent,
   pendingDecisionTaskStartEventWithStartedState,
@@ -15,6 +16,7 @@ jest.mock('@/utils/logger');
 const pendingEvents = [
   pendingActivityTaskStartEvent,
   pendingActivityTaskStartEventWithStartedState,
+  pendingActivityTaskStartEventWithCancelRequestedState,
   pendingDecisionTaskStartEvent,
   pendingDecisionTaskStartEventWithStartedState,
 ];

--- a/src/utils/data-formatters/format-pending-workflow-history-event/__tests__/index.test.ts.snapshot
+++ b/src/utils/data-formatters/format-pending-workflow-history-event/__tests__/index.test.ts.snapshot
@@ -56,6 +56,34 @@ exports[`formatWorkflowHistoryEvent should format workflow pendingActivityTaskSt
 }
 `;
 
+exports[`formatWorkflowHistoryEvent should format workflow pendingActivityTaskStartEventAttributes to match snapshot 3`] = `
+{
+  "activityId": "0",
+  "activityType": {
+    "name": "activity.cron.Start",
+  },
+  "attempt": 1,
+  "eventTime": 2024-09-07T22:16:10.599Z,
+  "eventType": "PendingActivityTaskStart",
+  "expirationTime": 1970-01-01T00:06:00.000Z,
+  "heartbeatDetails": [
+    "1725747370575409843",
+    "gadence-canary-xdc",
+    "workflow.sanity",
+  ],
+  "lastFailureDetails": null,
+  "lastFailureReason": "",
+  "lastHeartbeatTime": null,
+  "lastStartedTime": 2024-09-07T22:16:10.599Z,
+  "lastWorkerIdentity": "",
+  "maximumAttempts": 10,
+  "scheduleId": 7,
+  "scheduledTime": 1970-01-01T00:03:00.000Z,
+  "startedWorkerIdentity": "worker-1",
+  "state": "cancel requested",
+}
+`;
+
 exports[`formatWorkflowHistoryEvent should format workflow pendingDecisionTaskStartEventAttributes to match snapshot 1`] = `
 {
   "attempt": 1,

--- a/src/utils/data-formatters/schema/pending-history-event-schema.ts
+++ b/src/utils/data-formatters/schema/pending-history-event-schema.ts
@@ -32,6 +32,7 @@ export const pendingActivityTaskStartSchema = z.object({
     state: z.enum([
       PendingActivityState.PENDING_ACTIVITY_STATE_SCHEDULED,
       PendingActivityState.PENDING_ACTIVITY_STATE_STARTED,
+      PendingActivityState.PENDING_ACTIVITY_STATE_CANCEL_REQUESTED,
     ]),
     heartbeatDetails: payloadSchema.nullable(),
     lastHeartbeatTime: timestampSchema.nullable(),

--- a/src/views/workflow-history/__fixtures__/workflow-history-pending-events.ts
+++ b/src/views/workflow-history/__fixtures__/workflow-history-pending-events.ts
@@ -54,6 +54,14 @@ export const pendingActivityTaskStartEventWithStartedState = {
   },
 } as const satisfies PendingActivityTaskStartEvent;
 
+export const pendingActivityTaskStartEventWithCancelRequestedState = {
+  ...pendingActivityTaskStartEventWithStartedState,
+  pendingActivityTaskStartEventAttributes: {
+    ...pendingActivityTaskStartEventWithStartedState.pendingActivityTaskStartEventAttributes,
+    state: 'PENDING_ACTIVITY_STATE_CANCEL_REQUESTED',
+  },
+} as const satisfies PendingActivityTaskStartEvent;
+
 export const pendingDecisionTaskStartEvent = {
   eventId: null,
   computedEventId: 'pending-7',

--- a/src/views/workflow-history/helpers/__tests__/group-history-events.test.ts
+++ b/src/views/workflow-history/helpers/__tests__/group-history-events.test.ts
@@ -11,6 +11,7 @@ import {
 } from '../../__fixtures__/workflow-history-decision-events';
 import {
   pendingActivityTaskStartEvent,
+  pendingActivityTaskStartEventWithCancelRequestedState,
   pendingActivityTaskStartEventWithStartedState,
   pendingDecisionTaskStartEvent,
   pendingDecisionTaskStartEventWithStartedState,
@@ -149,22 +150,25 @@ describe('groupHistoryEvents', () => {
     ]);
   });
 
-  it('should append pending activity start with started state to group that has scheduled activity event only', () => {
+  it('should append pending activity start with different states to group that has scheduled activity event only', () => {
     const events: ActivityHistoryEvent[] = [scheduleActivityTaskEvent];
-    const pendingStartActivities = [
+    const testPendingActivities = [
       pendingActivityTaskStartEventWithStartedState,
+      pendingActivityTaskStartEventWithCancelRequestedState,
     ];
     (getHistoryEventGroupId as jest.Mock).mockReturnValue('group1');
 
-    const result = groupHistoryEvents(events, {
-      pendingStartDecision: null,
-      pendingStartActivities,
-    });
+    testPendingActivities.forEach((pendingActivityTaskStart) => {
+      const result = groupHistoryEvents(events, {
+        pendingStartDecision: null,
+        pendingStartActivities: [pendingActivityTaskStart],
+      });
 
-    expect(result.group1.events).toEqual([
-      ...events,
-      ...pendingStartActivities,
-    ]);
+      expect(result.group1.events).toEqual([
+        ...events,
+        pendingActivityTaskStart,
+      ]);
+    });
   });
 
   it('should not append pending activity start to group if it does not have scheduled activity event', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -3,6 +3,7 @@ import type {
   ExtendedActivityHistoryEvent,
   HistoryGroupEventToStatusMap,
   HistoryGroupEventToStringMap,
+  PendingActivityTaskStartEvent,
 } from '../../workflow-history.types';
 import getCommonHistoryGroupFields from '../get-common-history-group-fields';
 
@@ -26,7 +27,7 @@ export default function getActivityGroupFromEvents(
   let scheduleEvent: ExtendedActivityHistoryEvent | undefined;
   let timeoutEvent: ExtendedActivityHistoryEvent | undefined;
   let startEvent: ExtendedActivityHistoryEvent | undefined;
-  let pendingStartEvent: ExtendedActivityHistoryEvent | undefined;
+  let pendingStartEvent: PendingActivityTaskStartEvent | undefined;
   let closeEvent: ExtendedActivityHistoryEvent | undefined;
 
   events.forEach((e) => {
@@ -89,6 +90,11 @@ export default function getActivityGroupFromEvents(
     activityTaskTimedOutEventAttributes: 'FAILED',
   };
 
+  const pendingStartEventTimePrefix = pendingStartEvent?.[pendingStartAttr]
+    .lastStartedTime
+    ? 'Last started at'
+    : 'Scheduled at';
+
   return {
     label,
     hasMissingEvents,
@@ -98,7 +104,7 @@ export default function getActivityGroupFromEvents(
       events,
       eventToStatus,
       eventToLabel,
-      { pendingActivityTaskStartEventAttributes: 'Last started at' }
+      { pendingActivityTaskStartEventAttributes: pendingStartEventTimePrefix }
     ),
   };
 }

--- a/src/views/workflow-history/helpers/group-history-events.ts
+++ b/src/views/workflow-history/helpers/group-history-events.ts
@@ -115,7 +115,7 @@ export function groupHistoryEvents(
       );
     } else {
       const currentGroup = groupByFirstEventId[groupId];
-      // add pendingStart to group only if it is schedueled
+      // add pendingStart to group only if it is scheduled
       if (
         pa.eventTime &&
         currentGroup &&

--- a/src/views/workflow-history/helpers/pending-activities-info-to-events.ts
+++ b/src/views/workflow-history/helpers/pending-activities-info-to-events.ts
@@ -9,6 +9,7 @@ export default function pendingActivitiesInfoToEvents(
     switch (activityInfo.state) {
       case 'PENDING_ACTIVITY_STATE_SCHEDULED':
       case 'PENDING_ACTIVITY_STATE_STARTED':
+      case 'PENDING_ACTIVITY_STATE_CANCEL_REQUESTED':
         return {
           attributes: 'pendingActivityTaskStartEventAttributes',
           eventTime: activityInfo.lastStartedTime ?? activityInfo.scheduledTime,

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -58,7 +58,10 @@ export type PendingDecisionScheduleInfo = Omit<PendingDecisionInfo, 'state'> & {
 };
 
 export type PendingActivityStartInfo = Omit<PendingActivityInfo, 'state'> & {
-  state: 'PENDING_ACTIVITY_STATE_SCHEDULED' | 'PENDING_ACTIVITY_STATE_STARTED';
+  state:
+    | 'PENDING_ACTIVITY_STATE_SCHEDULED'
+    | 'PENDING_ACTIVITY_STATE_STARTED'
+    | 'PENDING_ACTIVITY_STATE_CANCEL_REQUESTED';
 };
 
 export type PendingActivityTaskStartEvent = {


### PR DESCRIPTION
### Summary
Show pending start event with state `Cancel Requested`

### Changes
- Add `PENDING_ACTIVITY_STATE_CANCEL_REQUESTED` to schema and types
- Fix start prefix to changed based on if the time stamp is scheduled or start time 

### Extra thoughts
Initially the plan was to have `Cancel Requested` shown as new Event in history timeline group under the Activity. This was confused with `activityTaskCancelRequestedEvent` which shows individually in the history timeline. Also the content of the pending event included data such as `attempts` which is the `Starting` attempts not the `Cancel Requested` attempts which can be confusing if added under an event named `Cancel Requested`.

### Screenshots
![Screenshot 2025-03-14 at 18 41 49](https://github.com/user-attachments/assets/2adb9363-3791-46e9-b079-28a125508d42)

