### PR TITLE
Restart workflow action

### DIFF
--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -32,6 +32,7 @@ const resolverSchemas: ResolverSchemas = {
     returnType: z.object({
       cancel: z.boolean(),
       terminate: z.boolean(),
+      restart: z.boolean(),
     }),
   },
 };

--- a/src/config/dynamic/resolvers/workflow-actions-enabled.ts
+++ b/src/config/dynamic/resolvers/workflow-actions-enabled.ts
@@ -13,5 +13,6 @@ export default async function workflowActionsEnabled(
   return {
     terminate: true,
     cancel: true,
+    restart: true,
   };
 }

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -30,6 +30,7 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
   WORKFLOW_ACTIONS_ENABLED: {
     terminate: true,
     cancel: true,
+    restart: true,
   },
 };
 export default mockResolvedConfigValues;

--- a/src/views/workflow-actions/config/workflow-actions.config.ts
+++ b/src/views/workflow-actions/config/workflow-actions.config.ts
@@ -1,4 +1,8 @@
-import { MdHighlightOff, MdPowerSettingsNew, MdRefresh } from 'react-icons/md';
+import {
+  MdHighlightOff,
+  MdPowerSettingsNew,
+  MdOutlineRestartAlt,
+} from 'react-icons/md';
 
 import { type CancelWorkflowResponse } from '@/route-handlers/cancel-workflow/cancel-workflow.types';
 import { type RestartWorkflowResponse } from '@/route-handlers/restart-workflow/restart-workflow.types';
@@ -60,7 +64,7 @@ const workflowActionsConfig: [
         'What differentiates Restart from Reset is that Restarted workflow is not aware of the previous workflow execution.',
       ],
     },
-    icon: MdRefresh,
+    icon: MdOutlineRestartAlt,
     getIsRunnable: () => true,
     apiRoute: 'restart',
     getSuccessMessage: (result) =>

--- a/src/views/workflow-actions/config/workflow-actions.config.ts
+++ b/src/views/workflow-actions/config/workflow-actions.config.ts
@@ -61,7 +61,7 @@ const workflowActionsConfig: [
     modal: {
       text: [
         'Restarts a workflow by creating a new execution with a fresh Run ID while using the existing input. If the previous execution is still running, it will be terminated.',
-        'What differentiates Restart from Reset is that restarted workflow is not aware of the previous workflow execution.',
+        'What differentiates Restart from Reset is that the restarted workflow is not aware of the previous workflow execution.',
       ],
     },
     icon: MdOutlineRestartAlt,

--- a/src/views/workflow-actions/config/workflow-actions.config.ts
+++ b/src/views/workflow-actions/config/workflow-actions.config.ts
@@ -61,7 +61,7 @@ const workflowActionsConfig: [
     modal: {
       text: [
         'Restarts a workflow by creating a new execution with a fresh Run ID while using the existing input. If the previous execution is still running, it will be terminated.',
-        'What differentiates Restart from Reset is that Restarted workflow is not aware of the previous workflow execution.',
+        'What differentiates Restart from Reset is that restarted workflow is not aware of the previous workflow execution.',
       ],
     },
     icon: MdOutlineRestartAlt,

--- a/src/views/workflow-actions/config/workflow-actions.config.ts
+++ b/src/views/workflow-actions/config/workflow-actions.config.ts
@@ -1,6 +1,7 @@
-import { MdHighlightOff, MdPowerSettingsNew } from 'react-icons/md';
+import { MdHighlightOff, MdPowerSettingsNew, MdRefresh } from 'react-icons/md';
 
 import { type CancelWorkflowResponse } from '@/route-handlers/cancel-workflow/cancel-workflow.types';
+import { type RestartWorkflowResponse } from '@/route-handlers/restart-workflow/restart-workflow.types';
 import { type TerminateWorkflowResponse } from '@/route-handlers/terminate-workflow/terminate-workflow.types';
 
 import getWorkflowIsCompleted from '../../workflow-page/helpers/get-workflow-is-completed';
@@ -9,6 +10,7 @@ import { type WorkflowAction } from '../workflow-actions.types';
 const workflowActionsConfig: [
   WorkflowAction<CancelWorkflowResponse>,
   WorkflowAction<TerminateWorkflowResponse>,
+  WorkflowAction<RestartWorkflowResponse>,
 ] = [
   {
     id: 'cancel',
@@ -47,6 +49,23 @@ const workflowActionsConfig: [
       ),
     apiRoute: 'terminate',
     getSuccessMessage: () => 'Workflow has been terminated.',
+  },
+  {
+    id: 'restart',
+    label: 'Restart',
+    subtitle: 'Restart a workflow execution',
+    modal: {
+      text: [
+        'Restarts a workflow by creating a new execution with a fresh runId while using the existing input. If the previous execution is still running, it will be terminated',
+        'What differentiates Restart from Reset is that Restarted workflow is not aware of the previous workflow execution.',
+      ],
+    },
+    icon: MdRefresh,
+    getIsRunnable: () => true,
+    apiRoute: 'restart',
+    getSuccessMessage: (result) =>
+      // TODO: change runid to a link (upcomming PR)
+      `Workflow has been restarted with new run ID: ${result.runId}`,
   },
 ] as const;
 

--- a/src/views/workflow-actions/config/workflow-actions.config.ts
+++ b/src/views/workflow-actions/config/workflow-actions.config.ts
@@ -60,7 +60,7 @@ const workflowActionsConfig: [
     subtitle: 'Restart a workflow execution',
     modal: {
       text: [
-        'Restarts a workflow by creating a new execution with a fresh runId while using the existing input. If the previous execution is still running, it will be terminated',
+        'Restarts a workflow by creating a new execution with a fresh Run ID while using the existing input. If the previous execution is still running, it will be terminated.',
         'What differentiates Restart from Reset is that Restarted workflow is not aware of the previous workflow execution.',
       ],
     },

--- a/src/views/workflow-actions/workflow-actions-menu/__tests__/workflow-actions-menu.test.tsx
+++ b/src/views/workflow-actions/workflow-actions-menu/__tests__/workflow-actions-menu.test.tsx
@@ -20,7 +20,7 @@ describe(WorkflowActionsMenu.name, () => {
 
   it('renders the menu items correctly', () => {
     setup({
-      actionsEnabledConfig: { terminate: true, cancel: true },
+      actionsEnabledConfig: { terminate: true, cancel: true, restart: true },
     });
 
     const menuButtons = screen.getAllByRole('button');
@@ -43,7 +43,7 @@ describe(WorkflowActionsMenu.name, () => {
 
   it('disables menu items if they are disabled from config', () => {
     setup({
-      actionsEnabledConfig: { terminate: true, cancel: false },
+      actionsEnabledConfig: { terminate: true, cancel: false, restart: true },
     });
 
     const menuButtons = screen.getAllByRole('button');
@@ -89,7 +89,7 @@ describe(WorkflowActionsMenu.name, () => {
 
   it('calls onActionSelect when the action button is clicked', async () => {
     const { user, mockOnActionSelect } = setup({
-      actionsEnabledConfig: { terminate: true, cancel: true },
+      actionsEnabledConfig: { terminate: true, cancel: true, restart: true },
     });
 
     const menuButtons = screen.getAllByRole('button');

--- a/src/views/workflow-actions/workflow-actions-modal-content/__tests__/workflow-actions-modal-content.test.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal-content/__tests__/workflow-actions-modal-content.test.tsx
@@ -3,9 +3,12 @@ import { HttpResponse } from 'msw';
 import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import { type CancelWorkflowResponse } from '@/route-handlers/cancel-workflow/cancel-workflow.types';
+import { type RestartWorkflowResponse } from '@/route-handlers/restart-workflow/restart-workflow.types';
+import { type TerminateWorkflowResponse } from '@/route-handlers/terminate-workflow/terminate-workflow.types';
 import { mockWorkflowDetailsParams } from '@/views/workflow-page/__fixtures__/workflow-details-params';
 
 import { mockWorkflowActionsConfig } from '../../__fixtures__/workflow-actions-config';
+import { type WorkflowAction } from '../../workflow-actions.types';
 import WorkflowActionsModalContent from '../workflow-actions-modal-content';
 
 const mockEnqueue = jest.fn();
@@ -76,15 +79,37 @@ describe(WorkflowActionsModalContent.name, () => {
     ).toBeInTheDocument();
     expect(mockOnClose).not.toHaveBeenCalled();
   });
+
+  it('renders array text correctly in modal content', () => {
+    const cancelAction = {
+      ...mockWorkflowActionsConfig[0],
+      modal: {
+        text: ['First line of array text', 'Second line of array text'],
+      },
+    };
+
+    setup({ actionConfig: cancelAction });
+
+    expect(screen.getByText('First line of array text')).toBeInTheDocument();
+    expect(screen.getByText('Second line of array text')).toBeInTheDocument();
+  });
 });
 
-function setup({ error }: { error?: boolean }) {
+function setup({
+  error,
+  actionConfig,
+}: {
+  error?: boolean;
+  actionConfig?: WorkflowAction<
+    CancelWorkflowResponse | TerminateWorkflowResponse | RestartWorkflowResponse
+  >;
+}) {
   const user = userEvent.setup();
   const mockOnClose = jest.fn();
 
   render(
     <WorkflowActionsModalContent
-      action={mockWorkflowActionsConfig[0]}
+      action={actionConfig ?? mockWorkflowActionsConfig[0]}
       params={{ ...mockWorkflowDetailsParams }}
       onCloseModal={mockOnClose}
     />,

--- a/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
@@ -63,19 +63,27 @@ export default function WorkflowActionsModalContent<R>({
     queryClient
   );
 
+  const modalText = Array.isArray(action.modal.text) ? (
+    action.modal.text.map((text, index) => <p key={index}>{text}</p>)
+  ) : (
+    <p>{action.modal.text}</p>
+  );
+
   return (
     <>
       <styled.ModalHeader>{action.label} workflow</styled.ModalHeader>
       <styled.ModalBody>
-        {action.modal.text}
-        <styled.Link
-          href={action.modal.docsLink.href}
-          target="_blank"
-          rel="noreferrer"
-        >
-          {action.modal.docsLink.text}
-          <MdOpenInNew />
-        </styled.Link>
+        {modalText}
+        {action.modal.docsLink && (
+          <styled.Link
+            href={action.modal.docsLink.href}
+            target="_blank"
+            rel="noreferrer"
+          >
+            {action.modal.docsLink.text}
+            <MdOpenInNew />
+          </styled.Link>
+        )}
         {error && (
           <Banner
             hierarchy={HIERARCHY.low}

--- a/src/views/workflow-actions/workflow-actions.types.ts
+++ b/src/views/workflow-actions/workflow-actions.types.ts
@@ -10,15 +10,15 @@ export type WorkflowActionInputParams = {
   // TODO: add input here for extended workflow actions
 };
 
-export type WorkflowActionID = 'cancel' | 'terminate';
+export type WorkflowActionID = 'cancel' | 'terminate' | 'restart';
 
 export type WorkflowAction<R> = {
   id: WorkflowActionID;
   label: string;
   subtitle: string;
   modal: {
-    text: string;
-    docsLink: {
+    text: string | string[];
+    docsLink?: {
       text: string;
       href: string;
     };


### PR DESCRIPTION
### Summary
Add restart workflow action to history page.


### Changes
- Added Restart to workflow actions dropdown
- Change the modal `text` to accept string or an array of strings to be shown as paragraphs
- Hide `docsLink` if not passed (currently there is no separate docs for restart, it is partially mentioned in the reset)

### Screenshots
![Screenshot 2025-03-18 at 16 51 32](https://github.com/user-attachments/assets/c691d66a-cfd9-4e3e-ac70-4b50dac903d5)
![Screenshot 2025-03-18 at 16 42 14](https://github.com/user-attachments/assets/9266514a-f81a-472f-9fec-9cbb291f50f8)
![Screenshot 2025-03-18 at 16 53 17](https://github.com/user-attachments/assets/32450622-d1b1-4bfa-9aea-23853b650b71)

