### PR TITLE
Fix workflow history flaky test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ COPY . .
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED 1
-# optimize Build size by inclduding only required resources
+# optimize Build size by including only required resources
 
 RUN npm run generate:idl
 RUN npm run build

--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -142,7 +142,6 @@ describe('WorkflowHistory', () => {
       hasNextPage: true,
     });
 
-    // Wait for initial loading state
     await waitFor(() => {
       expect(screen.getByText('keep loading events')).toBeInTheDocument();
     });
@@ -160,15 +159,14 @@ describe('WorkflowHistory', () => {
       });
     });
 
-    // Verify loading state persists
     await waitFor(() => {
       expect(screen.getByText('keep loading events')).toBeInTheDocument();
     });
 
-    // Load second page with selected event
+    // Load second page
     await act(async () => {
       const secondPageResolver = getRequestResolver();
-      await secondPageResolver({
+      secondPageResolver({
         history: {
           events: [completedDecisionTaskEvents[1]],
         },
@@ -178,7 +176,6 @@ describe('WorkflowHistory', () => {
       });
     });
 
-    // Wait for loading to complete and verify final state
     await waitFor(() => {
       expect(screen.queryByText('keep loading events')).not.toBeInTheDocument();
     });
@@ -239,17 +236,16 @@ async function setup({
 
             if (requestIndex > 0 && resolveLoadMoreManually) {
               return await new Promise((resolve, reject) => {
-                requestResolver = (result: GetWorkflowHistoryResponse) => {
+                requestResolver = (result: GetWorkflowHistoryResponse) =>
                   resolve(HttpResponse.json(result, { status: 200 }));
-                };
-                requestRejector = () => {
+
+                requestRejector = () =>
                   reject(
                     HttpResponse.json(
                       { message: 'Failed to fetch workflow history' },
                       { status: 500 }
                     )
                   );
-                };
               });
             } else {
               if (error) {

--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -159,7 +159,7 @@ describe('WorkflowHistory', () => {
 
     await act(async () => {
       const secondPageResolver = getRequestResolver();
-      secondPageResolver({
+      await secondPageResolver({
         history: {
           events: [completedDecisionTaskEvents[1]],
         },


### PR DESCRIPTION
### Summary
Fix flaky test happening due to assertion on uncommitted render result.

### Changes
- Assert on showing the loading state before requesting the details allows the act block on the correct UI changes.
- Misc: fixed docker file typo

### Testing
- Tested the changes on a slow docker image to be able to reproduce the flaky test consistently