### PR TITLE
Add form support to workflow actions modal

### DIFF
--- a/src/views/workflow-actions/__fixtures__/workflow-actions-config.ts
+++ b/src/views/workflow-actions/__fixtures__/workflow-actions-config.ts
@@ -6,8 +6,8 @@ import { type TerminateWorkflowResponse } from '@/route-handlers/terminate-workf
 import { type WorkflowAction } from '../workflow-actions.types';
 
 export const mockWorkflowActionsConfig: [
-  WorkflowAction<CancelWorkflowResponse>,
-  WorkflowAction<TerminateWorkflowResponse>,
+  WorkflowAction<null, null, CancelWorkflowResponse>,
+  WorkflowAction<null, null, TerminateWorkflowResponse>,
 ] = [
   {
     id: 'cancel',

--- a/src/views/workflow-actions/__fixtures__/workflow-actions-config.tsx
+++ b/src/views/workflow-actions/__fixtures__/workflow-actions-config.tsx
@@ -1,6 +1,8 @@
-import { MdHighlightOff, MdPowerSettingsNew } from 'react-icons/md';
+import { MdHighlightOff, MdPowerSettingsNew, MdRefresh } from 'react-icons/md';
+import { z } from 'zod';
 
 import { type CancelWorkflowResponse } from '@/route-handlers/cancel-workflow/cancel-workflow.types';
+import { type ResetWorkflowResponse } from '@/route-handlers/reset-workflow/reset-workflow.types';
 import { type TerminateWorkflowResponse } from '@/route-handlers/terminate-workflow/terminate-workflow.types';
 
 import { type WorkflowAction } from '../workflow-actions.types';
@@ -8,6 +10,11 @@ import { type WorkflowAction } from '../workflow-actions.types';
 export const mockWorkflowActionsConfig: [
   WorkflowAction<any, any, CancelWorkflowResponse>,
   WorkflowAction<any, any, TerminateWorkflowResponse>,
+  WorkflowAction<
+    { testField: string },
+    { transformed: string },
+    ResetWorkflowResponse
+  >,
 ] = [
   {
     id: 'cancel',
@@ -40,5 +47,37 @@ export const mockWorkflowActionsConfig: [
     getRunnableStatus: () => 'RUNNABLE',
     apiRoute: 'terminate',
     renderSuccessMessage: () => 'Mock terminate notification',
+  },
+  {
+    id: 'restart', // TODO: rename to reset
+    label: 'Mock reset',
+    subtitle: 'Mock reset a workflow execution',
+    modal: {
+      text: 'Mock modal text to reset a workflow execution',
+      docsLink: {
+        text: 'Mock docs link',
+        href: 'https://mock.docs.link',
+      },
+      form: ({ control, fieldErrors }) => (
+        <div data-testid="mock-form">
+          <input
+            data-testid="test-input"
+            aria-invalid={!!fieldErrors.testField}
+            {...control.register('testField')}
+          />
+        </div>
+      ),
+      formSchema: z.object({
+        testField: z.string().min(1),
+      }),
+      transformFormDataToSubmission: (data: { testField: string }) => ({
+        transformed: data.testField,
+      }),
+    },
+    icon: MdRefresh,
+    getRunnableStatus: () => 'RUNNABLE',
+    apiRoute: 'reset',
+    renderSuccessMessage: ({ result }) =>
+      `Mock reset notification (Run ID: ${result.runId})`,
   },
 ] as const;

--- a/src/views/workflow-actions/__fixtures__/workflow-actions-config.tsx
+++ b/src/views/workflow-actions/__fixtures__/workflow-actions-config.tsx
@@ -6,8 +6,8 @@ import { type TerminateWorkflowResponse } from '@/route-handlers/terminate-workf
 import { type WorkflowAction } from '../workflow-actions.types';
 
 export const mockWorkflowActionsConfig: [
-  WorkflowAction<null, null, CancelWorkflowResponse>,
-  WorkflowAction<null, null, TerminateWorkflowResponse>,
+  WorkflowAction<any, any, CancelWorkflowResponse>,
+  WorkflowAction<any, any, TerminateWorkflowResponse>,
 ] = [
   {
     id: 'cancel',

--- a/src/views/workflow-actions/config/workflow-actions.config.ts
+++ b/src/views/workflow-actions/config/workflow-actions.config.ts
@@ -15,9 +15,9 @@ import WorkflowActionNewRunSuccessMsg from '../workflow-action-new-run-success-m
 import { type WorkflowAction } from '../workflow-actions.types';
 
 const workflowActionsConfig: [
-  WorkflowAction<CancelWorkflowResponse>,
-  WorkflowAction<TerminateWorkflowResponse>,
-  WorkflowAction<RestartWorkflowResponse>,
+  WorkflowAction<null, null, CancelWorkflowResponse>,
+  WorkflowAction<null, null, TerminateWorkflowResponse>,
+  WorkflowAction<null, null, RestartWorkflowResponse>,
 ] = [
   {
     id: 'cancel',

--- a/src/views/workflow-actions/config/workflow-actions.config.ts
+++ b/src/views/workflow-actions/config/workflow-actions.config.ts
@@ -15,9 +15,9 @@ import WorkflowActionNewRunSuccessMsg from '../workflow-action-new-run-success-m
 import { type WorkflowAction } from '../workflow-actions.types';
 
 const workflowActionsConfig: [
-  WorkflowAction<null, null, CancelWorkflowResponse>,
-  WorkflowAction<null, null, TerminateWorkflowResponse>,
-  WorkflowAction<null, null, RestartWorkflowResponse>,
+  WorkflowAction<any, any, CancelWorkflowResponse>,
+  WorkflowAction<any, any, TerminateWorkflowResponse>,
+  WorkflowAction<any, any, RestartWorkflowResponse>,
 ] = [
   {
     id: 'cancel',

--- a/src/views/workflow-actions/workflow-action-new-run-success-msg/__tests__/workflow-action-new-run-success-msg.test.tsx
+++ b/src/views/workflow-actions/workflow-action-new-run-success-msg/__tests__/workflow-action-new-run-success-msg.test.tsx
@@ -14,6 +14,7 @@ describe('WorkflowActionNewRunSuccessMsg', () => {
       cluster: 'test-cluster',
       workflowId: 'test-workflow-id',
       runId: 'test-run-id',
+      submissionData: null,
     },
     successMessage: 'Workflow has been restarted.',
   };

--- a/src/views/workflow-actions/workflow-action-new-run-success-msg/workflow-action-new-run-success-msg.types.tsx
+++ b/src/views/workflow-actions/workflow-action-new-run-success-msg/workflow-action-new-run-success-msg.types.tsx
@@ -1,5 +1,8 @@
 import { type WorkflowActionSuccessMessageProps } from '../workflow-actions.types';
 
-export type Props = WorkflowActionSuccessMessageProps<{ runId: string }> & {
+export type Props = WorkflowActionSuccessMessageProps<
+  any,
+  { runId: string }
+> & {
   successMessage: string;
 };

--- a/src/views/workflow-actions/workflow-actions-menu/__tests__/workflow-actions-menu.test.tsx
+++ b/src/views/workflow-actions/workflow-actions-menu/__tests__/workflow-actions-menu.test.tsx
@@ -41,7 +41,7 @@ describe(WorkflowActionsMenu.name, () => {
     });
 
     const menuButtons = screen.getAllByRole('button');
-    expect(menuButtons).toHaveLength(2);
+    expect(menuButtons).toHaveLength(3);
 
     expect(within(menuButtons[0]).getByText('Mock cancel')).toBeInTheDocument();
     expect(
@@ -68,7 +68,7 @@ describe(WorkflowActionsMenu.name, () => {
     });
 
     const menuButtons = screen.getAllByRole('button');
-    expect(menuButtons).toHaveLength(2);
+    expect(menuButtons).toHaveLength(3);
 
     expect(within(menuButtons[0]).getByText('Mock cancel')).toBeInTheDocument();
     expect(
@@ -96,7 +96,7 @@ describe(WorkflowActionsMenu.name, () => {
     });
 
     const menuButtons = screen.getAllByRole('button');
-    expect(menuButtons).toHaveLength(2);
+    expect(menuButtons).toHaveLength(3);
 
     expect(within(menuButtons[0]).getByText('Mock cancel')).toBeInTheDocument();
     expect(
@@ -119,7 +119,7 @@ describe(WorkflowActionsMenu.name, () => {
     });
 
     const menuButtons = screen.getAllByRole('button');
-    expect(menuButtons).toHaveLength(2);
+    expect(menuButtons).toHaveLength(3);
 
     await user.click(menuButtons[0]);
     expect(mockOnActionSelect).toHaveBeenCalledWith(

--- a/src/views/workflow-actions/workflow-actions-menu/workflow-actions-menu.types.ts
+++ b/src/views/workflow-actions/workflow-actions-menu/workflow-actions-menu.types.ts
@@ -6,5 +6,5 @@ import { type WorkflowAction } from '../workflow-actions.types';
 export type Props = {
   workflow: DescribeWorkflowResponse;
   actionsEnabledConfig?: WorkflowActionsEnabledConfig;
-  onActionSelect: (action: WorkflowAction<any>) => void;
+  onActionSelect: (action: WorkflowAction<any, any, any>) => void;
 };

--- a/src/views/workflow-actions/workflow-actions-modal-content/__tests__/workflow-actions-modal-content.test.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal-content/__tests__/workflow-actions-modal-content.test.tsx
@@ -3,8 +3,6 @@ import { HttpResponse } from 'msw';
 import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import { type CancelWorkflowResponse } from '@/route-handlers/cancel-workflow/cancel-workflow.types';
-import { type RestartWorkflowResponse } from '@/route-handlers/restart-workflow/restart-workflow.types';
-import { type TerminateWorkflowResponse } from '@/route-handlers/terminate-workflow/terminate-workflow.types';
 import { mockWorkflowDetailsParams } from '@/views/workflow-page/__fixtures__/workflow-details-params';
 
 import { mockWorkflowActionsConfig } from '../../__fixtures__/workflow-actions-config';
@@ -41,11 +39,11 @@ describe(WorkflowActionsModalContent.name, () => {
     expect(docsLink).toHaveAttribute('href', 'https://mock.docs.link');
   });
 
-  it('calls onCloseModal when the Go Back button is clicked', async () => {
+  it('calls onCloseModal when the Cancel button is clicked', async () => {
     const { user, mockOnClose } = setup({});
 
-    const goBackButton = await screen.findByText('Go back');
-    await user.click(goBackButton);
+    const cancelButton = await screen.findByText('Cancel');
+    await user.click(cancelButton);
 
     expect(mockOnClose).toHaveBeenCalled();
   });
@@ -100,9 +98,7 @@ function setup({
   actionConfig,
 }: {
   error?: boolean;
-  actionConfig?: WorkflowAction<
-    CancelWorkflowResponse | TerminateWorkflowResponse | RestartWorkflowResponse
-  >;
+  actionConfig?: WorkflowAction<any, any, any>;
 }) {
   const user = userEvent.setup();
   const mockOnClose = jest.fn();

--- a/src/views/workflow-actions/workflow-actions-modal-content/__tests__/workflow-actions-modal-content.test.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal-content/__tests__/workflow-actions-modal-content.test.tsx
@@ -1,8 +1,9 @@
 import { HttpResponse } from 'msw';
 
-import { render, screen, userEvent } from '@/test-utils/rtl';
+import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 
 import { type CancelWorkflowResponse } from '@/route-handlers/cancel-workflow/cancel-workflow.types';
+import { type ResetWorkflowResponse } from '@/route-handlers/reset-workflow/reset-workflow.types';
 import { mockWorkflowDetailsParams } from '@/views/workflow-page/__fixtures__/workflow-details-params';
 
 import { mockWorkflowActionsConfig } from '../../__fixtures__/workflow-actions-config';
@@ -18,6 +19,8 @@ jest.mock('baseui/snackbar', () => ({
     dequeue: mockDequeue,
   }),
 }));
+
+const mockResetAction = mockWorkflowActionsConfig[2];
 
 describe(WorkflowActionsModalContent.name, () => {
   beforeEach(() => {
@@ -56,11 +59,13 @@ describe(WorkflowActionsModalContent.name, () => {
     });
     await user.click(cancelButton);
 
-    expect(mockEnqueue).toHaveBeenCalledWith(
-      expect.objectContaining({
-        message: 'Mock cancel notification',
-      })
-    );
+    await waitFor(() => {
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Mock cancel notification',
+        })
+      );
+    });
     expect(mockOnClose).toHaveBeenCalled();
   });
 
@@ -72,9 +77,9 @@ describe(WorkflowActionsModalContent.name, () => {
     });
     await user.click(cancelButton);
 
-    expect(
-      await screen.findByText('Failed to cancel workflow')
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Failed to cancel workflow')).toBeInTheDocument();
+    });
     expect(mockOnClose).not.toHaveBeenCalled();
   });
 
@@ -91,6 +96,58 @@ describe(WorkflowActionsModalContent.name, () => {
     expect(screen.getByText('First line of array text')).toBeInTheDocument();
     expect(screen.getByText('Second line of array text')).toBeInTheDocument();
   });
+
+  describe('form handling', () => {
+    it('renders form when provided in action config', () => {
+      setup({ actionConfig: mockResetAction });
+
+      expect(screen.getByTestId('mock-form')).toBeInTheDocument();
+      expect(screen.getByTestId('test-input')).toBeInTheDocument();
+    });
+
+    it('disables submit button when form has validation errors', async () => {
+      const { user } = setup({ actionConfig: mockResetAction });
+
+      const submitButton = screen.getByRole('button', {
+        name: 'Mock reset workflow',
+      });
+      await user.click(submitButton);
+
+      expect(submitButton).toHaveAttribute('disabled');
+    });
+
+    it('forms recieves validation error message when field is invalid', async () => {
+      const { user } = setup({ actionConfig: mockResetAction });
+
+      const submitButton = screen.getByRole('button', {
+        name: 'Mock reset workflow',
+      });
+      await user.click(submitButton);
+
+      expect(screen.getByTestId('test-input')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+    });
+
+    it('transforms form data before submission', async () => {
+      const { user, getLatestRequestBody, waitForRequest } = setup({
+        actionConfig: mockResetAction,
+      });
+
+      const input = screen.getByTestId('test-input');
+      await user.type(input, 'test value');
+
+      const submitButton = screen.getByRole('button', {
+        name: 'Mock reset workflow',
+      });
+      await user.click(submitButton);
+
+      await waitForRequest();
+
+      expect(getLatestRequestBody()).toEqual({ transformed: 'test value' });
+    });
+  });
 });
 
 function setup({
@@ -102,6 +159,11 @@ function setup({
 }) {
   const user = userEvent.setup();
   const mockOnClose = jest.fn();
+  let latestRequestBody: any = null;
+  let requestPromiseResolve = (v: unknown) => v;
+  const requestPromise = new Promise((resolve) => {
+    requestPromiseResolve = resolve;
+  });
 
   render(
     <WorkflowActionsModalContent
@@ -112,15 +174,26 @@ function setup({
     {
       endpointsMocks: [
         {
-          path: '/api/domains/:domain/:cluster/workflows/:workflowId/:runId/cancel',
+          path: '/api/domains/:domain/:cluster/workflows/:workflowId/:runId/:action',
           httpMethod: 'POST',
           mockOnce: false,
-          httpResolver: () => {
+          httpResolver: async ({ request }) => {
+            // Capture the request body
+            const text = await request.text();
+            latestRequestBody = text ? JSON.parse(text) : null;
+            requestPromiseResolve(null);
+
             if (error) {
               return HttpResponse.json(
                 { message: 'Failed to cancel workflow' },
                 { status: 500 }
               );
+            }
+
+            if (request.url.endsWith('/reset')) {
+              return HttpResponse.json({
+                runId: 'new-run-id',
+              } satisfies ResetWorkflowResponse);
             }
             return HttpResponse.json({} satisfies CancelWorkflowResponse);
           },
@@ -129,5 +202,10 @@ function setup({
     }
   );
 
-  return { user, mockOnClose };
+  return {
+    user,
+    mockOnClose,
+    getLatestRequestBody: () => latestRequestBody,
+    waitForRequest: () => requestPromise,
+  };
 }

--- a/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
@@ -1,29 +1,49 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Banner, HIERARCHY, KIND as BANNER_KIND } from 'baseui/banner';
 import { KIND as BUTTON_KIND, SIZE } from 'baseui/button';
 import { ModalButton } from 'baseui/modal';
 import { useSnackbar } from 'baseui/snackbar';
+import {
+  type FieldValues,
+  useForm,
+  type DefaultValues,
+  type Control,
+} from 'react-hook-form';
 import { MdCheckCircle, MdErrorOutline, MdOpenInNew } from 'react-icons/md';
 
 import request from '@/utils/request';
 import { type RequestError } from '@/utils/request/request-error';
 
-import { type WorkflowActionInputParams } from '../workflow-actions.types';
+import { type WorkflowActionInput } from '../workflow-actions.types';
 
 import { overrides, styled } from './workflow-actions-modal-content.styles';
 import { type Props } from './workflow-actions-modal-content.types';
 
-export default function WorkflowActionsModalContent<R>({
-  action,
-  params,
-  onCloseModal,
-}: Props<R>) {
+export default function WorkflowActionsModalContent<
+  FormData extends FieldValues,
+  SubmissionData,
+  Result,
+>({ action, params, onCloseModal }: Props<FormData, SubmissionData, Result>) {
   const queryClient = useQueryClient();
   const { enqueue, dequeue } = useSnackbar();
+
+  const {
+    handleSubmit,
+    formState: { errors: validationErrors, isSubmitting },
+    control,
+    watch,
+  } = useForm<FormData>({
+    resolver: action.modal.formSchema
+      ? zodResolver(action.modal.formSchema)
+      : undefined,
+    defaultValues: {} as DefaultValues<FormData>,
+  });
+
   const { mutate, isPending, error } = useMutation<
-    R,
+    Result,
     RequestError,
-    WorkflowActionInputParams
+    WorkflowActionInput<SubmissionData>
   >(
     {
       mutationFn: ({
@@ -31,24 +51,18 @@ export default function WorkflowActionsModalContent<R>({
         cluster,
         workflowId,
         runId,
-      }: WorkflowActionInputParams) =>
+        submissionData,
+      }: WorkflowActionInput<SubmissionData>) =>
         request(
           `/api/domains/${domain}/${cluster}/workflows/${workflowId}/${runId}/${action.apiRoute}`,
           {
             method: 'POST',
-            body: JSON.stringify({
-              // TODO: pass the input here when implementing extended workflow actions
-            }),
+            body: JSON.stringify(submissionData || {}),
           }
-        ).then((res) => res.json() as R),
+        ).then((res) => res.json() as Result),
       onSuccess: (result, params) => {
-        const {
-          // TODO: input,
-          ...workflowDetailsParams
-        } = params;
-
         queryClient.invalidateQueries({
-          queryKey: ['describe_workflow', workflowDetailsParams],
+          queryKey: ['describe_workflow', params],
         });
 
         onCloseModal();
@@ -66,11 +80,24 @@ export default function WorkflowActionsModalContent<R>({
     queryClient
   );
 
+  const onSubmit = (data: FormData) => {
+    const { transformFormDataToSubmission } = action.modal;
+    const transform = transformFormDataToSubmission || (() => undefined);
+
+    mutate({
+      ...params,
+      submissionData: transform(data),
+    });
+  };
+
   const modalText = Array.isArray(action.modal.text) ? (
     action.modal.text.map((text, index) => <p key={index}>{text}</p>)
   ) : (
     <p>{action.modal.text}</p>
   );
+
+  const Form = action.modal.form;
+  const isSubmitDisabled = Object.keys(validationErrors).length > 0;
 
   return (
     <>
@@ -87,6 +114,13 @@ export default function WorkflowActionsModalContent<R>({
             <MdOpenInNew />
           </styled.Link>
         )}
+        {Form && (
+          <Form
+            formData={watch()}
+            fieldErrors={validationErrors}
+            control={control as Control<FieldValues>}
+          />
+        )}
         {error && (
           <Banner
             hierarchy={HIERARCHY.low}
@@ -102,18 +136,19 @@ export default function WorkflowActionsModalContent<R>({
       </styled.ModalBody>
       <styled.ModalFooter>
         <ModalButton
-          autoFocus={true} // TODO: this needs to be set to false if there is an input
+          autoFocus={!action.modal.form}
           size={SIZE.compact}
           kind={BUTTON_KIND.secondary}
           onClick={onCloseModal}
         >
-          Go back
+          Cancel
         </ModalButton>
         <ModalButton
           size={SIZE.compact}
           kind={BUTTON_KIND.primary}
-          onClick={() => mutate(params)}
-          isLoading={isPending}
+          onClick={handleSubmit(onSubmit)}
+          isLoading={isPending || isSubmitting}
+          disabled={isSubmitDisabled}
         >
           {action.label} workflow
         </ModalButton>

--- a/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
@@ -102,57 +102,60 @@ export default function WorkflowActionsModalContent<
   return (
     <>
       <styled.ModalHeader>{action.label} workflow</styled.ModalHeader>
-      <styled.ModalBody>
-        {modalText}
-        {action.modal.docsLink && (
-          <styled.Link
-            href={action.modal.docsLink.href}
-            target="_blank"
-            rel="noreferrer"
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <styled.ModalBody>
+          {modalText}
+          {action.modal.docsLink && (
+            <styled.Link
+              href={action.modal.docsLink.href}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {action.modal.docsLink.text}
+              <MdOpenInNew />
+            </styled.Link>
+          )}
+          {Form && (
+            <Form
+              formData={watch()}
+              fieldErrors={validationErrors}
+              control={control as Control<FieldValues>}
+            />
+          )}
+          {error && (
+            <Banner
+              hierarchy={HIERARCHY.low}
+              kind={BANNER_KIND.negative}
+              overrides={overrides.banner}
+              artwork={{
+                icon: MdErrorOutline,
+              }}
+            >
+              {error.message}
+            </Banner>
+          )}
+        </styled.ModalBody>
+        <styled.ModalFooter>
+          <ModalButton
+            autoFocus={!action.modal.form}
+            size={SIZE.compact}
+            type="button"
+            kind={BUTTON_KIND.secondary}
+            onClick={onCloseModal}
           >
-            {action.modal.docsLink.text}
-            <MdOpenInNew />
-          </styled.Link>
-        )}
-        {Form && (
-          <Form
-            formData={watch()}
-            fieldErrors={validationErrors}
-            control={control as Control<FieldValues>}
-          />
-        )}
-        {error && (
-          <Banner
-            hierarchy={HIERARCHY.low}
-            kind={BANNER_KIND.negative}
-            overrides={overrides.banner}
-            artwork={{
-              icon: MdErrorOutline,
-            }}
+            Cancel
+          </ModalButton>
+          <ModalButton
+            size={SIZE.compact}
+            kind={BUTTON_KIND.primary}
+            type="submit"
+            isLoading={isPending || isSubmitting}
+            disabled={isSubmitDisabled}
           >
-            {error.message}
-          </Banner>
-        )}
-      </styled.ModalBody>
-      <styled.ModalFooter>
-        <ModalButton
-          autoFocus={!action.modal.form}
-          size={SIZE.compact}
-          kind={BUTTON_KIND.secondary}
-          onClick={onCloseModal}
-        >
-          Cancel
-        </ModalButton>
-        <ModalButton
-          size={SIZE.compact}
-          kind={BUTTON_KIND.primary}
-          onClick={handleSubmit(onSubmit)}
-          isLoading={isPending || isSubmitting}
-          disabled={isSubmitDisabled}
-        >
-          {action.label} workflow
-        </ModalButton>
-      </styled.ModalFooter>
+            {action.label} workflow
+          </ModalButton>
+        </styled.ModalFooter>
+      </form>
     </>
   );
 }

--- a/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.types.ts
+++ b/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.types.ts
@@ -3,8 +3,8 @@ import {
   type WorkflowActionInputParams,
 } from '../workflow-actions.types';
 
-export type Props<R> = {
-  action: WorkflowAction<R>;
+export type Props<FormData, SubmissionData, Result> = {
+  action: WorkflowAction<FormData, SubmissionData, Result>;
   params: WorkflowActionInputParams;
   onCloseModal: () => void;
 };

--- a/src/views/workflow-actions/workflow-actions-modal/workflow-actions-modal.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal/workflow-actions-modal.tsx
@@ -1,15 +1,20 @@
 import { Modal } from 'baseui/modal';
+import { type FieldValues } from 'react-hook-form';
 
 import WorkflowActionsModalContent from '../workflow-actions-modal-content/workflow-actions-modal-content';
 
 import { overrides } from './workflow-actions-modal.styles';
 import { type Props } from './workflow-actions-modal.types';
 
-export default function WorkflowActionsModal<R>({
+export default function WorkflowActionsModal<
+  FormData extends FieldValues,
+  SubmissionData,
+  Result,
+>({
   action,
   onClose,
   ...workflowDetailsParams
-}: Props<R>) {
+}: Props<FormData, SubmissionData, Result>) {
   return (
     <Modal
       isOpen={Boolean(action)}

--- a/src/views/workflow-actions/workflow-actions-modal/workflow-actions-modal.types.ts
+++ b/src/views/workflow-actions/workflow-actions-modal/workflow-actions-modal.types.ts
@@ -1,10 +1,12 @@
+import { type FieldValues } from 'react-hook-form';
+
 import { type WorkflowAction } from '../workflow-actions.types';
 
-export type Props<R> = {
+export type Props<FormData extends FieldValues, SubmissionData, Result> = {
   domain: string;
   cluster: string;
   workflowId: string;
   runId: string;
-  action: WorkflowAction<R> | undefined;
+  action: WorkflowAction<FormData, SubmissionData, Result> | undefined;
   onClose: () => void;
 };

--- a/src/views/workflow-actions/workflow-actions-modal/workflow-actions-modal.types.ts
+++ b/src/views/workflow-actions/workflow-actions-modal/workflow-actions-modal.types.ts
@@ -1,8 +1,6 @@
-import { type FieldValues } from 'react-hook-form';
-
 import { type WorkflowAction } from '../workflow-actions.types';
 
-export type Props<FormData extends FieldValues, SubmissionData, Result> = {
+export type Props<FormData, SubmissionData, Result> = {
   domain: string;
   cluster: string;
   workflowId: string;

--- a/src/views/workflow-actions/workflow-actions.tsx
+++ b/src/views/workflow-actions/workflow-actions.tsx
@@ -47,7 +47,7 @@ export default function WorkflowActions() {
   );
 
   const [selectedAction, setSelectedAction] = useState<
-    WorkflowAction<unknown> | undefined
+    WorkflowAction<any, any, any> | undefined
   >(undefined);
 
   return (

--- a/src/views/workflow-actions/workflow-actions.types.ts
+++ b/src/views/workflow-actions/workflow-actions.types.ts
@@ -3,9 +3,10 @@ import { type ReactNode } from 'react';
 import { type IconProps } from 'baseui/icon';
 import {
   type Control,
-  type FieldValues,
   type FieldErrors,
+  type FieldValues,
 } from 'react-hook-form';
+import { type z } from 'zod';
 
 import { type WorkflowActionID as WorkflowActionIDFromConfig } from '@/config/dynamic/resolvers/workflow-actions-enabled.types';
 import { type DescribeWorkflowResponse } from '@/route-handlers/describe-workflow/describe-workflow.types';
@@ -20,18 +21,21 @@ export type WorkflowActionInputParams = {
   cluster: string;
   workflowId: string;
   runId: string;
-  // TODO: add input here for extended workflow actions
 };
 
-export type WorkflowActionSuccessMessageProps<R> = {
-  result: R;
-  inputParams: WorkflowActionInputParams;
+export type WorkflowActionInput<SubmissionData> = WorkflowActionInputParams & {
+  submissionData: SubmissionData;
 };
 
 export type WorkflowActionFormProps<FormData extends FieldValues> = {
   formData: FormData;
   fieldErrors: FieldErrors<FormData>;
   control: Control<FormData>;
+};
+
+export type WorkflowActionSuccessMessageProps<SubmissionData, Result> = {
+  result: Result;
+  inputParams: WorkflowActionInput<SubmissionData>;
 };
 
 export type WorkflowActionNonRunnableStatus =
@@ -41,7 +45,20 @@ export type WorkflowActionRunnableStatus =
   | 'RUNNABLE'
   | WorkflowActionNonRunnableStatus;
 
-export type WorkflowAction<R> = {
+export type WorkflowActionModalForm<FormData, SubmissionData> =
+  FormData extends FieldValues
+    ? {
+        form: (props: WorkflowActionFormProps<FormData>) => ReactNode;
+        formSchema: z.ZodSchema<FormData>;
+        transformFormDataToSubmission: (formData: FormData) => SubmissionData;
+      }
+    : {
+        form?: undefined;
+        formSchema?: undefined;
+        transformFormDataToSubmission?: undefined;
+      };
+
+export type WorkflowAction<FormData, SubmissionData, Result> = {
   id: WorkflowActionID;
   label: string;
   subtitle: string;
@@ -51,7 +68,7 @@ export type WorkflowAction<R> = {
       text: string;
       href: string;
     };
-  };
+  } & WorkflowActionModalForm<FormData, SubmissionData>;
   icon: React.ComponentType<{
     size?: IconProps['size'];
     color?: IconProps['color'];
@@ -61,6 +78,6 @@ export type WorkflowAction<R> = {
   ) => WorkflowActionRunnableStatus;
   apiRoute: string;
   renderSuccessMessage: (
-    props: WorkflowActionSuccessMessageProps<R>
+    props: WorkflowActionSuccessMessageProps<SubmissionData, Result>
   ) => ReactNode;
 };


### PR DESCRIPTION
### Summary
Allow workflow action modal to accept forms as part of the configurations.

### Changes
- add `form`, `formSchema` and `transformFormDataToSubmission` to the modal configurations.
- add `submissionData` to the `WorkflowActionInput`
- add form logic to `WorkflowActionsModalContent`
- Change `Go back` to `Cancel` as the modal is not a navigation change
- General types updates across components