### PR TITLE
Refactor workflow action snackbar to a global provider

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { Rubik } from 'next/font/google';
 
+import SnackbarProvider from '@/components/snackbar-provider/snackbar-provider';
 import ReactQueryProvider from '@/providers/react-query-provider';
 
 import StyletronProvider from '../providers/styletron-provider';
@@ -8,7 +9,6 @@ import StyletronProvider from '../providers/styletron-provider';
 import StyledJsxRegistry from './registry';
 
 import './globals.css';
-import SnackbarProvider from '@/components/snackbar-provider/snackbar-provider';
 
 const inter = Rubik({ subsets: ['latin'] });
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,9 @@ import ReactQueryProvider from '@/providers/react-query-provider';
 import StyletronProvider from '../providers/styletron-provider';
 
 import StyledJsxRegistry from './registry';
+
 import './globals.css';
+import SnackbarProvider from '@/components/snackbar-provider/snackbar-provider';
 
 const inter = Rubik({ subsets: ['latin'] });
 
@@ -26,7 +28,9 @@ export default function RootLayout({
       <StyledJsxRegistry />
       <body className={inter.className}>
         <ReactQueryProvider>
-          <StyletronProvider>{children}</StyletronProvider>
+          <StyletronProvider>
+            <SnackbarProvider>{children}</SnackbarProvider>
+          </StyletronProvider>
         </ReactQueryProvider>
       </body>
     </html>

--- a/src/components/snackbar-provider/snackbar-provider.styles.ts
+++ b/src/components/snackbar-provider/snackbar-provider.styles.ts
@@ -1,0 +1,13 @@
+import { type Theme } from 'baseui';
+import { type SnackbarElementOverrides } from 'baseui/snackbar';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  snackbar: {
+    Root: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        backgroundColor: $theme.colors.contentPositive,
+      }),
+    },
+  } satisfies SnackbarElementOverrides,
+};

--- a/src/components/snackbar-provider/snackbar-provider.tsx
+++ b/src/components/snackbar-provider/snackbar-provider.tsx
@@ -1,0 +1,21 @@
+'use client';
+import {
+  SnackbarProvider as BaseSnackbarProvider,
+  PLACEMENT,
+  DURATION,
+} from 'baseui/snackbar';
+
+import { overrides } from './snackbar-provider.styles';
+import { type Props } from './snackbar-provider.types';
+
+export default function SnackbarProvider({ children }: Props) {
+  return (
+    <BaseSnackbarProvider
+      placement={PLACEMENT.bottom}
+      overrides={overrides.snackbar}
+      defaultDuration={DURATION.infinite}
+    >
+      {children}
+    </BaseSnackbarProvider>
+  );
+}

--- a/src/components/snackbar-provider/snackbar-provider.types.ts
+++ b/src/components/snackbar-provider/snackbar-provider.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  children: React.ReactNode;
+};

--- a/src/test-utils/test-provider.tsx
+++ b/src/test-utils/test-provider.tsx
@@ -9,7 +9,6 @@ import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 // @ts-expect-error Could not find a declaration file for module 'styletron-engine-snapshot'
 import { StyletronSnapshotEngine } from 'styletron-engine-snapshot';
 
-import SnackbarProvider from '@/components/snackbar-provider/snackbar-provider';
 import themeProviderOverrides from '@/config/theme/theme-provider-overrides.config';
 import StyletronProvider from '@/providers/styletron-provider';
 
@@ -76,12 +75,10 @@ export const TestProvider = ({
         styletronEngine: snapshotEngine,
       })}
     >
-      <SnackbarProvider>
-        <MSWMockHandlers endpointsMocks={endpointsMocks} />
-        <MemoryRouterProvider url={router.initialUrl}>
-          <QueryClientProvider client={client}>{children}</QueryClientProvider>
-        </MemoryRouterProvider>
-      </SnackbarProvider>
+      <MSWMockHandlers endpointsMocks={endpointsMocks} />
+      <MemoryRouterProvider url={router.initialUrl}>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </MemoryRouterProvider>
     </StyletronProvider>
   );
 };

--- a/src/test-utils/test-provider.tsx
+++ b/src/test-utils/test-provider.tsx
@@ -9,6 +9,7 @@ import { MemoryRouterProvider } from 'next-router-mock/MemoryRouterProvider';
 // @ts-expect-error Could not find a declaration file for module 'styletron-engine-snapshot'
 import { StyletronSnapshotEngine } from 'styletron-engine-snapshot';
 
+import SnackbarProvider from '@/components/snackbar-provider/snackbar-provider';
 import themeProviderOverrides from '@/config/theme/theme-provider-overrides.config';
 import StyletronProvider from '@/providers/styletron-provider';
 
@@ -75,10 +76,12 @@ export const TestProvider = ({
         styletronEngine: snapshotEngine,
       })}
     >
-      <MSWMockHandlers endpointsMocks={endpointsMocks} />
-      <MemoryRouterProvider url={router.initialUrl}>
-        <QueryClientProvider client={client}>{children}</QueryClientProvider>
-      </MemoryRouterProvider>
+      <SnackbarProvider>
+        <MSWMockHandlers endpointsMocks={endpointsMocks} />
+        <MemoryRouterProvider url={router.initialUrl}>
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        </MemoryRouterProvider>
+      </SnackbarProvider>
     </StyletronProvider>
   );
 };

--- a/src/views/workflow-actions/workflow-action-new-run-success-msg/__tests__/workflow-action-new-run-success-msg.test.tsx
+++ b/src/views/workflow-actions/workflow-action-new-run-success-msg/__tests__/workflow-action-new-run-success-msg.test.tsx
@@ -17,6 +17,7 @@ describe('WorkflowActionNewRunSuccessMsg', () => {
       submissionData: null,
     },
     successMessage: 'Workflow has been restarted.',
+    onDismissMessage: jest.fn(),
   };
 
   it('renders the success message with a link', () => {
@@ -39,5 +40,12 @@ describe('WorkflowActionNewRunSuccessMsg', () => {
       'href',
       `/domains/${domain}/${cluster}/workflows/${workflowId}/${runId}`
     );
+  });
+
+  it('calls the onDismissMessage function when the link is clicked', () => {
+    render(<WorkflowActionNewRunSuccessMsg {...mockProps} />);
+    const link = screen.getByText('Click here');
+    link.click();
+    expect(mockProps.onDismissMessage).toHaveBeenCalled();
   });
 });

--- a/src/views/workflow-actions/workflow-action-new-run-success-msg/workflow-action-new-run-success-msg.tsx
+++ b/src/views/workflow-actions/workflow-action-new-run-success-msg/workflow-action-new-run-success-msg.tsx
@@ -6,6 +6,7 @@ const WorkflowActionNewRunSuccessMsg = ({
   result: { runId },
   inputParams: { workflowId, cluster, domain },
   successMessage,
+  onDismissMessage,
 }: Props) => {
   return (
     <>
@@ -13,6 +14,7 @@ const WorkflowActionNewRunSuccessMsg = ({
       <Link
         color="contentInversePrimary"
         href={`/domains/${domain}/${cluster}/workflows/${workflowId}/${runId}`}
+        onClick={onDismissMessage}
       >
         Click here
       </Link>{' '}

--- a/src/views/workflow-actions/workflow-action-new-run-success-msg/workflow-action-new-run-success-msg.types.tsx
+++ b/src/views/workflow-actions/workflow-action-new-run-success-msg/workflow-action-new-run-success-msg.types.tsx
@@ -5,4 +5,5 @@ export type Props = WorkflowActionSuccessMessageProps<
   { runId: string }
 > & {
   successMessage: string;
+  onDismissMessage: () => void;
 };

--- a/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
+++ b/src/views/workflow-actions/workflow-actions-modal-content/workflow-actions-modal-content.tsx
@@ -70,6 +70,7 @@ export default function WorkflowActionsModalContent<
           message: action.renderSuccessMessage?.({
             result,
             inputParams: params,
+            onDismissMessage: () => dequeue(),
           }),
           startEnhancer: MdCheckCircle,
           actionMessage: 'OK',

--- a/src/views/workflow-actions/workflow-actions.styles.ts
+++ b/src/views/workflow-actions/workflow-actions.styles.ts
@@ -1,7 +1,6 @@
 import { type Theme } from 'baseui';
 import { type ButtonOverrides } from 'baseui/button';
 import { type PopoverOverrides } from 'baseui/popover';
-import { type SnackbarElementOverrides } from 'baseui/snackbar';
 import { type StyleObject } from 'styletron-react';
 
 export const overrides = {
@@ -12,13 +11,6 @@ export const overrides = {
       }),
     },
   } satisfies PopoverOverrides,
-  snackbar: {
-    Root: {
-      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
-        backgroundColor: $theme.colors.contentPositive,
-      }),
-    },
-  } satisfies SnackbarElementOverrides,
   button: {
     BaseButton: {
       style: ({

--- a/src/views/workflow-actions/workflow-actions.tsx
+++ b/src/views/workflow-actions/workflow-actions.tsx
@@ -6,11 +6,6 @@ import {
   StatefulPopover,
   PLACEMENT as POPOVER_PLACEMENT,
 } from 'baseui/popover';
-import {
-  SnackbarProvider,
-  PLACEMENT as SNACKBAR_PLACEMENT,
-  DURATION,
-} from 'baseui/snackbar';
 import { pick } from 'lodash';
 import { useParams } from 'next/navigation';
 import { MdArrowDropDown } from 'react-icons/md';
@@ -57,11 +52,7 @@ export default function WorkflowActions() {
   }
 
   return (
-    <SnackbarProvider
-      placement={SNACKBAR_PLACEMENT.bottom}
-      overrides={overrides.snackbar}
-      defaultDuration={DURATION.infinite}
-    >
+    <>
       <StatefulPopover
         placement={POPOVER_PLACEMENT.bottomRight}
         overrides={overrides.popover}
@@ -93,6 +84,6 @@ export default function WorkflowActions() {
         action={selectedAction}
         onClose={() => setSelectedAction(undefined)}
       />
-    </SnackbarProvider>
+    </>
   );
 }

--- a/src/views/workflow-actions/workflow-actions.types.ts
+++ b/src/views/workflow-actions/workflow-actions.types.ts
@@ -36,6 +36,7 @@ export type WorkflowActionFormProps<FormData extends FieldValues> = {
 export type WorkflowActionSuccessMessageProps<SubmissionData, Result> = {
   result: Result;
   inputParams: WorkflowActionInput<SubmissionData>;
+  onDismissMessage: () => void;
 };
 
 export type WorkflowActionNonRunnableStatus =


### PR DESCRIPTION
### Summary
Moving `SnackbarProvider` to be a global provider instead of having it locally within workflow action component. This allows queuing all messages within the same queue and allow navigation without dismissing all messages.

### Changes
- Create a component for `SnackbarProvider`
- Move the existing `SnackbarProvider` usage to `RootLayout`
- Add `onDismiss` prop to `WorkflowActionNewRunSuccessMsg` to allow dismissing after clicking on the link

### Testing
- Tested existing workflow action snackbar locally.
- Made sure opening new execution dismiss the message
- Made sure navigation doesn't remove the message