### PR TITLE
Show continuedExecutionRunId to a link in wf history

### DIFF
--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -73,7 +73,7 @@ const workflowHistoryEventDetailsConfig = [
   {
     name: 'RunIds as link',
     pathRegex:
-      '(firstExecutionRunId|originalExecutionRunId|newExecutionRunId)$',
+      '(firstExecutionRunId|originalExecutionRunId|newExecutionRunId|continuedExecutionRunId)$',
     valueComponent: ({ entryValue, domain, cluster, workflowId }) => {
       return createElement(WorkflowEventDetailsExecutionLink, {
         domain,


### PR DESCRIPTION
### Summary
Show `continuedExecutionRunId` as a link in history event details


### Screenshots
![Screenshot 2025-04-15 at 15 03 28](https://github.com/user-attachments/assets/5e5e9614-7201-44f1-bf85-22eeeee0d19c)
