### PR TITLE
Fix decisionTaskTimedOutEventSchema parse

### DIFF
--- a/src/utils/data-formatters/schema/history-event-schema.ts
+++ b/src/utils/data-formatters/schema/history-event-schema.ts
@@ -294,7 +294,7 @@ export const decisionTaskTimedOutEventSchema = historyEventBaseSchema.extend({
   attributes: z.literal('decisionTaskTimedOutEventAttributes'),
   decisionTaskTimedOutEventAttributes: z.object({
     scheduledEventId: z.string(),
-    startedEventId: z.coerce.string(), // coerce to string to avoid protoLoader issue of 0 as a number, this happens when reset workflow to decisiion started event.
+    startedEventId: z.coerce.string(), // coerce to string to avoid protoLoader issue of 0 as a number, this happens when reset workflow to decision started event.
     timeoutType: timeoutTypeSchema,
     baseRunId: z.string(),
     newRunId: z.string(),

--- a/src/utils/data-formatters/schema/history-event-schema.ts
+++ b/src/utils/data-formatters/schema/history-event-schema.ts
@@ -294,11 +294,11 @@ export const decisionTaskTimedOutEventSchema = historyEventBaseSchema.extend({
   attributes: z.literal('decisionTaskTimedOutEventAttributes'),
   decisionTaskTimedOutEventAttributes: z.object({
     scheduledEventId: z.string(),
-    startedEventId: z.string(),
+    startedEventId: z.coerce.string(), // coerce to string to avoid protoLoader issue of 0 as a number, this happens when reset workflow to decisiion started event.
     timeoutType: timeoutTypeSchema,
     baseRunId: z.string(),
     newRunId: z.string(),
-    forkEventVersion: z.string(),
+    forkEventVersion: z.coerce.string(),
     reason: z.string(),
     cause: decisionTaskTimedOutCauseSchema,
     requestId: z.string(),


### PR DESCRIPTION
### Summary
Fix parsing `decisionTaskTimedOutEventSchema` when `startedEventId` & `forkEventVersion` values are 0. This happened while reseting the workflow to decision started event.


### Screenshots
Before:
![Screenshot 2025-04-14 at 14 06 13](https://github.com/user-attachments/assets/9d26b6eb-0a3c-48b5-a1da-33f236f9ead9)
After:
![Screenshot 2025-04-14 at 14 28 16](https://github.com/user-attachments/assets/cd842815-eec0-41b5-a961-4576c61b3c04)

