### PR TITLE
Improve performance for parsing wf input

### DIFF
--- a/src/utils/data-formatters/__tests__/format-input-payload.test.ts
+++ b/src/utils/data-formatters/__tests__/format-input-payload.test.ts
@@ -32,7 +32,6 @@ describe('formatInputPayload', () => {
     expect(formatInputPayload(input)).toEqual(expected);
   });
   // end of empty data checks
-
   test('should handle base64 encoded JSON with boolean value', () => {
     const input = { data: btoa(`true`) };
     const expected = [true];

--- a/src/utils/data-formatters/__tests__/format-input-payload.test.ts
+++ b/src/utils/data-formatters/__tests__/format-input-payload.test.ts
@@ -32,6 +32,7 @@ describe('formatInputPayload', () => {
     expect(formatInputPayload(input)).toEqual(expected);
   });
   // end of empty data checks
+
   test('should handle base64 encoded JSON with boolean value', () => {
     const input = { data: btoa(`true`) };
     const expected = [true];

--- a/src/utils/data-formatters/format-input-payload.ts
+++ b/src/utils/data-formatters/format-input-payload.ts
@@ -1,62 +1,96 @@
 import logger from '@/utils/logger';
 
 import losslessJsonParse from '../lossless-json-parse';
+
+const separators = ['\n', ' '];
+
 const formatInputPayload = (
   payload: { data?: string | null } | null | undefined
 ) => {
   const data = payload?.data;
-
   if (!data) {
     return null;
   }
 
   const parsedData = atob(data);
-  return parseJsonLines(parsedData);
+  return parseMultipleInputs(parsedData);
 };
 
-function parseJsonLines(input: string) {
-  const jsonArray = [];
-  let currentJson = '';
-  const separators = ['\n', ' '];
+const extractJsonValue = (input: string, startIndex: number) => {
+  let endIndex = startIndex;
+  let openBrackets = 0;
+  let openBraces = 0;
+  let inString = false;
+  let escapeNext = false; // used to handle escaped quotes
 
-  for (let i = 0; i < input.length; i++) {
-    const char = input[i];
-    if (separators.includes(char)) {
-      // Try to parse the current JSON string
-      if (currentJson) {
-        try {
-          const jsonObject = losslessJsonParse(currentJson);
-          // If successful, add the object to the array
-          jsonArray.push(jsonObject);
-          // Reset currentJson for the next JSON object
-          currentJson = '';
-        } catch {
-          // If parsing fails, treat the separator as part of the currentJson and continue with the next char
-          currentJson += char;
-        }
+  while (endIndex < input.length) {
+    const char = input[endIndex];
+
+    if (escapeNext) {
+      escapeNext = false;
+    } else if (char === '\\') {
+      escapeNext = true;
+    } else if (char === '"' && !inString) {
+      inString = true;
+    } else if (char === '"' && inString) {
+      inString = false;
+    } else if (!inString) {
+      if (char === '[') openBrackets++;
+      if (char === ']') openBrackets--;
+      if (char === '{') openBraces++;
+      if (char === '}') openBraces--;
+
+      // When a separator is found, this indicates the end of a JSON value if we are not inside any array or object
+      if (separators.includes(char) && openBrackets === 0 && openBraces === 0) {
+        break;
       }
-    } else {
-      currentJson += char;
     }
+    endIndex++;
   }
 
-  // Handle case where the last JSON object might be malformed
-  if (currentJson.trim() !== '') {
+  return {
+    startIndex,
+    endIndex,
+    jsonString: input.slice(startIndex, endIndex),
+  };
+};
+
+const parseMultipleInputs = (input: string) => {
+  const results = [];
+  let currentIndex = 0;
+
+  while (currentIndex < input.length) {
+    while (separators.includes(input[currentIndex])) {
+      currentIndex++;
+    }
+    if (currentIndex >= input.length) break;
+
     try {
-      const jsonObject = losslessJsonParse(currentJson);
-      jsonArray.push(jsonObject);
-    } catch {
+      const { startIndex, endIndex, jsonString } = extractJsonValue(
+        input,
+        currentIndex
+      );
+
+      if (endIndex > startIndex) {
+        // move to the end of the string before parsing to avoid parsing the same string if the parsing fails
+        currentIndex = endIndex;
+        results.push(losslessJsonParse(jsonString));
+      } else {
+        currentIndex++;
+      }
+    } catch (error) {
       logger.error(
         {
           input,
-          currentJson,
+          currentIndex,
+          error,
         },
         'Error parsing JSON string'
       );
     }
   }
 
-  return jsonArray;
-}
+  return results;
+};
 
 export default formatInputPayload;

--- a/src/utils/data-formatters/format-input-payload.ts
+++ b/src/utils/data-formatters/format-input-payload.ts
@@ -16,45 +16,6 @@ const formatInputPayload = (
   return parseMultipleInputs(parsedData);
 };
 
-const extractJsonValue = (input: string, startIndex: number) => {
-  let endIndex = startIndex;
-  let openBrackets = 0;
-  let openBraces = 0;
-  let inString = false;
-  let escapeNext = false; // used to handle escaped quotes
-
-  while (endIndex < input.length) {
-    const char = input[endIndex];
-
-    if (escapeNext) {
-      escapeNext = false;
-    } else if (char === '\\') {
-      escapeNext = true;
-    } else if (char === '"' && !inString) {
-      inString = true;
-    } else if (char === '"' && inString) {
-      inString = false;
-    } else if (!inString) {
-      if (char === '[') openBrackets++;
-      if (char === ']') openBrackets--;
-      if (char === '{') openBraces++;
-      if (char === '}') openBraces--;
-
-      // When a separator is found, this indicates the end of a JSON value if we are not inside any array or object
-      if (separators.includes(char) && openBrackets === 0 && openBraces === 0) {
-        break;
-      }
-    }
-    endIndex++;
-  }
-
-  return {
-    startIndex,
-    endIndex,
-    jsonString: input.slice(startIndex, endIndex),
-  };
-};
-
 const parseMultipleInputs = (input: string) => {
   const results = [];
   let currentIndex = 0;
@@ -93,4 +54,42 @@ const parseMultipleInputs = (input: string) => {
   return results;
 };
 
+const extractJsonValue = (input: string, startIndex: number) => {
+  let endIndex = startIndex;
+  let openBrackets = 0;
+  let openBraces = 0;
+  let inString = false;
+  let escapeNext = false; // used to handle escaped quotes
+
+  while (endIndex < input.length) {
+    const char = input[endIndex];
+
+    if (escapeNext) {
+      escapeNext = false;
+    } else if (char === '\\') {
+      escapeNext = true;
+    } else if (char === '"' && !inString) {
+      inString = true;
+    } else if (char === '"' && inString) {
+      inString = false;
+    } else if (!inString) {
+      if (char === '[') openBrackets++;
+      if (char === ']') openBrackets--;
+      if (char === '{') openBraces++;
+      if (char === '}') openBraces--;
+
+      // When a separator is found, this indicates the end of a JSON value if we are not inside any array or object
+      if (separators.includes(char) && openBrackets === 0 && openBraces === 0) {
+        break;
+      }
+    }
+    endIndex++;
+  }
+
+  return {
+    startIndex,
+    endIndex,
+    jsonString: input.slice(startIndex, endIndex),
+  };
+};
 export default formatInputPayload;


### PR DESCRIPTION
### Summary
Improving parsing of multiple json inputs that can be separated by spaces/newlines. The old logic used to attempt a json parse whenever a separator is found. This caused slow performance with large inputs as the separators can be found so many times within each json. The new approach fixes that by having a single pass of the string and only attempt to parse the json when the separator is found outside a between json inputs.


### Performance
Before: 4s for the sample json
![Screenshot 2025-04-28 at 15 15 21](https://github.com/user-attachments/assets/b01499dd-9ef0-42d9-81b3-c6aba2eb6381)

After: 7ms for the same sample json
![Screenshot 2025-04-28 at 22 13 06](https://github.com/user-attachments/assets/619e2baf-442a-44b8-8db9-10bd5c526c0a)