### PR TITLE
Signal workflow API

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/(actions)/signal/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/(actions)/signal/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { signalWorkflow } from '@/route-handlers/signal-workflow/signal-workflow';
+import { type RequestParams } from '@/route-handlers/signal-workflow/signal-workflow.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function POST(
+  request: NextRequest,
+  options: { params: RequestParams['params'] }
+) {
+  return routeHandlerWithMiddlewares(
+    signalWorkflow,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+} 

--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/(actions)/signal/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/[runId]/(actions)/signal/route.ts
@@ -15,4 +15,4 @@ export async function POST(
     options,
     routeHandlersDefaultMiddlewares
   );
-} 
+}

--- a/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
+++ b/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
@@ -9,8 +9,8 @@ import { SignalWorkflowSubmissionData } from '@/views/workflow-actions/workflow-
 
 const defaultRequestBody = {
   signalName: 'test-signal',
-  signalInput: { data: 'test-input' },
-};
+  signalInput: 'test-input' ,
+} satisfies SignalWorkflowSubmissionData;
 
 describe(signalWorkflow.name, () => {
   beforeEach(() => {
@@ -18,12 +18,7 @@ describe(signalWorkflow.name, () => {
   });
 
   it('calls signalWorkflow and returns valid response', async () => {
-    const { res, mockSignalWorkflow } = await setup({
-      requestBody: JSON.stringify({
-        signalName: 'custom-signal',
-        signalInput: 'custom-input',
-      }),
-    });
+    const { res, mockSignalWorkflow } = await setup({});
 
     expect(mockSignalWorkflow).toHaveBeenCalledWith({
       domain: 'mock-domain',

--- a/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
+++ b/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
@@ -2,15 +2,17 @@ import { NextRequest } from 'next/server';
 
 import { GRPCError } from '@/utils/grpc/grpc-error';
 import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
-import { type SignalWorkflowSubmissionData } from '@/views/workflow-actions/workflow-action-signal-form/workflow-action-signal-form.types';
 
 import { signalWorkflow } from '../signal-workflow';
-import { type Context } from '../signal-workflow.types';
+import {
+  type SignalWorkflowRequestBody,
+  type Context,
+} from '../signal-workflow.types';
 
 const defaultRequestBody = {
   signalName: 'test-signal',
   signalInput: 'test-input',
-} satisfies SignalWorkflowSubmissionData;
+} satisfies SignalWorkflowRequestBody;
 
 describe(signalWorkflow.name, () => {
   beforeEach(() => {

--- a/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
+++ b/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
@@ -11,7 +11,7 @@ import {
 
 const defaultRequestBody = {
   signalName: 'test-signal',
-  signalInput: 'test-input',
+  signalInput: '"test-input"',
 } satisfies SignalWorkflowRequestBody;
 
 describe(signalWorkflow.name, () => {
@@ -29,7 +29,7 @@ describe(signalWorkflow.name, () => {
         runId: 'mock-runid',
       },
       signalName: 'test-signal',
-      signalInput: { data: Buffer.from('test-input') },
+      signalInput: { data: Buffer.from('"test-input"') },
     });
 
     const responseJson = await res.json();

--- a/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
+++ b/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
@@ -2,14 +2,14 @@ import { NextRequest } from 'next/server';
 
 import { GRPCError } from '@/utils/grpc/grpc-error';
 import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+import { type SignalWorkflowSubmissionData } from '@/views/workflow-actions/workflow-action-signal-form/workflow-action-signal-form.types';
 
 import { signalWorkflow } from '../signal-workflow';
 import { type Context } from '../signal-workflow.types';
-import { SignalWorkflowSubmissionData } from '@/views/workflow-actions/workflow-action-signal-form/workflow-action-signal-form.types';
 
 const defaultRequestBody = {
   signalName: 'test-signal',
-  signalInput: 'test-input' ,
+  signalInput: 'test-input',
 } satisfies SignalWorkflowSubmissionData;
 
 describe(signalWorkflow.name, () => {
@@ -119,4 +119,4 @@ async function setup({
   );
 
   return { res, mockSignalWorkflow };
-} 
+}

--- a/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
+++ b/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from 'next/server';
+
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import { signalWorkflow } from '../signal-workflow';
+import { type Context } from '../signal-workflow.types';
+import { SignalWorkflowSubmissionData } from '@/views/workflow-actions/workflow-action-signal-form/workflow-action-signal-form.types';
+
+const defaultRequestBody = {
+  signalName: 'test-signal',
+  signalInput: { data: 'test-input' },
+};
+
+describe(signalWorkflow.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls signalWorkflow and returns valid response', async () => {
+    const { res, mockSignalWorkflow } = await setup({
+      requestBody: JSON.stringify({
+        signalName: 'custom-signal',
+        signalInput: 'custom-input',
+      }),
+    });
+
+    expect(mockSignalWorkflow).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      workflowExecution: {
+        workflowId: 'mock-wfid',
+        runId: 'mock-runid',
+      },
+      signalName: 'test-signal',
+      signalInput: { data: Buffer.from('test-input') },
+    });
+
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({});
+  });
+
+  it('calls signalWorkflow without signalInput when not provided', async () => {
+    const { mockSignalWorkflow } = await setup({
+      requestBody: JSON.stringify({
+        signalName: 'signal-without-input',
+      }),
+    });
+
+    expect(mockSignalWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        signalName: 'signal-without-input',
+        signalInput: undefined,
+      })
+    );
+  });
+
+  it('returns an error if something went wrong in the backend', async () => {
+    const { res, mockSignalWorkflow } = await setup({
+      error: true,
+    });
+
+    expect(mockSignalWorkflow).toHaveBeenCalled();
+
+    expect(res.status).toEqual(500);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Could not signal workflow',
+      })
+    );
+  });
+
+  it('returns an error if the signal input has an unexpected format', async () => {
+    const { res, mockSignalWorkflow } = await setup({
+      requestBody: JSON.stringify({
+        signalName: 'test-signal',
+        signalInput: 'not-an-object', // should be an object
+      } satisfies SignalWorkflowSubmissionData),
+    });
+
+    expect(mockSignalWorkflow).not.toHaveBeenCalled();
+
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Invalid values provided for workflow signal',
+      })
+    );
+  });
+});
+
+async function setup({
+  requestBody = JSON.stringify(defaultRequestBody),
+  error,
+}: {
+  requestBody?: string;
+  error?: true;
+}) {
+  const mockSignalWorkflow = jest
+    .spyOn(mockGrpcClusterMethods, 'signalWorkflow')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw new GRPCError('Could not signal workflow');
+      }
+      return {};
+    });
+
+  const res = await signalWorkflow(
+    new NextRequest('http://localhost', {
+      method: 'POST',
+      body: requestBody ?? '{}',
+    }),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        workflowId: 'mock-wfid',
+        runId: 'mock-runid',
+      },
+    },
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockSignalWorkflow };
+} 

--- a/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
+++ b/src/route-handlers/signal-workflow/__tests__/signal-workflow.node.ts
@@ -72,7 +72,7 @@ describe(signalWorkflow.name, () => {
       requestBody: JSON.stringify({
         signalName: 'test-signal',
         signalInput: 'not-an-object', // should be an object
-      } satisfies SignalWorkflowSubmissionData),
+      } satisfies SignalWorkflowRequestBody),
     });
 
     expect(mockSignalWorkflow).not.toHaveBeenCalled();

--- a/src/route-handlers/signal-workflow/schemas/signal-workflow-input-schema.ts
+++ b/src/route-handlers/signal-workflow/schemas/signal-workflow-input-schema.ts
@@ -1,0 +1,15 @@
+import losslessJsonParse from "@/utils/lossless-json-parse";
+import { z } from "zod";
+
+const signalWorkflowInputSchema = z.string().superRefine((str, ctx) => {
+  if (!str) return undefined;
+
+  try {
+    return losslessJsonParse(str);
+  } catch {
+    ctx.addIssue({ code: 'custom', message: 'Invalid JSON' });
+    return z.NEVER;
+  }
+});
+
+export default signalWorkflowInputSchema;

--- a/src/route-handlers/signal-workflow/schemas/signal-workflow-input-schema.ts
+++ b/src/route-handlers/signal-workflow/schemas/signal-workflow-input-schema.ts
@@ -1,5 +1,6 @@
-import losslessJsonParse from "@/utils/lossless-json-parse";
-import { z } from "zod";
+import { z } from 'zod';
+
+import losslessJsonParse from '@/utils/lossless-json-parse';
 
 const signalWorkflowInputSchema = z.string().superRefine((str, ctx) => {
   if (!str) return undefined;

--- a/src/route-handlers/signal-workflow/schemas/signal-workflow-request-body-schema.ts
+++ b/src/route-handlers/signal-workflow/schemas/signal-workflow-request-body-schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import signalWorkflowInputSchema from './signal-workflow-input-schema';
+
+const signalWorkflowRequestBodySchema = z.object({
+  signalName: z.string().min(1),
+  signalInput: signalWorkflowInputSchema.optional(),
+});
+
+export default signalWorkflowRequestBodySchema; 

--- a/src/route-handlers/signal-workflow/schemas/signal-workflow-request-body-schema.ts
+++ b/src/route-handlers/signal-workflow/schemas/signal-workflow-request-body-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+
 import signalWorkflowInputSchema from './signal-workflow-input-schema';
 
 const signalWorkflowRequestBodySchema = z.object({
@@ -6,4 +7,4 @@ const signalWorkflowRequestBodySchema = z.object({
   signalInput: signalWorkflowInputSchema.optional(),
 });
 
-export default signalWorkflowRequestBodySchema; 
+export default signalWorkflowRequestBodySchema;

--- a/src/route-handlers/signal-workflow/signal-workflow.ts
+++ b/src/route-handlers/signal-workflow/signal-workflow.ts
@@ -4,8 +4,8 @@ import decodeUrlParams from '@/utils/decode-url-params';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
-import { type Context, type RequestParams } from './signal-workflow.types';
 import signalWorkflowRequestBodySchema from './schemas/signal-workflow-request-body-schema';
+import { type Context, type RequestParams } from './signal-workflow.types';
 
 export async function signalWorkflow(
   request: NextRequest,
@@ -13,7 +13,8 @@ export async function signalWorkflow(
   ctx: Context
 ) {
   const requestBody = await request.json();
-  const { data, error } = signalWorkflowRequestBodySchema.safeParse(requestBody);
+  const { data, error } =
+    signalWorkflowRequestBodySchema.safeParse(requestBody);
 
   if (error) {
     return NextResponse.json(
@@ -35,7 +36,9 @@ export async function signalWorkflow(
         runId: decodedParams.runId,
       },
       signalName: data.signalName,
-      signalInput: data.signalInput ? { data: Buffer.from(data.signalInput) } : undefined,
+      signalInput: data.signalInput
+        ? { data: Buffer.from(data.signalInput) }
+        : undefined,
       // TODO: add user identity
     });
 
@@ -55,4 +58,4 @@ export async function signalWorkflow(
       { status: getHTTPStatusCode(e) }
     );
   }
-} 
+}

--- a/src/route-handlers/signal-workflow/signal-workflow.ts
+++ b/src/route-handlers/signal-workflow/signal-workflow.ts
@@ -1,0 +1,58 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import decodeUrlParams from '@/utils/decode-url-params';
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import { type Context, type RequestParams } from './signal-workflow.types';
+import signalWorkflowRequestBodySchema from './schemas/signal-workflow-request-body-schema';
+
+export async function signalWorkflow(
+  request: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const requestBody = await request.json();
+  const { data, error } = signalWorkflowRequestBodySchema.safeParse(requestBody);
+
+  if (error) {
+    return NextResponse.json(
+      {
+        message: 'Invalid values provided for workflow signal',
+        validationErrors: error.errors,
+      },
+      { status: 400 }
+    );
+  }
+
+  const decodedParams = decodeUrlParams(requestParams.params);
+
+  try {
+    const response = await ctx.grpcClusterMethods.signalWorkflow({
+      domain: decodedParams.domain,
+      workflowExecution: {
+        workflowId: decodedParams.workflowId,
+        runId: decodedParams.runId,
+      },
+      signalName: data.signalName,
+      signalInput: data.signalInput ? { data: Buffer.from(data.signalInput) } : undefined,
+      // TODO: add user identity
+    });
+
+    return NextResponse.json(response);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: decodedParams, error: e },
+      'Error signaling workflow'
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError ? e.message : 'Error signaling workflow',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+} 

--- a/src/route-handlers/signal-workflow/signal-workflow.types.ts
+++ b/src/route-handlers/signal-workflow/signal-workflow.types.ts
@@ -1,4 +1,8 @@
+import { type z } from 'zod';
+
 import { type GRPCClusterMethods } from '@/utils/grpc/grpc-client';
+
+import type signalWorkflowRequestBodySchema from './schemas/signal-workflow-request-body-schema';
 
 export type RequestParams = {
   params: {
@@ -8,6 +12,10 @@ export type RequestParams = {
     runId: string;
   };
 };
+
+export type SignalWorkflowRequestBody = z.infer<
+  typeof signalWorkflowRequestBodySchema
+>;
 
 export type Context = {
   grpcClusterMethods: GRPCClusterMethods;

--- a/src/route-handlers/signal-workflow/signal-workflow.types.ts
+++ b/src/route-handlers/signal-workflow/signal-workflow.types.ts
@@ -1,0 +1,14 @@
+import { type GRPCClusterMethods } from '@/utils/grpc/grpc-client';
+
+export type RequestParams = {
+  params: {
+    domain: string;
+    cluster: string;
+    workflowId: string;
+    runId: string;
+  };
+};
+
+export type Context = {
+  grpcClusterMethods: GRPCClusterMethods;
+}; 

--- a/src/route-handlers/signal-workflow/signal-workflow.types.ts
+++ b/src/route-handlers/signal-workflow/signal-workflow.types.ts
@@ -11,4 +11,4 @@ export type RequestParams = {
 
 export type Context = {
   grpcClusterMethods: GRPCClusterMethods;
-}; 
+};


### PR DESCRIPTION
### Summary
Create REST end point for signaling workflows. It accepts `signalName` and an optional JSON `signalInput`.


### Testing
- locally by passing signalName and inputs for running workflows