### PR TITLE
Add word-break for table cells

### DIFF
--- a/src/components/table/table-body-cell/table-body-cell.styles.ts
+++ b/src/components/table/table-body-cell/table-body-cell.styles.ts
@@ -4,5 +4,6 @@ import { StyledTableBodyCell } from 'baseui/table-semantic';
 export const styled = {
   TableBodyCell: withStyle<typeof StyledTableBodyCell>(StyledTableBodyCell, {
     verticalAlign: 'middle',
+    wordBreak: 'break-word',
   }),
 };


### PR DESCRIPTION
## Summary
Add word-break for table cells to fix styling for abnormally long cell values.

## Test plan
Ran locally.

Before:
<img width="1705" alt="Screenshot 2025-05-21 at 3 37 12 PM" src="https://github.com/user-attachments/assets/e70f4f93-692a-4e23-9d1c-9dced921fb66" />

After:
<img width="1701" alt="Screenshot 2025-05-21 at 3 37 25 PM" src="https://github.com/user-attachments/assets/bf62b329-6518-4f17-83d5-46509db999a2" />
