### PR TITLE
fix duration to read correct startTime

### DIFF
--- a/src/views/workflow-history/__fixtures__/workflow-history-event-groups.ts
+++ b/src/views/workflow-history/__fixtures__/workflow-history-event-groups.ts
@@ -14,7 +14,8 @@ export const mockActivityEventGroup: ActivityHistoryGroup = {
   status: 'COMPLETED',
   eventsMetadata: [],
   hasMissingEvents: false,
-  timeMs: 1725747380000,
+  timeMs: 1725747370632,
+  startTimeMs: 1725747380000,
   timeLabel: 'Mock time label',
   events: completedActivityTaskEvents,
 };
@@ -26,6 +27,7 @@ export const mockTimerEventGroup: TimerHistoryGroup = {
   eventsMetadata: [],
   hasMissingEvents: false,
   timeMs: 1725747380000,
+  startTimeMs: 1725747380000,
   timeLabel: 'Mock time label',
   events: [startTimerTaskEvent],
 };
@@ -37,6 +39,7 @@ export const mockSingleEventGroup: SingleEventHistoryGroup = {
   eventsMetadata: [],
   hasMissingEvents: false,
   timeMs: 1725747380000,
+  startTimeMs: 1725747380000,
   timeLabel: 'Mock time label',
   events: [startWorkflowExecutionEvent],
 };

--- a/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
+++ b/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
@@ -92,6 +92,11 @@ describe('getCommonHistoryGroupFields', () => {
     expect(group.closeTimeMs).toEqual(null);
   });
 
+  it('should return group with startTimeMs equal to first event timeMs', () => {
+    const group = setup({});
+    expect(group.startTimeMs).toEqual(group.eventsMetadata[0].timeMs);
+  });
+
   const groupFieldsExtractedFromEventsMetadaTests: {
     name: string;
     groupField: 'events' | 'eventsMetadata' | 'status' | 'timeMs' | 'timeLabel';

--- a/src/views/workflow-history/helpers/get-common-history-group-fields.ts
+++ b/src/views/workflow-history/helpers/get-common-history-group-fields.ts
@@ -24,6 +24,7 @@ export default function getCommonHistoryGroupFields<
   | 'timeMs'
   | 'timeLabel'
   | 'closeTimeMs'
+  | 'startTimeMs'
 > {
   const eventsMetadata = events.map((event, index) => {
     const attrs = event.attributes as GroupT['events'][number]['attributes'];
@@ -47,6 +48,7 @@ export default function getCommonHistoryGroupFields<
 
   const groupStatus = eventsMetadata[eventsMetadata.length - 1].status;
   const groupTimeMs = eventsMetadata[eventsMetadata.length - 1].timeMs;
+  const groupStartTimeMs = eventsMetadata[0].timeMs;
   const groupTimeLabel = eventsMetadata[eventsMetadata.length - 1].timeLabel;
   const groupCloseTimeMs = closeEvent?.eventTime
     ? parseGrpcTimestamp(closeEvent.eventTime)
@@ -57,6 +59,7 @@ export default function getCommonHistoryGroupFields<
     events,
     status: groupStatus,
     timeMs: groupTimeMs,
+    startTimeMs: groupStartTimeMs,
     closeTimeMs: groupCloseTimeMs,
     timeLabel: groupTimeLabel,
   };

--- a/src/views/workflow-history/workflow-history-compact-event-card/__tests__/workflow-history-compact-event-card.test.tsx
+++ b/src/views/workflow-history/workflow-history-compact-event-card/__tests__/workflow-history-compact-event-card.test.tsx
@@ -71,9 +71,9 @@ describe('WorkflowHistoryCompactEventCard', () => {
     expect(mockOnClick).toHaveBeenCalled();
   });
 
-  it('should render duration badge passing showOngoingOnly as true when timeMs is provided', () => {
+  it('should render duration badge passing showOngoingOnly as true when startTimeMs is provided', () => {
     setup({
-      timeMs: 1726652232190.7927,
+      startTimeMs: 1726652232190.7927,
     });
     expect(WorkflowHistoryEventsDurationBadge).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -83,11 +83,10 @@ describe('WorkflowHistoryCompactEventCard', () => {
     );
   });
 
-  it('does not render duration badge when timeMs is not provided', () => {
+  it('should not render duration badge when startTimeMs is not provided', () => {
     setup({
-      timeMs: null,
+      startTimeMs: null,
     });
-
     expect(screen.queryByText('Duration Badge')).not.toBeInTheDocument();
   });
 });
@@ -102,7 +101,7 @@ function setup(props: Partial<Props>) {
         status="COMPLETED"
         label="test label"
         onClick={mockOnClick}
-        timeMs={null}
+        startTimeMs={null}
         closeTimeMs={null}
         events={[startWorkflowExecutionEvent]}
         workflowCloseTimeMs={null}

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.tsx
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.tsx
@@ -23,7 +23,7 @@ export default function WorkflowHistoryCompactEventCard({
   showLabelPlaceholder,
   selected,
   disabled,
-  timeMs,
+  startTimeMs,
   badges,
   closeTimeMs,
   events,
@@ -65,13 +65,14 @@ export default function WorkflowHistoryCompactEventCard({
                   color="primary"
                 />
               ))}
-            {timeMs && (
+            {startTimeMs && (
               <span className={cls.durationContainer}>
                 <WorkflowHistoryEventsDurationBadge
-                  startTime={timeMs}
+                  startTime={startTimeMs}
                   closeTime={closeTimeMs}
                   eventsCount={events.length}
                   hasMissingEvents={hasMissingEvents}
+                  loadingMoreEvents={!statusReady}
                   workflowCloseTime={workflowCloseTimeMs}
                   workflowIsArchived={workflowIsArchived}
                   workflowCloseStatus={workflowCloseStatus}

--- a/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.types.ts
+++ b/src/views/workflow-history/workflow-history-compact-event-card/workflow-history-compact-event-card.types.ts
@@ -12,7 +12,7 @@ export type Props = Pick<
   | 'status'
   | 'badges'
   | 'resetToDecisionEventId'
-  | 'timeMs'
+  | 'startTimeMs'
   | 'closeTimeMs'
 > & {
   statusReady: boolean;

--- a/src/views/workflow-history/workflow-history-events-duration-badge/__tests__/workflow-history-events-duration-badge.test.tsx
+++ b/src/views/workflow-history/workflow-history-events-duration-badge/__tests__/workflow-history-events-duration-badge.test.tsx
@@ -64,6 +64,14 @@ describe('WorkflowHistoryEventsDurationBadge', () => {
     expect(screen.getByText('Duration: 120')).toBeInTheDocument();
   });
 
+  it('does not render badge when loading more events', () => {
+    setup({
+      loadingMoreEvents: true,
+    });
+
+    expect(screen.queryByText(/Duration:/)).not.toBeInTheDocument();
+  });
+
   it('does not render badge when workflow is archived without close time', () => {
     setup({
       closeTime: null,
@@ -133,6 +141,7 @@ function setup({
   closeTime,
   eventsCount = 2,
   hasMissingEvents = false,
+  loadingMoreEvents = false,
   workflowIsArchived = false,
   workflowCloseStatus = WorkflowExecutionCloseStatus.WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID,
   workflowCloseTime = null,
@@ -143,6 +152,7 @@ function setup({
       closeTime={closeTime}
       eventsCount={eventsCount}
       hasMissingEvents={hasMissingEvents}
+      loadingMoreEvents={loadingMoreEvents}
       workflowIsArchived={workflowIsArchived}
       workflowCloseStatus={workflowCloseStatus}
       workflowCloseTime={workflowCloseTime}

--- a/src/views/workflow-history/workflow-history-events-duration-badge/helpers/__tests__/get-formatted-events-duration.test.ts
+++ b/src/views/workflow-history/workflow-history-events-duration-badge/helpers/__tests__/get-formatted-events-duration.test.ts
@@ -2,7 +2,9 @@ import getFormattedEventsDuration from '../get-formatted-events-duration';
 
 jest.mock('@/utils/data-formatters/format-duration', () => ({
   __esModule: true,
-  default: jest.fn((duration) => `mocked: ${duration.seconds}s`),
+  default: jest.fn(
+    (duration) => `mocked: ${duration.seconds}s ${duration.nanos / 1000000}ms`
+  ),
 }));
 
 describe('getFormattedEventsDuration', () => {
@@ -11,7 +13,7 @@ describe('getFormattedEventsDuration', () => {
       '2021-01-01T00:00:00Z',
       '2021-01-01T00:00:00Z'
     );
-    expect(duration).toEqual('mocked: 0s');
+    expect(duration).toEqual('mocked: 0s 0ms');
   });
 
   it('should return correct duration for 1 minute', () => {
@@ -19,7 +21,7 @@ describe('getFormattedEventsDuration', () => {
       '2021-01-01T00:00:00Z',
       '2021-01-01T00:01:00Z'
     );
-    expect(duration).toEqual('mocked: 60s');
+    expect(duration).toEqual('mocked: 60s 0ms');
   });
 
   it('should return correct duration for 1 hour, 2 minutes, 3 seconds', () => {
@@ -27,13 +29,13 @@ describe('getFormattedEventsDuration', () => {
       '2021-01-01T01:02:03Z',
       '2021-01-01T02:04:06Z'
     );
-    expect(duration).toEqual(`mocked: ${60 * 60 + 2 * 60 + 3}s`);
+    expect(duration).toEqual(`mocked: ${60 * 60 + 2 * 60 + 3}s 0ms`);
   });
 
   it('should handle endTime as null (use current time)', () => {
     const start = new Date(Date.now() - 60000).toISOString(); // 1 minute ago
     const duration = getFormattedEventsDuration(start, null);
-    expect(duration).toEqual('mocked: 60s');
+    expect(duration).toEqual('mocked: 60s 0ms');
   });
 
   it('should handle negative durations (start after end)', () => {
@@ -41,6 +43,29 @@ describe('getFormattedEventsDuration', () => {
       '2021-01-01T01:00:00Z',
       '2021-01-01T00:00:00Z'
     );
-    expect(duration).toEqual('mocked: -3600s');
+    expect(duration).toEqual('mocked: -3600s 0ms');
+  });
+
+  it('should handle numeric durations', () => {
+    const duration = getFormattedEventsDuration(1726652232190, 1726652292194);
+    expect(duration).toEqual('mocked: 60s 4ms');
+  });
+
+  it('should remove ms from duration when hideMs is true', () => {
+    const duration = getFormattedEventsDuration(
+      1726652232190,
+      1726652292194,
+      true
+    );
+    expect(duration).toEqual('mocked: 60s');
+  });
+
+  it('should not hide ms if there are no bigger units', () => {
+    const duration = getFormattedEventsDuration(
+      1726652232190,
+      1726652232194,
+      true
+    );
+    expect(duration).toEqual('mocked: 0s 4ms');
   });
 });

--- a/src/views/workflow-history/workflow-history-events-duration-badge/helpers/get-formatted-events-duration.ts
+++ b/src/views/workflow-history/workflow-history-events-duration-badge/helpers/get-formatted-events-duration.ts
@@ -2,18 +2,27 @@ import formatDuration from '@/utils/data-formatters/format-duration';
 import dayjs from '@/utils/datetime/dayjs';
 
 export default function getFormattedEventsDuration(
-  startTime: Date | string | number,
-  endTime: Date | string | number | null | undefined
+  startTime: Date | string | number | null,
+  endTime: Date | string | number | null | undefined,
+  hideMs: boolean = false
 ) {
   const end = endTime ? dayjs(endTime) : dayjs();
   const start = dayjs(startTime);
   const diff = end.diff(start);
   const durationObj = dayjs.duration(diff);
-  return formatDuration(
+  const seconds = Math.floor(durationObj.asSeconds());
+
+  const duration = formatDuration(
     {
-      seconds: durationObj.asSeconds().toString(),
-      nanos: 0,
+      seconds: seconds.toString(),
+      nanos: (durationObj.asMilliseconds() - seconds * 1000) * 1000000,
     },
     { separator: ' ' }
   );
+  // TODO: add this functionality to formatDuration in more reusable way
+  if (hideMs && seconds > 0) {
+    return duration.replace(/ \d+ms/i, '');
+  }
+
+  return duration;
 }

--- a/src/views/workflow-history/workflow-history-events-duration-badge/workflow-history-events-duration-badge.tsx
+++ b/src/views/workflow-history/workflow-history-events-duration-badge/workflow-history-events-duration-badge.tsx
@@ -12,6 +12,7 @@ export default function WorkflowHistoryEventsDurationBadge({
   workflowCloseStatus,
   eventsCount,
   hasMissingEvents,
+  loadingMoreEvents,
   workflowCloseTime,
   showOngoingOnly,
 }: Props) {
@@ -20,23 +21,25 @@ export default function WorkflowHistoryEventsDurationBadge({
     workflowIsArchived ||
     workflowCloseStatus !== 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID';
   const singleEvent = eventsCount === 1 && !hasMissingEvents;
-  const noDuration = singleEvent || (workflowEnded && !endTime);
+  const noDuration =
+    loadingMoreEvents || singleEvent || (workflowEnded && !endTime);
   const hideDuration = (showOngoingOnly && endTime) || noDuration;
+  const isOngoing = !endTime && !hideDuration;
 
   const [duration, setDuration] = useState<string>(() =>
-    getFormattedEventsDuration(startTime, endTime)
+    getFormattedEventsDuration(startTime, endTime, isOngoing)
   );
 
   useEffect(() => {
-    setDuration(getFormattedEventsDuration(startTime, endTime));
-    if (!endTime && !hideDuration) {
+    setDuration(getFormattedEventsDuration(startTime, endTime, isOngoing));
+    if (isOngoing) {
       const interval = setInterval(() => {
-        setDuration(getFormattedEventsDuration(startTime, endTime));
+        setDuration(getFormattedEventsDuration(startTime, endTime, true));
       }, 1000);
 
       return () => clearInterval(interval);
     }
-  }, [startTime, endTime, hideDuration]);
+  }, [startTime, endTime, isOngoing]);
 
   if (hideDuration) {
     return null;

--- a/src/views/workflow-history/workflow-history-events-duration-badge/workflow-history-events-duration-badge.types.ts
+++ b/src/views/workflow-history/workflow-history-events-duration-badge/workflow-history-events-duration-badge.types.ts
@@ -6,6 +6,7 @@ export type Props = {
   workflowIsArchived: boolean;
   workflowCloseStatus: WorkflowExecutionCloseStatus | null | undefined;
   eventsCount: number;
+  loadingMoreEvents: boolean;
   hasMissingEvents: boolean;
   workflowCloseTime: Date | string | number | null | undefined;
   showOngoingOnly?: boolean;

--- a/src/views/workflow-history/workflow-history-filters-status/helpers/__tests__/filter-events-by-event-status.test.ts
+++ b/src/views/workflow-history/workflow-history-filters-status/helpers/__tests__/filter-events-by-event-status.test.ts
@@ -8,6 +8,7 @@ const ACTIVITY_HISTORY_GROUP_COMPLETED: ActivityHistoryGroup = {
   status: 'COMPLETED',
   hasMissingEvents: false,
   timeMs: 123456789,
+  startTimeMs: 123456789,
   timeLabel: 'Mock time label',
   groupType: 'Activity',
   events: [],

--- a/src/views/workflow-history/workflow-history-timeline-chart/helpers/__tests__/convert-event-group-to-timeline-item.test.ts
+++ b/src/views/workflow-history/workflow-history-timeline-chart/helpers/__tests__/convert-event-group-to-timeline-item.test.ts
@@ -24,7 +24,7 @@ describe(convertEventGroupToTimelineItem.name, () => {
       id: 1,
       className: 'mock-class-name',
       content: 'Mock event',
-      end: new Date('2024-09-07T22:16:20.000Z'),
+      end: new Date('2024-09-07T22:16:10.632Z'),
       start: new Date('2024-09-07T22:16:10.599Z'),
       title: 'Mock event: Mock time label',
       type: 'range',

--- a/src/views/workflow-history/workflow-history-timeline-group/__tests__/workflow-history-timeline-group.test.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-group/__tests__/workflow-history-timeline-group.test.tsx
@@ -115,13 +115,17 @@ describe('WorkflowHistoryTimelineGroup', () => {
     expect(mockOnReset).toHaveBeenCalledTimes(1);
   });
 
-  it('renders duration badge when timeMs is provided', () => {
-    setup({ timeMs: 1726652232190.7927 });
+  it('should render duration badge when startTimeMs is provided', () => {
+    setup({
+      startTimeMs: 1726652232190.7927,
+    });
     expect(screen.getByText('Duration Badge')).toBeInTheDocument();
   });
 
-  it('does not render duration badge when timeMs is not provided', () => {
-    setup({ timeMs: null });
+  it('should not render duration badge when startTimeMs is not provided', () => {
+    setup({
+      startTimeMs: null,
+    });
     expect(screen.queryByText('Duration Badge')).not.toBeInTheDocument();
   });
 });
@@ -129,6 +133,7 @@ describe('WorkflowHistoryTimelineGroup', () => {
 function setup({
   label = 'Workflow Started',
   hasMissingEvents = false,
+  showLoadingMoreEvents = false,
   eventsMetadata = [
     {
       label: 'Started',
@@ -153,7 +158,7 @@ function setup({
   workflowCloseStatus,
   workflowIsArchived = false,
   workflowCloseTimeMs = null,
-  timeMs = null,
+  startTimeMs = 1726652232190.7927,
 }: Partial<Props>) {
   const mockOnReset = jest.fn();
   const user = userEvent.setup();
@@ -164,7 +169,9 @@ function setup({
       isLastEvent={isLastEvent}
       label={label}
       timeLabel={timeLabel}
+      startTimeMs={startTimeMs}
       hasMissingEvents={hasMissingEvents}
+      showLoadingMoreEvents={showLoadingMoreEvents}
       status={status}
       decodedPageUrlParams={decodedPageUrlParams}
       getIsEventExpanded={jest.fn()}
@@ -175,7 +182,6 @@ function setup({
       workflowCloseStatus={workflowCloseStatus}
       workflowIsArchived={workflowIsArchived}
       workflowCloseTimeMs={workflowCloseTimeMs}
-      timeMs={timeMs}
     />
   );
   return { mockOnReset, user };

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.tsx
@@ -21,7 +21,7 @@ export default function WorkflowHistoryTimelineGroup({
   status,
   label,
   timeLabel,
-  timeMs,
+  startTimeMs,
   closeTimeMs,
   workflowCloseTimeMs,
   workflowCloseStatus,
@@ -30,6 +30,7 @@ export default function WorkflowHistoryTimelineGroup({
   isLastEvent,
   eventsMetadata,
   hasMissingEvents,
+  showLoadingMoreEvents,
   decodedPageUrlParams,
   badges,
   resetToDecisionEventId,
@@ -52,7 +53,7 @@ export default function WorkflowHistoryTimelineGroup({
       <div className={cls.eventHeader}>
         <WorkflowHistoryEventStatusBadge
           status={status}
-          statusReady={!hasMissingEvents}
+          statusReady={!showLoadingMoreEvents}
           size="medium"
         />
         <div className={cls.eventLabelAndSecondaryDetails}>
@@ -71,11 +72,12 @@ export default function WorkflowHistoryTimelineGroup({
                 ))}
               </>
             )}
-            {timeMs && (
+            {startTimeMs && (
               <WorkflowHistoryEventsDurationBadge
-                startTime={timeMs}
+                startTime={startTimeMs}
                 closeTime={closeTimeMs}
                 eventsCount={events.length}
+                loadingMoreEvents={showLoadingMoreEvents}
                 hasMissingEvents={hasMissingEvents}
                 workflowCloseTime={workflowCloseTimeMs}
                 workflowIsArchived={workflowIsArchived}
@@ -102,7 +104,7 @@ export default function WorkflowHistoryTimelineGroup({
         <WorkflowHistoryEventsCard
           events={events}
           eventsMetadata={eventsMetadata}
-          showEventPlaceholder={hasMissingEvents}
+          showEventPlaceholder={showLoadingMoreEvents}
           decodedPageUrlParams={decodedPageUrlParams}
           getIsEventExpanded={getIsEventExpanded}
           onEventToggle={onEventToggle}

--- a/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.types.ts
+++ b/src/views/workflow-history/workflow-history-timeline-group/workflow-history-timeline-group.types.ts
@@ -19,10 +19,11 @@ export type Props = Pick<
   | 'status'
   | 'badges'
   | 'resetToDecisionEventId'
-  | 'timeMs'
+  | 'startTimeMs'
   | 'closeTimeMs'
 > & {
   isLastEvent: boolean;
+  showLoadingMoreEvents: boolean;
   decodedPageUrlParams: WorkflowHistoryProps['params'];
   getIsEventExpanded: GetIsEventExpanded;
   onEventToggle: ToggleIsEventExpanded;

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -405,7 +405,7 @@ export default function WorkflowHistory({ params }: Props) {
                 <WorkflowHistoryTimelineGroup
                   key={groupId}
                   {...group}
-                  hasMissingEvents={
+                  showLoadingMoreEvents={
                     group.hasMissingEvents && !reachedAvailableHistoryEnd
                   }
                   resetToDecisionEventId={group.resetToDecisionEventId}

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -50,6 +50,7 @@ type BaseHistoryGroup = {
   status: WorkflowEventStatus;
   hasMissingEvents: boolean;
   timeMs: number | null;
+  startTimeMs: number | null;
   closeTimeMs?: number | null;
   timeLabel: string;
   badges?: HistoryGroupBadge[];


### PR DESCRIPTION
### Summary
History timeline events is was calculating duration based on incorrect timestamps. The timeMs (previously used as `startTime`) is not the correct start time which caused wrong calculations.


### Changes
- Calculate new `startTimeMs` based on the first group events `timeMs`
- Add new `loadingMoreEvents` prop to the duration badge to be used to hide badge until all available group events are loaded
- Replaced added new prop `showLoadingMoreEvents` to `WorkflowHistoryTimelineGroup` and reporposed `hasMissingEvents` to be the same value as the group `hasMissingEvents`. This is more clear and prevents confusion.
- Added new arg `hideMs` to `getFormattedEventsDuration` to hide milliseconds in onGoing events. This prevented ms unit to be changed while we are incrementing the badge as `1000` interval wont execute exactly in 1 sec.
- Fixed an issue with `getFormattedEventsDuration` by passing milliseconds to `formatDuration` through milliseconds instead of seconds

### Screenshots
... to be added