### PR TITLE
Fix parsing for workflow cancel request

### DIFF
--- a/src/utils/data-formatters/schema/history-event-schema.ts
+++ b/src/utils/data-formatters/schema/history-event-schema.ts
@@ -29,7 +29,7 @@ const parentExecutionInfoSchema = z.object({
   domainId: z.string(),
   domainName: z.string(),
   workflowExecution: workflowExecutionSchema.nullable(),
-  initiatedId: z.string(),
+  initiatedId: z.coerce.string(),
 });
 
 const taskListSchema = z.object({
@@ -178,7 +178,7 @@ const activityTypeSchema = z.object({
 
 const externalExecutionInfoSchema = z.object({
   workflowExecution: workflowExecutionSchema.nullable(),
-  initiatedId: z.string(),
+  initiatedId: z.coerce.string(),
 });
 
 const historyEventBaseSchema = z.object({


### PR DESCRIPTION
### Summary
Fix parsing `initiatedId` by coercing it to string. The reason why parsing fails, is that the `grpc-protoloader` return `0` as the value for `initiatedId` when it is empty while it's type is string. 