### PR TITLE
Format header fields

### DIFF
--- a/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts.snapshot
+++ b/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts.snapshot
@@ -722,7 +722,9 @@ exports[`formatWorkflowHistoryEvent should format workflow workflowExecutionStar
   "firstExecutionRunId": "1d0e29d3-9c20-4eda-aeca-daed7f0ccb2e",
   "firstScheduledTimeNano": 1716246362895.4253,
   "header": {
-    "fields": {},
+    "fields": {
+      "test-header": "test-header-data",
+    },
   },
   "identity": null,
   "initiator": "CRON_SCHEDULE",

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
@@ -34,6 +34,7 @@ const formatWorkflowExecutionStartedEvent = ({
     searchAttributes,
     taskList,
     taskStartToCloseTimeout,
+    header,
     ...eventAttributes
   },
   ...eventFields
@@ -69,6 +70,7 @@ const formatWorkflowExecutionStartedEvent = ({
       : null,
     identity: identity || null,
     initiator: formatEnum(initiator, 'CONTINUE_AS_NEW_INITIATOR'),
+    header: formatPayloadMap(header, 'fields'),
     memo: formatPayloadMap(memo, 'fields'),
     originalExecutionRunId: originalExecutionRunId || null,
     parentInitiatedEventId: parentExecutionInfo?.initiatedId

--- a/src/views/workflow-history/__fixtures__/workflow-history-single-events.ts
+++ b/src/views/workflow-history/__fixtures__/workflow-history-single-events.ts
@@ -52,7 +52,11 @@ export const startWorkflowExecutionEvent = {
       points: [],
     },
     header: {
-      fields: {},
+      fields: {
+        'test-header': {
+          data: 'dGVzdC1oZWFkZXItZGF0YQ==',
+        },
+      },
     },
     firstScheduledTime: {
       seconds: '1716246362',


### PR DESCRIPTION
### Summary
Format `header.fields` in the `workflow start` event by decoding it from base64.

### Screenshot
Before
![Screenshot 2025-06-03 at 10 27 44](https://github.com/user-attachments/assets/32b13f4c-6c6e-4ef9-bea4-7f3e305942f9)
After
![Screenshot 2025-06-03 at 10 28 02](https://github.com/user-attachments/assets/f1f5e622-bd54-48e0-966f-150547ab3074)

