### PR TITLE
Separate the Copy Link to Event button into a dedicated component

### DIFF
--- a/src/views/workflow-history/workflow-history-event-link-button/__tests__/workflow-history-event-link-button.test.tsx
+++ b/src/views/workflow-history/workflow-history-event-link-button/__tests__/workflow-history-event-link-button.test.tsx
@@ -1,0 +1,92 @@
+import copy from 'copy-to-clipboard';
+
+import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
+
+import WorkflowHistoryEventLinkButton from '../workflow-history-event-link-button';
+
+jest.mock('copy-to-clipboard', jest.fn);
+
+describe('WorkflowHistoryEventLinkButton', () => {
+  let originalWindow: Window & typeof globalThis;
+
+  beforeEach(() => {
+    // Mock window.location
+    originalWindow = window;
+    window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...window.location,
+        origin: 'http://localhost',
+        pathname:
+          '/domains/test-domain/workflows/test-workflow/test-run/history',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    window = originalWindow;
+    jest.clearAllMocks();
+  });
+
+  it('renders a button with a link icon', () => {
+    render(<WorkflowHistoryEventLinkButton historyEventId="123" />);
+    expect(screen.getByTestId('share-button')).toBeInTheDocument();
+  });
+
+  it('shows tooltip with "Copy link to event" by default', async () => {
+    const user = userEvent.setup();
+    render(<WorkflowHistoryEventLinkButton historyEventId="123" />);
+    const button = screen.getByTestId('share-button');
+    await user.hover(button);
+    expect(await screen.findByText('Copy link to event')).toBeInTheDocument();
+  });
+
+  it('copies the current URL with event ID when clicked', async () => {
+    const user = userEvent.setup();
+    render(<WorkflowHistoryEventLinkButton historyEventId="123" />);
+    const button = screen.getByTestId('share-button');
+    await user.click(button);
+    expect(copy).toHaveBeenCalledWith(
+      'http://localhost/domains/test-domain/workflows/test-workflow/test-run/history?he=123'
+    );
+  });
+
+  it('shows "Copied link to event" tooltip after clicking', async () => {
+    const user = userEvent.setup();
+    render(<WorkflowHistoryEventLinkButton historyEventId="123" />);
+    const button = screen.getByTestId('share-button');
+    await user.click(button);
+    expect(await screen.findByText('Copied link to event')).toBeInTheDocument();
+  });
+
+  it('resets tooltip text when mouse leaves', async () => {
+    const user = userEvent.setup();
+    render(<WorkflowHistoryEventLinkButton historyEventId="123" />);
+    const button = screen.getByTestId('share-button');
+    await user.click(button);
+
+    const copiedText = await screen.findByText('Copied link to event');
+    expect(copiedText).toBeInTheDocument();
+
+    await user.unhover(button);
+    await waitFor(() => {
+      expect(copiedText).not.toBeInTheDocument();
+    });
+
+    await user.hover(button);
+    expect(await screen.findByText('Copy link to event')).toBeInTheDocument();
+  });
+
+  it('adds ungrouped view parameter when isUngroupedView is true', async () => {
+    const user = userEvent.setup();
+    render(
+      <WorkflowHistoryEventLinkButton historyEventId="123" isUngroupedView />
+    );
+    const button = screen.getByTestId('share-button');
+    await user.click(button);
+    expect(copy).toHaveBeenCalledWith(
+      'http://localhost/domains/test-domain/workflows/test-workflow/test-run/history?he=123&u=true'
+    );
+  });
+});

--- a/src/views/workflow-history/workflow-history-event-link-button/workflow-history-event-link-button.styles.ts
+++ b/src/views/workflow-history/workflow-history-event-link-button/workflow-history-event-link-button.styles.ts
@@ -1,0 +1,14 @@
+import { type Theme } from 'baseui';
+import { type ButtonOverrides } from 'baseui/button';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  copyButton: {
+    BaseButton: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        height: $theme.sizing.scale600,
+        width: $theme.sizing.scale600,
+      }),
+    },
+  } satisfies ButtonOverrides,
+};

--- a/src/views/workflow-history/workflow-history-event-link-button/workflow-history-event-link-button.tsx
+++ b/src/views/workflow-history/workflow-history-event-link-button/workflow-history-event-link-button.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import { Button } from 'baseui/button';
+import { StatefulTooltip } from 'baseui/tooltip';
+import copy from 'copy-to-clipboard';
+import queryString from 'query-string';
+import { MdLink } from 'react-icons/md';
+
+import { overrides } from './workflow-history-event-link-button.styles';
+import { type Props } from './workflow-history-event-link-button.types';
+
+export default function WorkflowHistoryEventLinkButton({
+  historyEventId,
+  isUngroupedView,
+}: Props) {
+  const [isEventLinkCopied, setIsEventLinkCopied] = useState(false);
+
+  return (
+    <StatefulTooltip
+      showArrow
+      placement="right"
+      popoverMargin={8}
+      accessibilityType="tooltip"
+      content={() =>
+        isEventLinkCopied ? 'Copied link to event' : 'Copy link to event'
+      }
+      onMouseLeave={() => setIsEventLinkCopied(false)}
+      returnFocus
+      autoFocus
+    >
+      <Button
+        data-testid="share-button"
+        size="mini"
+        shape="circle"
+        kind="tertiary"
+        overrides={overrides.copyButton}
+        onClick={(e) => {
+          e.stopPropagation();
+          copy(
+            queryString.stringifyUrl({
+              url: window.location.origin + window.location.pathname,
+              query: {
+                he: historyEventId,
+                u: isUngroupedView ? 'true' : undefined,
+              },
+            })
+          );
+          setIsEventLinkCopied(true);
+        }}
+      >
+        <MdLink />
+      </Button>
+    </StatefulTooltip>
+  );
+}

--- a/src/views/workflow-history/workflow-history-event-link-button/workflow-history-event-link-button.types.ts
+++ b/src/views/workflow-history/workflow-history-event-link-button/workflow-history-event-link-button.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  historyEventId: string;
+  isUngroupedView?: boolean;
+};

--- a/src/views/workflow-history/workflow-history-events-card/__tests__/workflow-history-events-card.test.tsx
+++ b/src/views/workflow-history/workflow-history-events-card/__tests__/workflow-history-events-card.test.tsx
@@ -1,5 +1,3 @@
-import copy from 'copy-to-clipboard';
-
 import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import {
@@ -17,6 +15,16 @@ jest.mock(
 jest.mock(
   '../../workflow-history-event-details/workflow-history-event-details',
   () => jest.fn(({ event }) => <div>Details eventId: {event.eventId}</div>)
+);
+
+jest.mock(
+  '../../workflow-history-event-link-button/workflow-history-event-link-button',
+  () =>
+    jest.fn(({ historyEventId }) => (
+      <div data-testid="event-link-button" data-event-id={historyEventId}>
+        Link to Event {historyEventId}
+      </div>
+    ))
 );
 
 jest.mock('copy-to-clipboard', jest.fn);
@@ -68,6 +76,7 @@ describe('WorkflowHistoryEventsCard', () => {
         `Details eventId: ${scheduleActivityTaskEvent.eventId}`
       )
     ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('event-link-button')).not.toBeInTheDocument();
   });
 
   it('render accordion expanded when get getIsEventExpanded returns true', async () => {
@@ -89,6 +98,11 @@ describe('WorkflowHistoryEventsCard', () => {
         `Details eventId: ${scheduleActivityTaskEvent.eventId}`
       )
     ).toBeInTheDocument();
+    expect(screen.getByTestId('event-link-button')).toBeInTheDocument();
+    expect(screen.getByTestId('event-link-button')).toHaveAttribute(
+      'data-event-id',
+      scheduleActivityTaskEvent.eventId
+    );
   });
 
   it('should call onEventToggle callback on click', async () => {
@@ -119,56 +133,6 @@ describe('WorkflowHistoryEventsCard', () => {
     await user.click(screen.getByText('Second event'));
 
     expect(mockedOnEventToggle).toHaveBeenCalledWith('9');
-  });
-
-  it('should show copy event button when the accordion is expanded', async () => {
-    // TODO: this is a bit hacky, see if there is a better way to mock window properties
-    const originalWindow = window;
-    window = Object.create(window);
-    Object.defineProperty(window, 'location', {
-      value: {
-        ...window.location,
-        origin: 'http://localhost',
-        pathname: '/domains/mock-domain/workflows/wfid/runid/history',
-      },
-      writable: true,
-    });
-
-    const events: Props['events'] = [
-      scheduleActivityTaskEvent,
-      startActivityTaskEvent,
-    ];
-
-    const eventsMetadata: Props['eventsMetadata'] = [
-      {
-        label: 'First event',
-        status: 'COMPLETED',
-      },
-      {
-        label: 'Second event',
-        status: 'ONGOING',
-      },
-    ];
-
-    const { user } = setup({
-      events,
-      eventsMetadata,
-      getIsEventExpanded: jest.fn().mockReturnValue(true),
-    });
-
-    const shareButtons = await screen.findAllByTestId('share-button');
-    expect(shareButtons).toHaveLength(2);
-
-    await user.hover(shareButtons[0]);
-    expect(await screen.findByText('Copy link to event')).toBeInTheDocument();
-
-    await user.click(shareButtons[0]);
-    expect(copy).toHaveBeenCalledWith(
-      'http://localhost/domains/mock-domain/workflows/wfid/runid/history?he=7'
-    );
-    expect(await screen.findByText('Copied link to event')).toBeInTheDocument();
-
-    window = originalWindow;
   });
 
   it('should add placeholder event when showMissingEventPlaceholder is set to true', async () => {

--- a/src/views/workflow-history/workflow-history-events-card/workflow-history-events-card.tsx
+++ b/src/views/workflow-history/workflow-history-events-card/workflow-history-events-card.tsx
@@ -1,17 +1,13 @@
 'use client';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { StatelessAccordion, Panel } from 'baseui/accordion';
-import { Button } from 'baseui/button';
 import { Skeleton } from 'baseui/skeleton';
-import { StatefulTooltip } from 'baseui/tooltip';
-import copy from 'copy-to-clipboard';
-import queryString from 'query-string';
-import { MdLink } from 'react-icons/md';
 
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 
 import WorkflowHistoryEventDetails from '../workflow-history-event-details/workflow-history-event-details';
+import WorkflowHistoryEventLinkButton from '../workflow-history-event-link-button/workflow-history-event-link-button';
 import getBadgeContainerSize from '../workflow-history-event-status-badge/helpers/get-badge-container-size';
 import WorkflowHistoryEventStatusBadge from '../workflow-history-event-status-badge/workflow-history-event-status-badge';
 
@@ -31,8 +27,6 @@ export default function WorkflowHistoryEventsCard({
   animateBorderOnEnter,
 }: Props) {
   const { cls, theme } = useStyletronClasses(cssStyles);
-
-  const [isEventLinkCopied, setIsEventLinkCopied] = useState(false);
 
   if (!eventsMetadata?.length && !showEventPlaceholder) return null;
   const expanded = events.reduce((result, event) => {
@@ -63,44 +57,7 @@ export default function WorkflowHistoryEventsCard({
                 <div className={cls.eventLabel}>
                   {eventMetadata.label}
                   {isPanelExpanded && (
-                    <StatefulTooltip
-                      showArrow
-                      placement="right"
-                      popoverMargin={8}
-                      accessibilityType="tooltip"
-                      content={() =>
-                        isEventLinkCopied
-                          ? 'Copied link to event'
-                          : 'Copy link to event'
-                      }
-                      onMouseLeave={() => setIsEventLinkCopied(false)}
-                      returnFocus
-                      autoFocus
-                    >
-                      <Button
-                        data-testid="share-button"
-                        size="mini"
-                        shape="circle"
-                        kind="tertiary"
-                        overrides={overrides.shareButton}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          copy(
-                            queryString.stringifyUrl({
-                              url:
-                                window.location.origin +
-                                window.location.pathname,
-                              query: {
-                                he: id,
-                              },
-                            })
-                          );
-                          setIsEventLinkCopied(true);
-                        }}
-                      >
-                        <MdLink />
-                      </Button>
-                    </StatefulTooltip>
+                    <WorkflowHistoryEventLinkButton historyEventId={id} />
                   )}
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Create new WorkflowHistoryEventLinkButton component that copies the link to a history event
- Remove resulting dead code

## Test plan
Add unit tests.