### PR TITLE
Add Workflow Diagnostics tab with placeholder content

### DIFF
--- a/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
+++ b/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
@@ -1,3 +1,3 @@
 export default async function workflowDiagnosticsEnabled(): Promise<boolean> {
-  return false;
+  return true;
 }

--- a/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
+++ b/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
@@ -1,3 +1,3 @@
 export default async function workflowDiagnosticsEnabled(): Promise<boolean> {
-  return true;
+  return false;
 }

--- a/src/views/workflow-diagnostics/config/workflow-diagnostics-disabled-error-panel.config.ts
+++ b/src/views/workflow-diagnostics/config/workflow-diagnostics-disabled-error-panel.config.ts
@@ -1,0 +1,15 @@
+import { type Props as ErrorPanelProps } from '@/components/error-panel/error-panel.types';
+
+const workflowDiagnosticsDisabledErrorPanelConfig: ErrorPanelProps = {
+  message: 'Workflow Diagnostics is currently disabled',
+  omitLogging: true,
+  actions: [
+    {
+      kind: 'link-internal',
+      link: './summary',
+      label: 'Go to workflow summary',
+    },
+  ],
+};
+
+export default workflowDiagnosticsDisabledErrorPanelConfig;

--- a/src/views/workflow-diagnostics/workflow-diagnostics.tsx
+++ b/src/views/workflow-diagnostics/workflow-diagnostics.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import React from 'react';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+import PageSection from '@/components/page-section/page-section';
+import PanelSection from '@/components/panel-section/panel-section';
+import { type WorkflowPageTabContentProps } from '@/views/workflow-page/workflow-page-tab-content/workflow-page-tab-content.types';
+
+import useSuspenseIsWorkflowDiagnosticsEnabled from '../workflow-page/hooks/use-is-workflow-diagnostics-enabled/use-suspense-is-workflow-diagnostics-enabled';
+
+import workflowDiagnosticsDisabledErrorPanelConfig from './config/workflow-diagnostics-disabled-error-panel.config';
+
+export default function WorkflowDiagnostics(_: WorkflowPageTabContentProps) {
+  const { data: isWorkflowDiagnosticsEnabled } =
+    useSuspenseIsWorkflowDiagnosticsEnabled();
+
+  if (!isWorkflowDiagnosticsEnabled) {
+    return (
+      <PanelSection>
+        <ErrorPanel {...workflowDiagnosticsDisabledErrorPanelConfig} />
+      </PanelSection>
+    );
+  }
+
+  return (
+    <PageSection>
+      <div>Workflow Diagnostics (WIP)</div>
+    </PageSection>
+  );
+}

--- a/src/views/workflow-page/__fixtures__/workflow-page-tabs-config.ts
+++ b/src/views/workflow-page/__fixtures__/workflow-page-tabs-config.ts
@@ -22,6 +22,14 @@ export const mockWorkflowPageTabsConfig: WorkflowPageTabsConfig<
       createElement('div', {}, JSON.stringify(params)),
     getErrorConfig: () => ({ message: 'history error' }),
   },
+  diagnostics: {
+    title: 'Diagnostics',
+    artwork: () =>
+      createElement('div', { 'data-testid': 'diagnostics-artwork' }),
+    content: ({ params }: WorkflowPageTabContentProps) =>
+      createElement('div', {}, JSON.stringify(params)),
+    getErrorConfig: () => ({ message: 'diagnostics error' }),
+  },
   queries: {
     title: 'Queries',
     artwork: () => createElement('div', { 'data-testid': 'queries-artwork' }),
@@ -36,13 +44,5 @@ export const mockWorkflowPageTabsConfig: WorkflowPageTabsConfig<
     content: ({ params }: WorkflowPageTabContentProps) =>
       createElement('div', {}, JSON.stringify(params)),
     getErrorConfig: () => ({ message: 'stack trace error' }),
-  },
-  diagnostics: {
-    title: 'Diagnostics',
-    artwork: () =>
-      createElement('div', { 'data-testid': 'diagnostics-artwork' }),
-    content: ({ params }: WorkflowPageTabContentProps) =>
-      createElement('div', {}, JSON.stringify(params)),
-    getErrorConfig: () => ({ message: 'diagnostics error' }),
   },
 } as const;

--- a/src/views/workflow-page/__fixtures__/workflow-page-tabs-config.ts
+++ b/src/views/workflow-page/__fixtures__/workflow-page-tabs-config.ts
@@ -4,7 +4,7 @@ import type { WorkflowPageTabContentProps } from '../workflow-page-tab-content/w
 import { type WorkflowPageTabsConfig } from '../workflow-page-tabs/workflow-page-tabs.types';
 
 export const mockWorkflowPageTabsConfig: WorkflowPageTabsConfig<
-  'summary' | 'history' | 'queries' | 'stack-trace'
+  'summary' | 'history' | 'queries' | 'stack-trace' | 'diagnostics'
 > = {
   summary: {
     title: 'Summary',
@@ -36,5 +36,13 @@ export const mockWorkflowPageTabsConfig: WorkflowPageTabsConfig<
     content: ({ params }: WorkflowPageTabContentProps) =>
       createElement('div', {}, JSON.stringify(params)),
     getErrorConfig: () => ({ message: 'stack trace error' }),
+  },
+  diagnostics: {
+    title: 'Diagnostics',
+    artwork: () =>
+      createElement('div', { 'data-testid': 'diagnostics-artwork' }),
+    content: ({ params }: WorkflowPageTabContentProps) =>
+      createElement('div', {}, JSON.stringify(params)),
+    getErrorConfig: () => ({ message: 'diagnostics error' }),
   },
 } as const;

--- a/src/views/workflow-page/config/workflow-page-tabs.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs.config.ts
@@ -1,3 +1,4 @@
+import { FaStethoscope } from 'react-icons/fa';
 import {
   MdListAlt,
   MdOutlineHistory,
@@ -5,6 +6,7 @@ import {
   MdOutlineTerminal,
 } from 'react-icons/md';
 
+import WorkflowDiagnostics from '@/views/workflow-diagnostics/workflow-diagnostics';
 import WorkflowHistory from '@/views/workflow-history/workflow-history';
 import WorkflowQueries from '@/views/workflow-queries/workflow-queries';
 import WorkflowStackTrace from '@/views/workflow-stack-trace/workflow-stack-trace';
@@ -15,7 +17,7 @@ import WorkflowPagePendingEventsBadge from '../workflow-page-pending-events-badg
 import type { WorkflowPageTabsConfig } from '../workflow-page-tabs/workflow-page-tabs.types';
 
 const workflowPageTabsConfig: WorkflowPageTabsConfig<
-  'summary' | 'history' | 'queries' | 'stack-trace'
+  'summary' | 'history' | 'queries' | 'stack-trace' | 'diagnostics'
 > = {
   summary: {
     title: 'Summary',
@@ -38,6 +40,17 @@ const workflowPageTabsConfig: WorkflowPageTabsConfig<
         err,
         'Failed to load workflow history',
         'history'
+      ),
+  },
+  diagnostics: {
+    title: 'Diagnostics',
+    artwork: FaStethoscope,
+    content: WorkflowDiagnostics,
+    getErrorConfig: (err) =>
+      getWorkflowPageErrorConfig(
+        err,
+        'Failed to load workflow diagnostics',
+        'diagnostics'
       ),
   },
   queries: {

--- a/src/views/workflow-page/config/workflow-page-tabs.config.ts
+++ b/src/views/workflow-page/config/workflow-page-tabs.config.ts
@@ -1,10 +1,10 @@
-import { FaStethoscope } from 'react-icons/fa';
 import {
   MdListAlt,
   MdOutlineHistory,
   MdOutlineManageSearch,
   MdOutlineTerminal,
 } from 'react-icons/md';
+import { RiStethoscopeLine } from 'react-icons/ri';
 
 import WorkflowDiagnostics from '@/views/workflow-diagnostics/workflow-diagnostics';
 import WorkflowHistory from '@/views/workflow-history/workflow-history';
@@ -44,7 +44,7 @@ const workflowPageTabsConfig: WorkflowPageTabsConfig<
   },
   diagnostics: {
     title: 'Diagnostics',
-    artwork: FaStethoscope,
+    artwork: RiStethoscopeLine,
     content: WorkflowDiagnostics,
     getErrorConfig: (err) =>
       getWorkflowPageErrorConfig(

--- a/src/views/workflow-page/hooks/use-is-workflow-diagnostics-enabled/get-is-workflow-diagnostics-enabled-query-options.ts
+++ b/src/views/workflow-page/hooks/use-is-workflow-diagnostics-enabled/get-is-workflow-diagnostics-enabled-query-options.ts
@@ -1,0 +1,30 @@
+import { type UseQueryOptions } from '@tanstack/react-query';
+import queryString from 'query-string';
+
+import { type GetConfigResponse } from '@/route-handlers/get-config/get-config.types';
+import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
+
+export default function getIsWorkflowDiagnosticsEnabledQueryOptions(): UseQueryOptions<
+  GetConfigResponse<'WORKFLOW_DIAGNOSTICS_ENABLED'>,
+  RequestError,
+  GetConfigResponse<'WORKFLOW_DIAGNOSTICS_ENABLED'>,
+  [string, { configKey: 'WORKFLOW_DIAGNOSTICS_ENABLED' }]
+> {
+  return {
+    queryKey: ['dynamic_config', { configKey: 'WORKFLOW_DIAGNOSTICS_ENABLED' }],
+    queryFn: ({
+      queryKey: [_, { configKey }],
+    }: {
+      queryKey: [string, { configKey: 'WORKFLOW_DIAGNOSTICS_ENABLED' }];
+    }): Promise<GetConfigResponse<'WORKFLOW_DIAGNOSTICS_ENABLED'>> =>
+      request(
+        queryString.stringifyUrl({
+          url: '/api/config',
+          query: {
+            configKey,
+          },
+        })
+      ).then((res) => res.json()),
+  };
+}

--- a/src/views/workflow-page/hooks/use-is-workflow-diagnostics-enabled/use-suspense-is-workflow-diagnostics-enabled.ts
+++ b/src/views/workflow-page/hooks/use-is-workflow-diagnostics-enabled/use-suspense-is-workflow-diagnostics-enabled.ts
@@ -1,0 +1,7 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import getIsWorkflowDiagnosticsEnabledQueryOptions from './get-is-workflow-diagnostics-enabled-query-options';
+
+export default function useSuspenseIsWorkflowDiagnosticsEnabled() {
+  return useSuspenseQuery(getIsWorkflowDiagnosticsEnabledQueryOptions());
+}

--- a/src/views/workflow-page/workflow-page-tabs/__tests__/workflow-page-tabs.test.tsx
+++ b/src/views/workflow-page/workflow-page-tabs/__tests__/workflow-page-tabs.test.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 
-import { render, screen } from '@/test-utils/rtl';
+import { HttpResponse } from 'msw';
+
+import { render, screen, act, fireEvent } from '@/test-utils/rtl';
+
+import ErrorBoundary from '@/components/error-boundary/error-boundary';
 
 import { mockWorkflowPageTabsConfig } from '../../__fixtures__/workflow-page-tabs-config';
-import workflowPageTabsConfig from '../../config/workflow-page-tabs.config';
 import WorkflowPageTabs from '../workflow-page-tabs';
 
 const mockPushFn = jest.fn();
@@ -46,30 +49,111 @@ describe('WorkflowPageTabs', () => {
     jest.clearAllMocks();
   });
 
-  it('renders tabs titles correctly', () => {
-    setup();
-    Object.values(workflowPageTabsConfig).forEach(({ title }) => {
-      expect(screen.getByText(title)).toBeInTheDocument();
-    });
+  it('renders tabs titles correctly with diagnostics disabled', async () => {
+    await setup({ enableDiagnostics: false });
+
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('History')).toBeInTheDocument();
+    expect(screen.getByText('Queries')).toBeInTheDocument();
+    expect(screen.getByText('Stack Trace')).toBeInTheDocument();
+    expect(screen.queryByText('Diagnostics')).toBeNull();
   });
 
-  it('renders tabs buttons correctly', () => {
-    setup();
+  it('renders tabs with diagnostics enabled', async () => {
+    await setup({ enableDiagnostics: true });
+
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('History')).toBeInTheDocument();
+    expect(screen.getByText('Queries')).toBeInTheDocument();
+    expect(screen.getByText('Stack Trace')).toBeInTheDocument();
+    expect(screen.getByText('Diagnostics')).toBeInTheDocument();
+  });
+
+  it('renders tabs buttons correctly', async () => {
+    await setup({ enableDiagnostics: false });
+
     expect(screen.getByText('CLI Commands')).toBeInTheDocument();
     expect(screen.getByText('Actions')).toBeInTheDocument();
   });
 
-  it('renders tabs artworks correctly', () => {
-    setup();
-    Object.entries(workflowPageTabsConfig).forEach(([key, { artwork }]) => {
-      if (typeof artwork !== 'undefined')
-        expect(screen.getByTestId(`${key}-artwork`)).toBeInTheDocument();
-      else
-        expect(screen.queryByTestId(`${key}-artwork`)).not.toBeInTheDocument();
+  it('renders tabs artworks correctly with diagnostics disabled', async () => {
+    await setup({ enableDiagnostics: false });
+
+    expect(screen.getByTestId('summary-artwork')).toBeInTheDocument();
+    expect(screen.getByTestId('history-artwork')).toBeInTheDocument();
+    expect(screen.getByTestId('queries-artwork')).toBeInTheDocument();
+    expect(screen.getByTestId('stack-trace-artwork')).toBeInTheDocument();
+    expect(screen.queryByTestId('diagnostics-artwork')).toBeNull();
+  });
+
+  it('renders tabs artworks correctly with diagnostics enabled', async () => {
+    await setup({ enableDiagnostics: true });
+
+    expect(screen.getByTestId('summary-artwork')).toBeInTheDocument();
+    expect(screen.getByTestId('history-artwork')).toBeInTheDocument();
+    expect(screen.getByTestId('queries-artwork')).toBeInTheDocument();
+    expect(screen.getByTestId('stack-trace-artwork')).toBeInTheDocument();
+    expect(screen.getByTestId('diagnostics-artwork')).toBeInTheDocument();
+  });
+
+  it('reroutes when new tab is clicked', async () => {
+    await setup({ enableDiagnostics: false });
+
+    const historyTab = await screen.findByText('History');
+    act(() => {
+      fireEvent.click(historyTab);
     });
+
+    expect(mockPushFn).toHaveBeenCalledWith('history');
+  });
+
+  it('handles errors gracefully', async () => {
+    await setup({ error: true });
+
+    expect(
+      await screen.findByText('Error: Failed to fetch config')
+    ).toBeInTheDocument();
   });
 });
 
-function setup() {
-  return render(<WorkflowPageTabs />);
+async function setup({
+  error,
+  enableDiagnostics,
+}: {
+  error?: boolean;
+  enableDiagnostics?: boolean;
+}) {
+  render(
+    <ErrorBoundary
+      fallbackRender={({ error }) => <div>Error: {error.message}</div>}
+    >
+      <Suspense fallback={<div>Loading...</div>}>
+        <WorkflowPageTabs />
+      </Suspense>
+    </ErrorBoundary>,
+    {
+      endpointsMocks: [
+        {
+          path: '/api/config',
+          httpMethod: 'GET',
+          mockOnce: false,
+          httpResolver: async () => {
+            if (error) {
+              return HttpResponse.json(
+                { message: 'Failed to fetch config' },
+                { status: 500 }
+              );
+            } else {
+              return HttpResponse.json(enableDiagnostics ?? false);
+            }
+          },
+        },
+      ],
+    }
+  );
+
+  if (!error) {
+    // Wait for the first tab to load
+    await screen.findByText('Summary');
+  }
 }

--- a/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
+++ b/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useMemo } from 'react';
 
+import omit from 'lodash/omit';
 import { useRouter, useParams } from 'next/navigation';
 
 import ErrorBoundary from '@/components/error-boundary/error-boundary';
@@ -9,6 +10,7 @@ import decodeUrlParams from '@/utils/decode-url-params';
 import WorkflowActions from '@/views/workflow-actions/workflow-actions';
 
 import workflowPageTabsConfig from '../config/workflow-page-tabs.config';
+import useSuspenseIsWorkflowDiagnosticsEnabled from '../hooks/use-is-workflow-diagnostics-enabled/use-suspense-is-workflow-diagnostics-enabled';
 import WorkflowPageCliCommandsButton from '../workflow-page-cli-commands-button/workflow-page-cli-commands-button';
 
 import { styled } from './workflow-page-tabs.styles';
@@ -19,15 +21,26 @@ export default function WorkflowPageTabs() {
   const params = useParams<WorkflowPageTabsParams>();
   const decodedParams = decodeUrlParams(params) as WorkflowPageTabsParams;
 
+  const { data: isWorkflowDiagnosticsEnabled } =
+    useSuspenseIsWorkflowDiagnosticsEnabled();
+
+  const filteredTabsConfig = useMemo(
+    () =>
+      isWorkflowDiagnosticsEnabled
+        ? workflowPageTabsConfig
+        : omit(workflowPageTabsConfig, 'diagnostics'),
+    [isWorkflowDiagnosticsEnabled]
+  );
+
   const tabList = useMemo(
     () =>
-      Object.entries(workflowPageTabsConfig).map(([key, tabConfig]) => ({
+      Object.entries(filteredTabsConfig).map(([key, tabConfig]) => ({
         key,
         title: tabConfig.title,
         artwork: tabConfig.artwork,
         endEnhancer: tabConfig.endEnhancer,
       })),
-    []
+    [filteredTabsConfig]
   );
 
   return (


### PR DESCRIPTION
## Summary
- Add useIsWorkflowDiagnosticsEnabled hook
- Add Workflow Diagnostics tab to tabs config
- Show tab depending on config value
- Create Workflow Diagnostics root component with placeholder, and error panel if diagnostics is disabled

## Test plan
Updated unit tests + ran locally.

Diagnostics disabled:
<img width="2238" height="716" alt="Screenshot 2025-07-14 at 2 21 35 PM" src="https://github.com/user-attachments/assets/69c6f985-e4d8-413c-864a-dc4b9990685c" />
<img width="2247" height="850" alt="Screenshot 2025-07-14 at 2 24 51 PM" src="https://github.com/user-attachments/assets/f9757e01-7fa9-4ddf-b13b-8e22b3175d7b" />

Diagnostics enabled:
<img width="1676" height="634" alt="Screenshot 2025-07-14 at 2 40 03 PM" src="https://github.com/user-attachments/assets/2bb264f8-a673-4599-995c-623e10a84bf3" />
<img width="1663" height="338" alt="Screenshot 2025-07-14 at 2 40 07 PM" src="https://github.com/user-attachments/assets/10a64fa0-263c-4dd3-8807-37d00988346e" />

