### PR TITLE
Return null parsingError instead of undefined from diagnoseWorkflow

### DIFF
--- a/src/route-handlers/diagnose-workflow/__tests__/diagnose-workflow.node.ts
+++ b/src/route-handlers/diagnose-workflow/__tests__/diagnose-workflow.node.ts
@@ -78,6 +78,7 @@ describe(diagnoseWorkflow.name, () => {
     const responseJson = await res.json();
     expect(responseJson).toEqual({
       result: mockWorkflowDiagnosticsResult,
+      parsingError: null,
     });
   });
 
@@ -112,6 +113,7 @@ describe(diagnoseWorkflow.name, () => {
     const responseJson = await res.json();
     expect(responseJson).toEqual({
       result: mockWorkflowDiagnosticsResult,
+      parsingError: null,
     });
   });
 

--- a/src/route-handlers/diagnose-workflow/diagnose-workflow.ts
+++ b/src/route-handlers/diagnose-workflow/diagnose-workflow.ts
@@ -77,11 +77,12 @@ export async function diagnoseWorkflow(
     return NextResponse.json(
       (error
         ? {
-            parsingError: error,
             result: unparsedResult,
+            parsingError: error,
           }
         : {
             result: parsedResult,
+            parsingError: null,
           }) satisfies DiagnoseWorkflowResponse
     );
   } catch (e) {

--- a/src/route-handlers/diagnose-workflow/diagnose-workflow.types.ts
+++ b/src/route-handlers/diagnose-workflow/diagnose-workflow.types.ts
@@ -22,6 +22,7 @@ export type WorkflowDiagnosticsResult = z.infer<
 export type DiagnoseWorkflowResponse =
   | {
       result: WorkflowDiagnosticsResult;
+      parsingError: null;
     }
   | {
       result: any;


### PR DESCRIPTION
## Summary
Return null parsingError instead of undefined from diagnoseWorkflow, to allow Typescript to better infer the result type on the frontend.

## Test plan
Updated unit tests.