### PR TITLE
Ignore config and fixtures in test coverage

### DIFF
--- a/jest/browser/jest.config.ts
+++ b/jest/browser/jest.config.ts
@@ -35,7 +35,7 @@ const config: Config = {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  //collectCoverage: true,
+  //  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,
@@ -44,10 +44,12 @@ const config: Config = {
   //coverageDirectory: "coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
-  /*  coveragePathIgnorePatterns: [
-    "/node_modules/",
-    "src/test-utils",
-  ], */
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    'src/test-utils',
+    '/__fixtures__/',
+    '\\.config\\.ts(x)?$',
+  ],
 
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "v8",

--- a/jest/node/jest.config.ts
+++ b/jest/node/jest.config.ts
@@ -1,11 +1,16 @@
 import type { Config } from 'jest';
 import nextJest from 'next/jest.js';
 
-const esModules = ['query-string', 'decode-uri-component','split-on-first','filter-obj']
+const esModules = [
+  'query-string',
+  'decode-uri-component',
+  'split-on-first',
+  'filter-obj',
+];
 
 const createJestConfig = nextJest({
   dir: './',
-})
+});
 const config: Config = {
   displayName: {
     color: 'cyan',
@@ -17,16 +22,19 @@ const config: Config = {
   },
   rootDir: '../../',
   preset: 'ts-jest',
-  setupFilesAfterEnv: ["<rootDir>/jest/node/jest.setup.ts"],
-  testEnvironment: "node",
-  testMatch: [
-    "**/__tests__/**/*.node.ts"
+  setupFilesAfterEnv: ['<rootDir>/jest/node/jest.setup.ts'],
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.node.ts'],
+  coveragePathIgnorePatterns: [
+    '/node_modules/',
+    'src/test-utils',
+    '/__fixtures__/',
+    '\\.config\\.ts$',
   ],
   transformIgnorePatterns: [`/node_modules/(?!(${esModules.join('|')})/)`],
 };
- 
 
-const getCustomizedConfig= async () => {
+const getCustomizedConfig = async () => {
   const jestConfig = await createJestConfig(config)();
   return {
     ...jestConfig,
@@ -35,7 +43,7 @@ const getCustomizedConfig= async () => {
     transformIgnorePatterns: jestConfig.transformIgnorePatterns?.filter(
       (ptn) => ptn !== '/node_modules/'
     ),
-  }
-}
+  };
+};
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
-export default getCustomizedConfig
+export default getCustomizedConfig;


### PR DESCRIPTION
**Summary**
Text coverage is computed based on files that are not included in test cases such as `.config.ts(x)` files and `/__fixtures__/` files. This changes aim to remove them from calculations to get more accurate percentage of coverage.

**Testing**
Tested locally and made sure files with those patterns doesn't show in the coverage report.