### PR TITLE
Pass entire event metadata to ungrouped history view

### DIFF
--- a/src/views/workflow-history/workflow-history-ungrouped-event/__tests__/workflow-history-ungrouped-event.test.tsx
+++ b/src/views/workflow-history/workflow-history-ungrouped-event/__tests__/workflow-history-ungrouped-event.test.tsx
@@ -95,25 +95,37 @@ jest.mock(
 const mockEventInfo: WorkflowHistoryUngroupedEventInfo = {
   id: '1',
   label: 'Workflow Execution Started',
-  status: 'COMPLETED',
-  statusLabel: 'Completed',
   event: startWorkflowExecutionEvent,
+  eventMetadata: {
+    label: 'Completed',
+    status: 'COMPLETED',
+    timeMs: 1704067200000,
+    timeLabel: 'Mock time label',
+  },
 };
 
 const mockPendingActivityEventInfo: WorkflowHistoryUngroupedEventInfo = {
   id: 'pending-7',
   label: 'Activity Task Started',
-  status: 'WAITING',
-  statusLabel: 'Pending',
   event: pendingActivityTaskStartEvent,
+  eventMetadata: {
+    label: 'Pending',
+    status: 'WAITING',
+    timeMs: null,
+    timeLabel: 'Pending',
+  },
 };
 
 const mockPendingDecisionEventInfo: WorkflowHistoryUngroupedEventInfo = {
   id: 'pending-7',
   label: 'Decision Task Started',
-  status: 'WAITING',
-  statusLabel: 'Pending',
   event: pendingDecisionTaskStartEvent,
+  eventMetadata: {
+    label: 'Pending',
+    status: 'WAITING',
+    timeMs: null,
+    timeLabel: 'Pending',
+  },
 };
 
 const mockDecodedPageUrlParams: WorkflowPageTabsParams = {

--- a/src/views/workflow-history/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
+++ b/src/views/workflow-history/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
@@ -62,9 +62,9 @@ export default function WorkflowHistoryUngroupedEvent({
             <WorkflowHistoryEventStatusBadge
               statusReady={true}
               size="small"
-              status={eventInfo.status}
+              status={eventInfo.eventMetadata.status}
             />
-            {eventInfo.statusLabel}
+            {eventInfo.eventMetadata.label}
             {retries ? (
               <Badge
                 overrides={overrides.badge}

--- a/src/views/workflow-history/workflow-history-ungrouped-event/workflow-history-ungrouped-event.types.ts
+++ b/src/views/workflow-history/workflow-history-ungrouped-event/workflow-history-ungrouped-event.types.ts
@@ -2,8 +2,8 @@ import { type Timestamp } from '@/__generated__/proto-ts/google/protobuf/Timesta
 import { type HistoryEvent } from '@/__generated__/proto-ts/uber/cadence/api/v1/HistoryEvent';
 import { type WorkflowPageTabsParams } from '@/views/workflow-page/workflow-page-tabs/workflow-page-tabs.types';
 
-import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
 import {
+  type HistoryGroupEventMetadata,
   type PendingActivityTaskStartEvent,
   type PendingDecisionTaskStartEvent,
 } from '../workflow-history.types';
@@ -12,12 +12,11 @@ export type WorkflowHistoryUngroupedEventInfo = {
   id: string;
   label: string;
   shortLabel?: string;
-  status: WorkflowEventStatus;
-  statusLabel: string;
   event:
     | HistoryEvent
     | PendingDecisionTaskStartEvent
     | PendingActivityTaskStartEvent;
+  eventMetadata: HistoryGroupEventMetadata;
   canReset?: boolean;
 };
 

--- a/src/views/workflow-history/workflow-history-ungrouped-table/__tests__/workflow-history-ungrouped-table.test.tsx
+++ b/src/views/workflow-history/workflow-history-ungrouped-table/__tests__/workflow-history-ungrouped-table.test.tsx
@@ -39,16 +39,24 @@ const mockEventsInfo: WorkflowHistoryUngroupedEventInfo[] = [
   {
     id: '1',
     label: 'Workflow Execution Started',
-    status: 'COMPLETED',
-    statusLabel: 'Completed',
     event: startWorkflowExecutionEvent,
+    eventMetadata: {
+      label: 'Completed',
+      status: 'COMPLETED',
+      timeMs: 1704067200000,
+      timeLabel: 'Mock time label',
+    },
   },
   {
     id: '2',
     label: 'Decision Task Scheduled',
-    status: 'COMPLETED',
-    statusLabel: 'Completed',
     event: scheduleDecisionTaskEvent,
+    eventMetadata: {
+      label: 'Completed',
+      status: 'COMPLETED',
+      timeMs: 1704067200000,
+      timeLabel: 'Mock time label',
+    },
   },
 ];
 

--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -174,10 +174,9 @@ export default function WorkflowHistory({ params }: Props) {
           .map(([_, group]) => [
             ...group.events.map((event, index) => ({
               event,
+              eventMetadata: group.eventsMetadata[index],
               label: group.label,
               shortLabel: group.shortLabel,
-              status: group.eventsMetadata[index].status,
-              statusLabel: group.eventsMetadata[index].label,
               id: event.eventId ?? event.computedEventId,
               canReset: group.resetToDecisionEventId === event.eventId,
             })),


### PR DESCRIPTION
## Summary
Pass entire event metadata to ungrouped history view, instead of just the status and status label. This will come in use later for a future PR.

## Test plan
Unit tests + ran locally to sanity check.