### PR TITLE
Scroll to selected event after it has loaded, instead of relying on Virtuoso

### DIFF
--- a/src/views/workflow-history/workflow-history.tsx
+++ b/src/views/workflow-history/workflow-history.tsx
@@ -1,5 +1,11 @@
 'use client';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import {
   useSuspenseInfiniteQuery,
@@ -303,6 +309,33 @@ export default function WorkflowHistory({ params }: Props) {
   const timelineSectionListRef = useRef<VirtuosoHandle>(null);
   const ungroupedTableRef = useRef<VirtuosoHandle>(null);
 
+  useEffect(() => {
+    if (
+      queryParams.ungroupedHistoryViewEnabled ||
+      !shouldSearchForInitialEvent ||
+      !initialEventFound ||
+      !initialEventGroupIndex
+    )
+      return;
+
+    compactSectionListRef.current?.scrollToIndex({
+      index: initialEventGroupIndex,
+      align: 'start',
+      behavior: 'auto',
+    });
+
+    timelineSectionListRef.current?.scrollToIndex({
+      index: initialEventGroupIndex,
+      align: 'start',
+      behavior: 'auto',
+    });
+  }, [
+    shouldSearchForInitialEvent,
+    initialEventFound,
+    initialEventGroupIndex,
+    queryParams.ungroupedHistoryViewEnabled,
+  ]);
+
   if (contentIsLoading) {
     return <SectionLoadingIndicator />;
   }
@@ -444,11 +477,6 @@ export default function WorkflowHistory({ params }: Props) {
                       compactEndIndex: endIndex,
                     }))
                   }
-                  {...(initialEventGroupIndex === undefined
-                    ? {}
-                    : {
-                        initialTopMostItemIndex: initialEventGroupIndex,
-                      })}
                   itemContent={(index, [groupId, group]) => (
                     <div role="listitem" className={cls.compactCardContainer}>
                       <WorkflowHistoryCompactEventCard
@@ -500,15 +528,6 @@ export default function WorkflowHistory({ params }: Props) {
                       endIndex,
                     }))
                   }
-                  {...(initialEventGroupIndex === undefined
-                    ? {}
-                    : {
-                        initialTopMostItemIndex: {
-                          index: initialEventGroupIndex,
-                          align: 'start',
-                          behavior: 'auto',
-                        },
-                      })}
                   itemContent={(index, [groupId, group]) => (
                     <WorkflowHistoryTimelineGroup
                       key={groupId}


### PR DESCRIPTION
## Summary
Use a useEffect hook to scroll to the index instead of relying on Virtuoso's height estimates for scroll behaviour, to fix inconsistent scrolling when an initial item is provided in a long list of history events.

## Test plan
Ran locally.