### PR TITLE
Change pending event label based on state

### DIFF
--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@/views/workflow-history/__fixtures__/workflow-history-activity-events';
 import {
   pendingActivityTaskStartEvent,
+  pendingActivityTaskStartEventWithCancelRequestedState,
   pendingActivityTaskStartEventWithStartedState,
 } from '@/views/workflow-history/__fixtures__/workflow-history-pending-events';
 import * as shortenGroupLabelsConfigModule from '@/views/workflow-history/config/workflow-history-should-shorten-group-labels.config';
@@ -118,6 +119,34 @@ describe('getActivityGroupFromEvents', () => {
     ];
     const group = getActivityGroupFromEvents(events);
     expect(group.groupType).toBe('Activity');
+  });
+
+  it('should return a group with correct label for pending activity event', () => {
+    const events: ExtendedActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      pendingActivityTaskStartEvent,
+    ];
+    const group = getActivityGroupFromEvents(events);
+    expect(group.eventsMetadata[1].label).toBe('Starting');
+
+    const eventsWithStartedState = getActivityGroupFromEvents([
+      scheduleActivityTaskEvent,
+      pendingActivityTaskStartEventWithStartedState,
+    ]);
+    expect(eventsWithStartedState.eventsMetadata[1].label).toBe('Running');
+
+    const eventsWithCanceledState = getActivityGroupFromEvents([
+      scheduleActivityTaskEvent,
+      pendingActivityTaskStartEventWithCancelRequestedState,
+    ]);
+    expect(eventsWithCanceledState.eventsMetadata[1].label).toBe('Cancelling');
+
+    const eventsWithInvalidState = getActivityGroupFromEvents([
+      scheduleActivityTaskEvent,
+      // @ts-expect-error - state is not defined in the type
+      { ...pendingActivityTaskStartEvent, state: undefined },
+    ]);
+    expect(eventsWithInvalidState.eventsMetadata[1].label).toBe('Starting');
   });
 
   it('should return group eventsMetadata with correct labels', () => {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -85,6 +85,28 @@ describe('getDecisionGroupFromEvents', () => {
     expect(group.groupType).toBe('Decision');
   });
 
+  it('should return a group with correct label for pending decision event', () => {
+    const events: ExtendedDecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      pendingDecisionTaskStartEvent,
+    ];
+    const group = getDecisionGroupFromEvents(events);
+    expect(group.eventsMetadata[1].label).toBe('Starting');
+
+    const eventsWithStartedState = getDecisionGroupFromEvents([
+      scheduleDecisionTaskEvent,
+      pendingDecisionTaskStartEventWithStartedState,
+    ]);
+    expect(eventsWithStartedState.eventsMetadata[1].label).toBe('Running');
+
+    const eventsWithInvalidState = getDecisionGroupFromEvents([
+      scheduleDecisionTaskEvent,
+      // @ts-expect-error - state is not defined in the type
+      { ...pendingDecisionTaskStartEvent, state: undefined },
+    ]);
+    expect(eventsWithInvalidState.eventsMetadata[1].label).toBe('Starting');
+  });
+
   it('should return group eventsMetadata with correct labels', () => {
     const events: ExtendedDecisionHistoryEvent[] = [
       scheduleDecisionTaskEvent,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -82,9 +82,23 @@ export default function getActivityGroupFromEvents(
     });
   }
 
+  const pendingStateToLabel: Record<
+    PendingActivityTaskStartEvent['pendingActivityTaskStartEventAttributes']['state'],
+    string
+  > = {
+    PENDING_ACTIVITY_STATE_SCHEDULED: 'Starting',
+    PENDING_ACTIVITY_STATE_STARTED: 'Running',
+    PENDING_ACTIVITY_STATE_CANCEL_REQUESTED: 'Cancelling',
+  };
+
+  const pendingState = pendingStartEvent?.[pendingStartAttr].state;
+
   const eventToLabel: HistoryGroupEventToStringMap<ActivityHistoryGroup> = {
     activityTaskScheduledEventAttributes: 'Scheduled',
-    pendingActivityTaskStartEventAttributes: 'Starting',
+    pendingActivityTaskStartEventAttributes:
+      pendingState && pendingStateToLabel[pendingState]
+        ? pendingStateToLabel[pendingState]
+        : pendingStateToLabel.PENDING_ACTIVITY_STATE_SCHEDULED,
     activityTaskStartedEventAttributes: 'Started',
     activityTaskCompletedEventAttributes: 'Completed',
     activityTaskFailedEventAttributes: 'Failed',

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -1,3 +1,5 @@
+import { type PendingDecisionInfo } from '@/__generated__/proto-ts/uber/cadence/api/v1/PendingDecisionInfo';
+
 import type {
   DecisionHistoryGroup,
   ExtendedDecisionHistoryEvent,
@@ -77,10 +79,22 @@ export default function getDecisionGroupFromEvents(
     resetToDecisionEventId = timeoutEvent.eventId;
   }
 
+  const pendingStateToLabel: Record<
+    PendingDecisionTaskStartEvent['pendingDecisionTaskStartEventAttributes']['state'],
+    string
+  > = {
+    PENDING_DECISION_STATE_SCHEDULED: 'Starting',
+    PENDING_DECISION_STATE_STARTED: 'Running',
+  };
+  const pendingState = pendingStartEvent?.[pendingStartAttr].state;
+
   // populate event to label and status maps
   const eventToLabel: HistoryGroupEventToStringMap<DecisionHistoryGroup> = {
     decisionTaskScheduledEventAttributes: 'Scheduled',
-    pendingDecisionTaskStartEventAttributes: 'Starting',
+    pendingDecisionTaskStartEventAttributes:
+      pendingState && pendingStateToLabel[pendingState]
+        ? pendingStateToLabel[pendingState]
+        : pendingStateToLabel.PENDING_DECISION_STATE_SCHEDULED,
     decisionTaskStartedEventAttributes: 'Started',
     decisionTaskCompletedEventAttributes: 'Completed',
     decisionTaskFailedEventAttributes: 'Failed',


### PR DESCRIPTION
**Summary:**
Label for pending events are confusing. It show as `Starting` even if the internal state of the pending event is `started`. It is better to change the label for pending events to be based on the internal state value.

| State  | Label |
| --------|--------|
| Scheduled  | Starting| 
| Started | Running| 
| Cancel Requested |  Cancelling| 


**Changes:**
- Change label processing for decisions and activities

**Screenshots:**
<img width="1666" height="684" alt="Screenshot 2025-07-23 at 17 05 31" src="https://github.com/user-attachments/assets/db7b592f-c55b-4eef-9e3c-9d136925689c" />
<img width="1692" height="1092" alt="Screenshot 2025-07-23 at 17 03 49" src="https://github.com/user-attachments/assets/a0363fa2-b1f1-442f-b715-aad7b6b64d20" />
<img width="1690" height="1010" alt="Screenshot 2025-07-23 at 17 02 48" src="https://github.com/user-attachments/assets/1d9fb1dc-df07-49e0-a045-04f4eb659d0e" />
