### PR TITLE
Fix return type for diagnoseWorkflow route handler

### DIFF
--- a/src/route-handlers/diagnose-workflow/__fixtures__/mock-diagnostics-query-result.ts
+++ b/src/route-handlers/diagnose-workflow/__fixtures__/mock-diagnostics-query-result.ts
@@ -1,16 +1,18 @@
-import { type WorkflowDiagnosticsResult } from '../diagnose-workflow.types';
+import { type z } from 'zod';
 
-export const mockWorkflowDiagnosticsResult = {
-  result: {
+import type workflowDiagnosticsResultSchema from '../schemas/workflow-diagnostics-result-schema';
+
+export const mockDiagnosticsQueryResult = {
+  DiagnosticsResult: {
     Timeouts: null,
     Failures: {
-      issues: [
+      Issues: [
         {
-          issueId: 0,
-          invariantType: 'Activity Failed',
-          reason:
+          IssueID: 0,
+          InvariantType: 'Activity Failed',
+          Reason:
             'The failure is because of an error returned from the service code',
-          metadata: {
+          Metadata: {
             Identity: 'test-worker@test-host@test-domain@test-workflow@12345',
             ActivityType: 'main.helloWorldActivity',
             ActivityScheduledID: 43,
@@ -18,11 +20,11 @@ export const mockWorkflowDiagnosticsResult = {
           },
         },
         {
-          issueId: 1,
-          invariantType: 'Activity Failed',
-          reason:
+          IssueID: 1,
+          InvariantType: 'Activity Failed',
+          Reason:
             'The failure is because of an error returned from the service code',
-          metadata: {
+          Metadata: {
             Identity: 'test-worker@test-host@test-domain@test-workflow@12345',
             ActivityType: 'main.helloWorldActivity',
             ActivityScheduledID: 29,
@@ -30,11 +32,11 @@ export const mockWorkflowDiagnosticsResult = {
           },
         },
         {
-          issueId: 2,
-          invariantType: 'Activity Failed',
-          reason:
+          IssueID: 2,
+          InvariantType: 'Activity Failed',
+          Reason:
             'The failure is because of an error returned from the service code',
-          metadata: {
+          Metadata: {
             Identity: 'test-worker@test-host@test-domain@test-workflow@12345',
             ActivityType: 'main.helloWorldActivity',
             ActivityScheduledID: 82,
@@ -42,11 +44,11 @@ export const mockWorkflowDiagnosticsResult = {
           },
         },
         {
-          issueId: 3,
-          invariantType: 'Activity Failed',
-          reason:
+          IssueID: 3,
+          InvariantType: 'Activity Failed',
+          Reason:
             'The failure is because of an error returned from the service code',
-          metadata: {
+          Metadata: {
             Identity: 'test-worker@test-host@test-domain@test-workflow@12345',
             ActivityType: 'main.helloWorldActivity',
             ActivityScheduledID: 102,
@@ -54,11 +56,11 @@ export const mockWorkflowDiagnosticsResult = {
           },
         },
         {
-          issueId: 4,
-          invariantType: 'Workflow Failed',
-          reason:
+          IssueID: 4,
+          InvariantType: 'Workflow Failed',
+          Reason:
             'The failure is because of an error returned from the service code',
-          metadata: {
+          Metadata: {
             Identity: 'test-worker@test-host@test-domain@test-workflow@12345',
             ActivityType: '',
             ActivityScheduledID: 0,
@@ -66,42 +68,43 @@ export const mockWorkflowDiagnosticsResult = {
           },
         },
       ],
-      rootCauses: [
+      RootCause: [
         {
-          issueId: 0,
-          rootCauseType:
+          IssueID: 0,
+          RootCauseType:
             'There is an issue in the worker service that is causing a failure. Check identity for service logs',
-          metadata: null,
+          Metadata: null,
         },
         {
-          issueId: 1,
-          rootCauseType:
+          IssueID: 1,
+          RootCauseType:
             'There is an issue in the worker service that is causing a failure. Check identity for service logs',
-          metadata: null,
+          Metadata: null,
         },
         {
-          issueId: 2,
-          rootCauseType:
+          IssueID: 2,
+          RootCauseType:
             'There is an issue in the worker service that is causing a failure. Check identity for service logs',
-          metadata: null,
+          Metadata: null,
         },
         {
-          issueId: 3,
-          rootCauseType:
+          IssueID: 3,
+          RootCauseType:
             'There is an issue in the worker service that is causing a failure. Check identity for service logs',
-          metadata: null,
+          Metadata: null,
         },
         {
-          issueId: 4,
-          rootCauseType:
+          IssueID: 4,
+          RootCauseType:
             'There is an issue in the worker service that is causing a failure. Check identity for service logs',
-          metadata: null,
+          Metadata: null,
         },
       ],
-      runbook:
+      Runbooks: [
         'https://cadenceworkflow.io/docs/workflow-troubleshooting/activity-failures/',
+      ],
     },
     Retries: null,
   },
-  completed: true,
-} as const satisfies WorkflowDiagnosticsResult;
+  DiagnosticsCompleted: true,
+} as const satisfies z.input<typeof workflowDiagnosticsResultSchema>;

--- a/src/route-handlers/diagnose-workflow/__tests__/diagnose-workflow.node.ts
+++ b/src/route-handlers/diagnose-workflow/__tests__/diagnose-workflow.node.ts
@@ -6,6 +6,7 @@ import { type QueryWorkflowResponse } from '@/__generated__/proto-ts/uber/cadenc
 import { GRPCError } from '@/utils/grpc/grpc-error';
 import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
 
+import { mockDiagnosticsQueryResult } from '../__fixtures__/mock-diagnostics-query-result';
 import { mockWorkflowDiagnosticsResult } from '../__fixtures__/mock-workflow-diagnostics-result';
 import { diagnoseWorkflow } from '../diagnose-workflow';
 import {
@@ -97,7 +98,7 @@ describe(diagnoseWorkflow.name, () => {
       .mockResolvedValueOnce({
         queryResult: {
           data: Buffer.from(
-            JSON.stringify(mockWorkflowDiagnosticsResult)
+            JSON.stringify(mockDiagnosticsQueryResult)
           ).toString('base64'),
         },
       } as QueryWorkflowResponse);
@@ -207,8 +208,8 @@ describe(diagnoseWorkflow.name, () => {
     expect(responseJson).toEqual({
       parsingError: expect.objectContaining({ name: 'ZodError' }),
       result: {
-        DiagnosticsCompleted: true,
-        DiagnosticsResult: 'invalid-diagnostics',
+        completed: true,
+        result: 'invalid-diagnostics',
       },
     });
   });
@@ -289,7 +290,7 @@ function setup(options?: {
   } as Context;
 
   const mockQueryResultJson =
-    options?.queryResultData || mockWorkflowDiagnosticsResult;
+    options?.queryResultData || mockDiagnosticsQueryResult;
 
   const mockQueryResponse = {
     queryResult: {

--- a/src/route-handlers/diagnose-workflow/diagnose-workflow.ts
+++ b/src/route-handlers/diagnose-workflow/diagnose-workflow.ts
@@ -77,7 +77,10 @@ export async function diagnoseWorkflow(
     return NextResponse.json(
       (error
         ? {
-            result: unparsedResult,
+            result: {
+              completed: unparsedResult.DiagnosticsCompleted,
+              result: unparsedResult.DiagnosticsResult,
+            },
             parsingError: error,
           }
         : {

--- a/src/route-handlers/diagnose-workflow/schemas/workflow-diagnostics-issue-schema.ts
+++ b/src/route-handlers/diagnose-workflow/schemas/workflow-diagnostics-issue-schema.ts
@@ -1,9 +1,17 @@
 import { z } from 'zod';
 
-const workflowDiagnosticsIssueSchema = z.object({
-  IssueID: z.number(),
-  InvariantType: z.string(),
-  Reason: z.string(),
-  Metadata: z.any(),
-});
+const workflowDiagnosticsIssueSchema = z
+  .object({
+    IssueID: z.number(),
+    InvariantType: z.string(),
+    Reason: z.string(),
+    Metadata: z.any(),
+  })
+  .transform(({ IssueID, InvariantType, Reason, Metadata }) => ({
+    issueId: IssueID,
+    invariantType: InvariantType,
+    reason: Reason,
+    metadata: Metadata,
+  }));
+
 export default workflowDiagnosticsIssueSchema;

--- a/src/route-handlers/diagnose-workflow/schemas/workflow-diagnostics-result-schema.ts
+++ b/src/route-handlers/diagnose-workflow/schemas/workflow-diagnostics-result-schema.ts
@@ -3,18 +3,41 @@ import { z } from 'zod';
 import workflowDiagnosticsIssueSchema from './workflow-diagnostics-issue-schema';
 import workflowDiagnosticsRootCauseSchema from './workflow-diagnostics-root-cause-schema';
 
-const workflowDiagnosticsResultSchema = z.object({
-  DiagnosticsResult: z.record(
-    z.string(),
-    z
-      .object({
-        Issues: z.array(workflowDiagnosticsIssueSchema),
-        RootCause: z.array(workflowDiagnosticsRootCauseSchema).optional(),
-        Runbooks: z.array(z.string()).optional().or(z.null()),
-      })
-      .or(z.null())
-  ),
-  DiagnosticsCompleted: z.literal(true),
-});
+const workflowDiagnosticsResultSchema = z
+  .object({
+    DiagnosticsResult: z.record(
+      z.string(),
+      z
+        .object({
+          Issues: z.array(workflowDiagnosticsIssueSchema),
+          RootCause: z.array(workflowDiagnosticsRootCauseSchema).optional(),
+          // https://github.com/cadence-workflow/cadence/pull/7094 introduces a change to return a single runbook instead of an array
+          // To retain backwards compatibility, we will support both fields but only use the first runbook link if an array is passed
+          Runbook: z.string().optional().nullable(),
+          Runbooks: z.array(z.string()).optional().nullable(),
+        })
+        .transform(({ Issues, RootCause, Runbook, Runbooks }) => {
+          let runbook: string | undefined;
+
+          if (Runbook) {
+            runbook = Runbook;
+          } else if (Runbooks && Runbooks.length > 0) {
+            runbook = Runbooks[0];
+          }
+
+          return {
+            issues: Issues,
+            rootCauses: RootCause,
+            runbook,
+          };
+        })
+        .nullable()
+    ),
+    DiagnosticsCompleted: z.literal(true),
+  })
+  .transform(({ DiagnosticsCompleted, DiagnosticsResult }) => ({
+    result: DiagnosticsResult,
+    completed: DiagnosticsCompleted,
+  }));
 
 export default workflowDiagnosticsResultSchema;

--- a/src/route-handlers/diagnose-workflow/schemas/workflow-diagnostics-root-cause-schema.ts
+++ b/src/route-handlers/diagnose-workflow/schemas/workflow-diagnostics-root-cause-schema.ts
@@ -1,9 +1,15 @@
 import { z } from 'zod';
 
-const workflowDiagnosticsRootCauseSchema = z.object({
-  IssueID: z.number(),
-  RootCauseType: z.string(),
-  Metadata: z.any(),
-});
+const workflowDiagnosticsRootCauseSchema = z
+  .object({
+    IssueID: z.number(),
+    RootCauseType: z.string(),
+    Metadata: z.any(),
+  })
+  .transform(({ IssueID, RootCauseType, Metadata }) => ({
+    rootCauseType: RootCauseType,
+    issueId: IssueID,
+    metadata: Metadata,
+  }));
 
 export default workflowDiagnosticsRootCauseSchema;

--- a/src/views/workflow-diagnostics/workflow-diagnostics-content/__tests__/workflow-diagnostics-content.test.tsx
+++ b/src/views/workflow-diagnostics/workflow-diagnostics-content/__tests__/workflow-diagnostics-content.test.tsx
@@ -86,16 +86,16 @@ describe(WorkflowDiagnosticsContent.name, () => {
   it('should handle empty diagnostics result', async () => {
     setup({
       diagnosticsResult: {
-        DiagnosticsResult: {
+        result: {
           Timeouts: null,
           Failures: {
-            Issues: [],
-            RootCause: [],
-            Runbooks: [],
+            issues: [],
+            rootCauses: [],
+            runbook: '',
           },
           Retries: null,
         },
-        DiagnosticsCompleted: true,
+        completed: true,
       },
     });
 

--- a/src/views/workflow-diagnostics/workflow-diagnostics-content/workflow-diagnostics-content.tsx
+++ b/src/views/workflow-diagnostics/workflow-diagnostics-content/workflow-diagnostics-content.tsx
@@ -26,14 +26,14 @@ export default function WorkflowDiagnosticsContent({
 
   const nonEmptyIssueGroups: Array<string> = useMemo(
     () =>
-      Object.entries(diagnosticsResult.DiagnosticsResult)
+      Object.entries(diagnosticsResult.result)
         .map(([name, issuesGroup]) => {
           if (!issuesGroup) return null;
-          if (issuesGroup.Issues.length === 0) return null;
+          if (issuesGroup.issues.length === 0) return null;
           return name;
         })
         .filter((name) => name !== null) as Array<string>,
-    [diagnosticsResult.DiagnosticsResult]
+    [diagnosticsResult.result]
   );
 
   if (nonEmptyIssueGroups.length === 0) {

--- a/src/views/workflow-diagnostics/workflow-diagnostics-json/__tests__/workflow-diagnostics-json.test.tsx
+++ b/src/views/workflow-diagnostics/workflow-diagnostics-json/__tests__/workflow-diagnostics-json.test.tsx
@@ -29,16 +29,14 @@ describe(WorkflowDiagnosticsJson.name, () => {
   it('renders the PrettyJson component with diagnostics result', () => {
     setup({});
     expect(screen.getByTestId('pretty-json')).toBeInTheDocument();
-    expect(screen.getByTestId('pretty-json')).toHaveTextContent(
-      '"DiagnosticsResult"'
-    );
+    expect(screen.getByTestId('pretty-json')).toHaveTextContent('"result"');
   });
 
   it('renders copy text button with text to copy', () => {
     setup({});
     const copyButton = screen.getByTestId('copy-text-button');
     expect(copyButton).toBeInTheDocument();
-    expect(copyButton).toHaveTextContent('"DiagnosticsResult"');
+    expect(copyButton).toHaveTextContent('"result"');
   });
 
   it('downloads JSON when download button is clicked', async () => {
@@ -55,24 +53,22 @@ describe(WorkflowDiagnosticsJson.name, () => {
   it('renders with empty diagnostics result', () => {
     setup({
       diagnosticsResult: {
-        DiagnosticsResult: {},
-        DiagnosticsCompleted: true,
+        result: {},
+        completed: true,
       },
     });
 
     expect(screen.getByTestId('pretty-json')).toBeInTheDocument();
-    expect(screen.getByTestId('pretty-json')).toHaveTextContent(
-      '"DiagnosticsResult"'
-    );
+    expect(screen.getByTestId('pretty-json')).toHaveTextContent('"result"');
   });
 
   it('renders JSON with invalid data structure', () => {
     setup({
       diagnosticsResult: {
-        DiagnosticsResult: {
+        result: {
           invalidParsedField: 'invalid-value',
         },
-        DiagnosticsCompleted: true,
+        completed: true,
       },
     });
 

--- a/src/views/workflow-diagnostics/workflow-diagnostics-list/__tests__/workflow-diagnostics-list.test.tsx
+++ b/src/views/workflow-diagnostics/workflow-diagnostics-list/__tests__/workflow-diagnostics-list.test.tsx
@@ -4,16 +4,20 @@ import { render, screen, within } from '@/test-utils/rtl';
 
 import { mockWorkflowDiagnosticsResult } from '@/route-handlers/diagnose-workflow/__fixtures__/mock-workflow-diagnostics-result';
 
+import { type Props as IssueProps } from '../../workflow-diagnostics-issue/workflow-diagnostics-issue.types';
 import WorkflowDiagnosticsList from '../workflow-diagnostics-list';
 import { type Props } from '../workflow-diagnostics-list.types';
 
 jest.mock('../../workflow-diagnostics-issue/workflow-diagnostics-issue', () => {
-  return function MockWorkflowDiagnosticsIssue({ issue, rootCauses }: any) {
+  return function MockWorkflowDiagnosticsIssue({
+    issue,
+    rootCauses,
+  }: IssueProps) {
     return (
       <div data-testid="workflow-diagnostics-issue">
-        <div data-testid="issue-id">{issue.IssueID}</div>
-        <div data-testid="issue-type">{issue.InvariantType}</div>
-        <div data-testid="issue-reason">{issue.Reason}</div>
+        <div data-testid="issue-id">{issue.issueId}</div>
+        <div data-testid="issue-type">{issue.invariantType}</div>
+        <div data-testid="issue-reason">{issue.reason}</div>
         <div data-testid="root-causes-count">{rootCauses.length}</div>
       </div>
     );
@@ -107,8 +111,8 @@ describe(WorkflowDiagnosticsList.name, () => {
   it('handles empty diagnostics result', () => {
     setup({
       diagnosticsResult: {
-        DiagnosticsResult: {},
-        DiagnosticsCompleted: true,
+        result: {},
+        completed: true,
       },
     });
 
@@ -121,15 +125,15 @@ describe(WorkflowDiagnosticsList.name, () => {
   it('hides issues groups with no issues', () => {
     setup({
       diagnosticsResult: {
-        DiagnosticsResult: {
-          ...mockWorkflowDiagnosticsResult.DiagnosticsResult,
+        result: {
+          ...mockWorkflowDiagnosticsResult.result,
           'Empty Issues Group': {
-            Issues: [],
-            RootCause: [],
-            Runbooks: [],
+            issues: [],
+            rootCauses: [],
+            runbook: '',
           },
         },
-        DiagnosticsCompleted: true,
+        completed: true,
       },
     });
 

--- a/src/views/workflow-diagnostics/workflow-diagnostics-list/workflow-diagnostics-list.tsx
+++ b/src/views/workflow-diagnostics/workflow-diagnostics-list/workflow-diagnostics-list.tsx
@@ -8,22 +8,22 @@ export default function WorkflowDiagnosticsList({ diagnosticsResult }: Props) {
 
   return (
     <styled.IssuesGroupsContainer>
-      {Object.entries(diagnosticsResult.DiagnosticsResult).map(
+      {Object.entries(diagnosticsResult.result).map(
         ([issuesType, issuesGroup]) => {
-          if (!issuesGroup || issuesGroup.Issues.length === 0) return null;
+          if (!issuesGroup || issuesGroup.issues.length === 0) return null;
 
-          const { Issues, RootCause } = issuesGroup;
+          const { issues, rootCauses } = issuesGroup;
           return (
             <styled.IssuesGroup key={issuesType}>
               <styled.IssuesTitle>{issuesType}</styled.IssuesTitle>
-              {Issues.map((issue) => (
+              {issues.map((issue) => (
                 <WorkflowDiagnosticsIssue
-                  key={`${issuesType}.${issue.IssueID}`}
+                  key={`${issuesType}.${issue.issueId}`}
                   issue={issue}
                   rootCauses={
-                    RootCause
-                      ? RootCause.filter(
-                          (rootCause) => rootCause.IssueID === issue.IssueID
+                    rootCauses
+                      ? rootCauses.filter(
+                          (rootCause) => rootCause.issueId === issue.issueId
                         )
                       : []
                   }


### PR DESCRIPTION
## Summary
- Fix Zod schemas for diagnoseWorkflow to transform diagnostics result into lowercase
- Add a backwards-compatible check in diagnostics result schema to handle https://github.com/cadence-workflow/cadence/pull/7094
- Modify fixture for diagnostics result to match post-parsing format
- Add fixture for diagnostics query result
- Fix types in components

## Test plan
Updated unit tests + ran locally as a sanity check.
