### PR TITLE
Revert hiding version field

### DIFF
--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-cancel-requested-event.ts
@@ -8,10 +8,13 @@ const formatActivityTaskCancelRequestedEvent = ({
   },
   ...eventFields
 }: ActivityTaskCancelRequestedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-cancel-requested-event.ts
@@ -10,6 +10,7 @@ const formatActivityTaskCancelRequestedEvent = ({
 }: ActivityTaskCancelRequestedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-canceled-event.ts
@@ -13,13 +13,16 @@ const formatActivityTaskCanceledEvent = ({
   },
   ...eventFields
 }: ActivityTaskCanceledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     details: formatPayload(details),
     latestCancelRequestedEventId: parseInt(latestCancelRequestedEventId),
     scheduledEventId: parseInt(scheduledEventId),
     startedEventId: parseInt(startedEventId),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-canceled-event.ts
@@ -15,6 +15,7 @@ const formatActivityTaskCanceledEvent = ({
 }: ActivityTaskCanceledEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     details: formatPayload(details),

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-completed-event.ts
@@ -13,13 +13,16 @@ const formatActivityTaskCompletedEvent = ({
   },
   ...eventFields
 }: ActivityTaskCompletedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     result: formatPayload(result),
     identity,
     scheduledEventId: parseInt(scheduledEventId),
     startedEventId: parseInt(startedEventId),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-completed-event.ts
@@ -15,6 +15,7 @@ const formatActivityTaskCompletedEvent = ({
 }: ActivityTaskCompletedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     result: formatPayload(result),

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-failed-event.ts
@@ -15,6 +15,7 @@ const formatActivityTaskFailedEvent = ({
 }: ActivityTaskFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     details: formatFailureDetails(failure),

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-failed-event.ts
@@ -13,14 +13,17 @@ const formatActivityTaskFailedEvent = ({
   },
   ...eventFields
 }: ActivityTaskFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     details: formatFailureDetails(failure),
     reason: failure?.reason || null,
     identity,
     scheduledEventId: parseInt(scheduledEventId),
     startedEventId: parseInt(startedEventId),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
@@ -25,6 +25,7 @@ const formatActivityTaskScheduledEvent = ({
 }: ActivityTaskScheduledEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-scheduled-event.ts
@@ -23,8 +23,10 @@ const formatActivityTaskScheduledEvent = ({
   },
   ...eventFields
 }: ActivityTaskScheduledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     taskList: {
       kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
@@ -43,6 +45,7 @@ const formatActivityTaskScheduledEvent = ({
     domain: domain || null,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
     header: formatPayloadMap(header, 'fields'),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-started-event.ts
@@ -16,6 +16,7 @@ const formatActivityTaskStartedEvent = ({
 }: ActivityTaskStartedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     lastFailureDetails: formatFailureDetails(lastFailure),

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-started-event.ts
@@ -14,8 +14,10 @@ const formatActivityTaskStartedEvent = ({
   },
   ...eventFields
 }: ActivityTaskStartedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     lastFailureDetails: formatFailureDetails(lastFailure),
     lastFailureReason: lastFailure?.reason || null,
     attempt,
@@ -23,6 +25,7 @@ const formatActivityTaskStartedEvent = ({
     scheduledEventId: parseInt(scheduledEventId),
     requestId,
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-timed-out-event.ts
@@ -16,8 +16,10 @@ const formatActivityTaskTimedOutEvent = ({
   },
   ...eventFields
 }: ActivityTaskTimedOutEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     timeoutType: formatEnum(timeoutType, 'TIMEOUT_TYPE', 'pascal'),
     details: formatPayload(details),
@@ -25,6 +27,7 @@ const formatActivityTaskTimedOutEvent = ({
     lastFailureReason: lastFailure?.reason || null,
     scheduledEventId: parseInt(scheduledEventId),
     startedEventId: parseInt(startedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-activity-task-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-activity-task-timed-out-event.ts
@@ -18,6 +18,7 @@ const formatActivityTaskTimedOutEvent = ({
 }: ActivityTaskTimedOutEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-cancel-timer-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-cancel-timer-failed-event.ts
@@ -8,10 +8,13 @@ const formatCancelTimerFailedEvent = ({
   },
   ...eventFields
 }: CancelTimerFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-cancel-timer-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-cancel-timer-failed-event.ts
@@ -10,6 +10,7 @@ const formatCancelTimerFailedEvent = ({
 }: CancelTimerFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-event.ts
@@ -14,6 +14,7 @@ const formatChildWorkflowExecutionCanceledEvent = ({
 }: ChildWorkflowExecutionCanceledEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     details: formatPayload(details),

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-event.ts
@@ -12,12 +12,15 @@ const formatChildWorkflowExecutionCanceledEvent = ({
   },
   ...eventFields
 }: ChildWorkflowExecutionCanceledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     details: formatPayload(details),
     ...eventAttributes,
     initiatedEventId: parseInt(initiatedEventId),
     startedEventId: parseInt(startedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-terminated.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-terminated.ts
@@ -11,6 +11,7 @@ const formatChildWorkflowExecutionTerminatedEvent = ({
 }: ChildWorkflowExecutionTerminatedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-terminated.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-canceled-terminated.ts
@@ -9,11 +9,14 @@ const formatChildWorkflowExecutionTerminatedEvent = ({
   },
   ...eventFields
 }: ChildWorkflowExecutionTerminatedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     initiatedEventId: parseInt(initiatedEventId),
     startedEventId: parseInt(startedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-completed-event.ts
@@ -12,12 +12,15 @@ const formatChildWorkflowExecutionCompletedEvent = ({
   },
   ...eventFields
 }: ChildWorkflowExecutionCompletedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     result: formatPayload(result),
     ...eventAttributes,
     initiatedEventId: parseInt(initiatedEventId),
     startedEventId: parseInt(startedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-completed-event.ts
@@ -14,6 +14,7 @@ const formatChildWorkflowExecutionCompletedEvent = ({
 }: ChildWorkflowExecutionCompletedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     result: formatPayload(result),

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-failed-event.ts
@@ -14,6 +14,7 @@ const formatChildWorkflowExecutionFailedEvent = ({
 }: ChildWorkflowExecutionFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     details: formatFailureDetails(failure),

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-failed-event.ts
@@ -12,13 +12,16 @@ const formatChildWorkflowExecutionFailedEvent = ({
   },
   ...eventFields
 }: ChildWorkflowExecutionFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     details: formatFailureDetails(failure),
     reason: failure?.reason || null,
     ...eventAttributes,
     initiatedEventId: parseInt(initiatedEventId),
     startedEventId: parseInt(startedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-started-event.ts
@@ -11,11 +11,14 @@ const formatChildWorkflowExecutionStartedEvent = ({
   },
   ...eventFields
 }: ChildWorkflowExecutionStartedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     initiatedEventId: parseInt(initiatedEventId),
     header: formatPayloadMap(header, 'fields'),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-started-event.ts
@@ -13,6 +13,7 @@ const formatChildWorkflowExecutionStartedEvent = ({
 }: ChildWorkflowExecutionStartedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-timed-out-event.ts
@@ -11,6 +11,7 @@ const formatChildWorkflowExecutionTimedOutEvent = ({
 }: ChildWorkflowExecutionTimedOutEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-child-workflow-execution-timed-out-event.ts
@@ -9,11 +9,14 @@ const formatChildWorkflowExecutionTimedOutEvent = ({
   },
   ...eventFields
 }: ChildWorkflowExecutionTimedOutEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     initiatedEventId: parseInt(initiatedEventId),
     startedEventId: parseInt(startedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-completed-event.ts
@@ -10,12 +10,15 @@ const formatDecisionTaskCompletedEvent = ({
   },
   ...eventFields
 }: DecisionTaskCompletedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     identity,
     binaryChecksum,
     executionContext: executionContext || null,
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-completed-event.ts
@@ -12,6 +12,7 @@ const formatDecisionTaskCompletedEvent = ({
 }: DecisionTaskCompletedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     identity,

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-failed-event.ts
@@ -17,6 +17,7 @@ const formatDecisionTaskFailedEvent = ({
 }: DecisionTaskFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     details: formatFailureDetails(failure),

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-failed-event.ts
@@ -15,8 +15,10 @@ const formatDecisionTaskFailedEvent = ({
   },
   ...eventFields
 }: DecisionTaskFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     details: formatFailureDetails(failure),
     forkEventVersion: parseInt(forkEventVersion),
     reason: failure?.reason || null,
@@ -24,6 +26,7 @@ const formatDecisionTaskFailedEvent = ({
     scheduledEventId: parseInt(scheduledEventId),
     startedEventId: parseInt(startedEventId),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
@@ -12,14 +12,17 @@ const formatDecisionTaskScheduledEvent = ({
   },
   ...eventFields
 }: DecisionTaskScheduledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     taskList: {
       kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
       name: taskList?.name || null,
     },
     startToCloseTimeoutSeconds: formatDurationToSeconds(startToCloseTimeout),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-scheduled-event.ts
@@ -14,6 +14,7 @@ const formatDecisionTaskScheduledEvent = ({
 }: DecisionTaskScheduledEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     taskList: {

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
@@ -12,6 +12,7 @@ const formatDecisionTaskStartedEvent = ({
 }: DecisionTaskStartedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     identity,

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-task-started-event.ts
@@ -10,12 +10,15 @@ const formatDecisionTaskStartedEvent = ({
   },
   ...eventFields
 }: DecisionTaskStartedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     identity,
     scheduledEventId: parseInt(scheduledEventId),
     requestId,
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-timed-out-event.ts
@@ -16,6 +16,7 @@ const formatDecisionTaskTimedOutEvent = ({
 }: DecisionTaskTimedOutEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     cause: formatEnum(cause, 'DECISION_TASK_TIMED_OUT_CAUSE'),

--- a/src/utils/data-formatters/format-workflow-history-event/format-decision-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-decision-timed-out-event.ts
@@ -14,14 +14,17 @@ const formatDecisionTaskTimedOutEvent = ({
   },
   ...eventFields
 }: DecisionTaskTimedOutEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     cause: formatEnum(cause, 'DECISION_TASK_TIMED_OUT_CAUSE'),
     reason,
     forkEventVersion: parseInt(forkEventVersion),
     scheduledEventId: parseInt(scheduledEventId),
     startedEventId: parseInt(startedEventId),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-cancel-requested-event.ts
@@ -10,6 +10,7 @@ const formatExternalWorkflowExecutionCancelRequestedEvent = ({
 }: ExternalWorkflowExecutionCancelRequestedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     initiatedEventId: parseInt(initiatedEventId),

--- a/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-cancel-requested-event.ts
@@ -8,10 +8,13 @@ const formatExternalWorkflowExecutionCancelRequestedEvent = ({
   },
   ...eventFields
 }: ExternalWorkflowExecutionCancelRequestedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     initiatedEventId: parseInt(initiatedEventId),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-signaled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-signaled-event.ts
@@ -9,11 +9,14 @@ const formatExternalWorkflowExecutionSignaledEvent = ({
   },
   ...eventFields
 }: ExternalWorkflowExecutionSignaledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     control: control ? parseInt(atob(control)) : null,
     initiatedEventId: parseInt(initiatedEventId),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-signaled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-external-workflow-execution-signaled-event.ts
@@ -11,6 +11,7 @@ const formatExternalWorkflowExecutionSignaledEvent = ({
 }: ExternalWorkflowExecutionSignaledEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     control: control ? parseInt(atob(control)) : null,

--- a/src/utils/data-formatters/format-workflow-history-event/format-format-marker-recorded-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-format-marker-recorded-event.ts
@@ -14,13 +14,16 @@ const formatMarkerRecordedEvent = ({
   },
   ...eventFields
 }: MarkerRecordedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     markerName,
     details: formatPayload(details),
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
     header: formatPayloadMap(header, 'fields'),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-format-marker-recorded-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-format-marker-recorded-event.ts
@@ -16,6 +16,7 @@ const formatMarkerRecordedEvent = ({
 }: MarkerRecordedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     markerName,

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-activity-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-activity-task-failed-event.ts
@@ -8,10 +8,13 @@ const formatRequestCancelActivityTaskFailedEvent = ({
   },
   ...eventFields
 }: RequestCancelActivityTaskFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-activity-task-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-activity-task-failed-event.ts
@@ -10,6 +10,7 @@ const formatRequestCancelActivityTaskFailedEvent = ({
 }: RequestCancelActivityTaskFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
@@ -13,6 +13,7 @@ const formatRequestCancelExternalWorkflowExecutionFailedEvent = ({
 }: RequestCancelExternalWorkflowExecutionFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     cause,

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
@@ -11,13 +11,16 @@ const formatRequestCancelExternalWorkflowExecutionFailedEvent = ({
   },
   ...eventFields
 }: RequestCancelExternalWorkflowExecutionFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     cause,
     control: control ? parseInt(atob(control)) : null,
     initiatedEventId: parseInt(initiatedEventId),
     ...eventAttributes,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-initiated-event.ts
@@ -9,11 +9,14 @@ const formatRequestCancelExternalWorkflowExecutionInitiatedEvent = ({
   },
   ...eventFields
 }: RequestCancelExternalWorkflowExecutionInitiatedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     control: control ? parseInt(atob(control)) : null,
     ...eventAttributes,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-initiated-event.ts
@@ -11,6 +11,7 @@ const formatRequestCancelExternalWorkflowExecutionInitiatedEvent = ({
 }: RequestCancelExternalWorkflowExecutionInitiatedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     control: control ? parseInt(atob(control)) : null,

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
@@ -11,13 +11,16 @@ const formatSignalExternalWorkflowExecutionFailedEvent = ({
   },
   ...eventFields
 }: SignalExternalWorkflowExecutionFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     cause,
     control: control ? parseInt(atob(control)) : null,
     initiatedEventId: parseInt(initiatedEventId),
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
@@ -13,6 +13,7 @@ const formatSignalExternalWorkflowExecutionFailedEvent = ({
 }: SignalExternalWorkflowExecutionFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
@@ -15,6 +15,7 @@ const formatSignalExternalWorkflowExecutionInitiatedEvent = ({
 }: SignalExternalWorkflowExecutionInitiatedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-initiated-event.ts
@@ -13,13 +13,16 @@ const formatSignalExternalWorkflowExecutionInitiatedEvent = ({
   },
   ...eventFields
 }: SignalExternalWorkflowExecutionInitiatedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     input: formatInputPayload(input),
     signalName,
     control: control ? parseInt(atob(control)) : null,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
@@ -13,6 +13,7 @@ const formatStartChildWorkflowExecutionFailedEvent = ({
 }: StartChildWorkflowExecutionFailedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     cause,

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
@@ -11,13 +11,16 @@ const formatStartChildWorkflowExecutionFailedEvent = ({
   },
   ...eventFields
 }: StartChildWorkflowExecutionFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     cause,
     ...eventAttributes,
     control: control ? parseInt(atob(control)) : null,
     initiatedEventId: parseInt(initiatedEventId),
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
@@ -31,6 +31,7 @@ const formatStartChildWorkflowExecutionInitiatedEvent = ({
 }: StartChildWorkflowExecutionInitiatedEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-initiated-event.ts
@@ -29,8 +29,10 @@ const formatStartChildWorkflowExecutionInitiatedEvent = ({
   },
   ...eventFields
 }: StartChildWorkflowExecutionInitiatedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     taskList: {
       kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
@@ -59,6 +61,7 @@ const formatStartChildWorkflowExecutionInitiatedEvent = ({
     header: formatPayloadMap(header, 'fields'),
     memo: formatPayloadMap(memo, 'fields'),
     searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-canceled-event.ts
@@ -11,6 +11,7 @@ const formatTimerCanceledEvent = ({
 }: TimerCanceledEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
+
   return {
     ...primaryCommonFields,
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-canceled-event.ts
@@ -9,11 +9,14 @@ const formatTimerCanceledEvent = ({
   },
   ...eventFields
 }: TimerCanceledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     startedEventId: parseInt(startedEventId),
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-fired-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-fired-event.ts
@@ -5,10 +5,14 @@ const formatTimerFiredEvent = ({
   timerFiredEventAttributes: { startedEventId, ...eventAttributes },
   ...eventFields
 }: TimerFiredEvent) => {
-  return {
-    ...formatWorkflowCommonEventFields(eventFields),
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+    
+    return {
+    ...primaryCommonFields,
     ...eventAttributes,
     startedEventId: parseInt(startedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-fired-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-fired-event.ts
@@ -7,8 +7,8 @@ const formatTimerFiredEvent = ({
 }: TimerFiredEvent) => {
   const { primaryCommonFields, secondaryCommonFields } =
     formatWorkflowCommonEventFields(eventFields);
-    
-    return {
+
+  return {
     ...primaryCommonFields,
     ...eventAttributes,
     startedEventId: parseInt(startedEventId),

--- a/src/utils/data-formatters/format-workflow-history-event/format-timer-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-timer-started-event.ts
@@ -11,11 +11,15 @@ const formatTimerStartedEvent = ({
   },
   ...eventFields
 }: TimerStartedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     startToFireTimeoutSeconds: formatDurationToSeconds(startToFireTimeout),
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-upsert-workflow-search-attributes-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-upsert-workflow-search-attributes-event.ts
@@ -11,11 +11,15 @@ const formatUpsertWorkflowSearchAttributesEvent = ({
   },
   ...eventFields
 }: UpsertWorkflowSearchAttributesEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),
     searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-common-event-fields.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-common-event-fields.ts
@@ -15,10 +15,16 @@ export default function formatWorkflowCommonEventFields<
   eventTime: HistoryEvent['eventTime'];
   attributes: T;
 }) {
-  return {
-    ...rest,
+  const primaryCommonFields = {
     eventId: parseInt(eventId),
     timestamp: formatTimestampToDatetime(eventTime),
     eventType: formatWorkflowHistoryEventType<T>(attributes),
+  };
+
+  const secondaryCommonFields = rest;
+
+  return {
+    primaryCommonFields,
+    secondaryCommonFields,
   };
 }

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-cancel-requested-event.ts
@@ -11,8 +11,11 @@ const formatWorkflowExecutionCancelRequestedEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionCancelRequestedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     cause,
     externalInitiatedEventId: externalExecutionInfo?.initiatedId
       ? parseInt(externalExecutionInfo.initiatedId)
@@ -21,6 +24,7 @@ const formatWorkflowExecutionCancelRequestedEvent = ({
     identity,
     requestId,
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-canceled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-canceled-event.ts
@@ -12,13 +12,17 @@ const formatWorkflowExecutionCanceledEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionCanceledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     details: formatPayload(details),
     decisionTaskCompletedEventId: formatWorkflowEventId(
       decisionTaskCompletedEventId
     ),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-completed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-completed-event.ts
@@ -12,13 +12,17 @@ const formatWorkflowExecutionCompletedEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionCompletedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     result: formatPayload(result),
     decisionTaskCompletedEventId: formatWorkflowEventId(
       decisionTaskCompletedEventId
     ),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-continued-as-new-event.ts
@@ -27,8 +27,11 @@ const formatWorkflowExecutionContinuedAsNewEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionContinuedAsNewEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
     taskList: {
       kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
@@ -54,6 +57,7 @@ const formatWorkflowExecutionContinuedAsNewEvent = ({
     header: formatPayloadMap(header, 'fields'),
     memo: formatPayloadMap(memo, 'fields'),
     searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-failed-event.ts
@@ -12,14 +12,18 @@ const formatWorkflowExecutionFailedEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionFailedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     reason: failure?.reason || null,
     details: formatFailureDetails(failure),
     decisionTaskCompletedEventId: formatWorkflowEventId(
       decisionTaskCompletedEventId
     ),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-signaled-event.ts
@@ -11,11 +11,15 @@ const formatWorkflowExecutionSignaledEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionSignaledEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     input: formatInputPayload(input),
     ...eventAttributes,
     requestId,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-started-event.ts
@@ -42,10 +42,13 @@ const formatWorkflowExecutionStartedEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionStartedEvent) => {
-  return {
-    ...formatWorkflowCommonEventFields<'workflowExecutionStartedEventAttributes'>(
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields<'workflowExecutionStartedEventAttributes'>(
       eventFields
-    ),
+    );
+
+  return {
+    ...primaryCommonFields,
     workflowType,
     taskList: {
       kind: formatEnum(taskList?.kind, 'TASK_LIST_KIND'),
@@ -86,6 +89,7 @@ const formatWorkflowExecutionStartedEvent = ({
     searchAttributes: formatPayloadMap(searchAttributes, 'indexedFields'),
     prevAutoResetPoints: formatPrevAutoResetPoints(prevAutoResetPoints),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-terminated-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-terminated-event.ts
@@ -11,11 +11,15 @@ const formatWorkflowExecutionTerminatedEvent = ({
   },
   ...eventFields
 }: WorkflowExecutionTerminatedEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     reason: reason || null,
     details: formatPayload(details),
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-timed-out-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-workflow-execution-timed-out-event.ts
@@ -5,9 +5,13 @@ const formatWorkflowExecutionTimedOutEvent = ({
   workflowExecutionTimedOutEventAttributes: { ...eventAttributes },
   ...eventFields
 }: WorkflowExecutionTimedOutEvent) => {
+  const { primaryCommonFields, secondaryCommonFields } =
+    formatWorkflowCommonEventFields(eventFields);
+
   return {
-    ...formatWorkflowCommonEventFields(eventFields),
+    ...primaryCommonFields,
     ...eventAttributes,
+    ...secondaryCommonFields,
   };
 };
 

--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -17,7 +17,7 @@ const workflowHistoryEventDetailsConfig = [
   },
   {
     name: 'Filter unneeded values',
-    pathRegex: '(version|taskId|eventType)$',
+    pathRegex: '(taskId|eventType)$',
     hide: () => true,
   },
   {


### PR DESCRIPTION
**Summary**
Version field is needed by some users. It is needs to be shown again, but at the end of the details since it is not frequently used.

**Screenshots**
<img width="1408" height="1672" alt="Screenshot 2025-07-29 at 15 35 21" src="https://github.com/user-attachments/assets/578ef137-ba7b-46be-8f4f-4bfaa1b3c917" />
