### PR TITLE
Add docstring for workflowDiagnosticsEnabled feature flag resolver

### DIFF
--- a/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
+++ b/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
@@ -2,8 +2,9 @@
  * Returns whether workflow diagnostics APIs and UI are enabled.
  *
  * To enable workflow diagnostics, set the CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED env variable to true.
+ * For further customization, override the implementation of this resolver.
  *
- * Server version behavior:
+ * Server version behaviour:
  * - \>= 1.3.1: Diagnostics APIs and UI will work as expected.
  * - \>= 1.2.13 & < 1.3.1: Diagnostics APIs will work, but the format may not be as expected; only raw JSON will be displayed.
  * - < 1.2.13: Diagnostics APIs will return a GRPC unimplemented error (maps to HTTP 404 in the client).

--- a/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
+++ b/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
@@ -1,7 +1,7 @@
 /**
  * Returns whether workflow diagnostics APIs and UI are enabled.
  *
- * To enable workflow diagnostics, change the return value of this resolver to "true".
+ * To enable workflow diagnostics, set the CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED env variable to true.
  *
  * Server version behavior:
  * - \>= 1.3.1: Diagnostics APIs and UI will work as expected.
@@ -11,5 +11,5 @@
  * @returns {Promise<boolean>} Whether workflow diagnostics are enabled.
  */
 export default async function workflowDiagnosticsEnabled(): Promise<boolean> {
-  return false;
+  return process.env.CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED === 'true';
 }

--- a/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
+++ b/src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts
@@ -1,3 +1,15 @@
+/**
+ * Returns whether workflow diagnostics APIs and UI are enabled.
+ *
+ * To enable workflow diagnostics, change the return value of this resolver to "true".
+ *
+ * Server version behavior:
+ * - \>= 1.3.1: Diagnostics APIs and UI will work as expected.
+ * - \>= 1.2.13 & < 1.3.1: Diagnostics APIs will work, but the format may not be as expected; only raw JSON will be displayed.
+ * - < 1.2.13: Diagnostics APIs will return a GRPC unimplemented error (maps to HTTP 404 in the client).
+ *
+ * @returns {Promise<boolean>} Whether workflow diagnostics are enabled.
+ */
 export default async function workflowDiagnosticsEnabled(): Promise<boolean> {
   return false;
 }


### PR DESCRIPTION
## Summary
- Add env variable for enabling workflow diagnostics, and use it in the workflowDiagnosticsEnabled feature flag resolver
- Add docstring to workflowDiagnosticsEnabled resolver, detailing required server versions for full & partial support.

## Test plan
Ran locally to sanity check.