### PR TITLE
Add section in readme for feature flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,14 @@ CADENCE_CLUSTERS_NAMES=cluster0,cluster1
 
 #### Feature flags
 
-Feature flags in `cadence-web` are configured as separate resolvers in the dynamic config system (`src/config/dynamic/resolvers`). These flags control various UI features and functionality. 
+Feature flags control various UI features and functionality in `cadence-web`. These can be configured using environment variables.
 
-| Feature Flag | Description | Configuration |
-|-------------|-------------|---------------|
-| `EXTENDED_DOMAIN_INFO_ENABLED` | Controls the display of extended domain information including metadata and issues sections | [`extended-domain-info-enabled.ts`](src/config/dynamic/resolvers/extended-domain-info-enabled.ts) |
-| `WORKFLOW_DIAGNOSTICS_ENABLED` | Controls the availability of workflow diagnostics features | `CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED` environment variable or [`workflow-diagnostics-enabled.ts`](src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts) |
+| Feature | Description | Environment Variable Configuration | Minimum Cadence server Version |
+|---------|-------------|---------------------|------------------------|
+| Extended Domain Information | Enhanced domain metadata display and help menu UI | `CADENCE_EXTENDED_DOMAIN_INFO_METADATA_ENABLED=true` | N/A |
+| Workflow Diagnostics | Workflow diagnostics APIs and UI for debugging workflows | `CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED=true` | 1.2.13+ (1.3.1+ for full functionality) |
+
+**Note:** For advanced customization, feature flags can be modified through resolvers in the dynamic config system ([`src/config/dynamic/resolvers`](src/config/dynamic/resolvers)).
 
 ### Using cadence-web
 

--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ CADENCE_CLUSTERS_NAMES=cluster0,cluster1
 
 #### Feature flags
 
-Feature flags in `cadence-web` are configured as separate resolvers in the dynamic config system (`src/config/dynamic/resolvers`). These flags control various UI features and functionality.
+Feature flags in `cadence-web` are configured as separate resolvers in the dynamic config system (`src/config/dynamic/resolvers`). These flags control various UI features and functionality. 
 
-| Feature Flag | Description | Resolver |
-|-------------|-------------|----------|
+| Feature Flag | Description | Configuration |
+|-------------|-------------|---------------|
 | `EXTENDED_DOMAIN_INFO_ENABLED` | Controls the display of extended domain information including metadata and issues sections | [`extended-domain-info-enabled.ts`](src/config/dynamic/resolvers/extended-domain-info-enabled.ts) |
-| `WORKFLOW_DIAGNOSTICS_ENABLED` | Controls the availability of workflow diagnostics features | [`workflow-diagnostics-enabled.ts`](src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts) |
+| `WORKFLOW_DIAGNOSTICS_ENABLED` | Controls the availability of workflow diagnostics features | `CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED` environment variable or [`workflow-diagnostics-enabled.ts`](src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts) |
 
 ### Using cadence-web
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ CADENCE_GRPC_SERVICES_NAMES=cadence-frontend-cluster0,cadence-frontend-cluster1
 CADENCE_CLUSTERS_NAMES=cluster0,cluster1
 ```
 
+#### Feature flags
+
+Feature flags in `cadence-web` are configured as separate resolvers in the dynamic config system (`src/config/dynamic/resolvers`). These flags control various UI features and functionality.
+
+| Feature Flag | Description | Resolver |
+|-------------|-------------|----------|
+| `WORKFLOW_ACTIONS_ENABLED` | Controls whether users can access workflow actions (terminate, cancel, restart, reset, signal) in the UI | [`src/config/dynamic/resolvers/workflow-actions-enabled.ts`](src/config/dynamic/resolvers/workflow-actions-enabled.ts) |
+| `EXTENDED_DOMAIN_INFO_ENABLED` | Controls the display of extended domain information including metadata and issues sections | [`src/config/dynamic/resolvers/extended-domain-info-enabled.ts`](src/config/dynamic/resolvers/extended-domain-info-enabled.ts) |
+| `WORKFLOW_DIAGNOSTICS_ENABLED` | Controls the availability of workflow diagnostics features | [`src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts`](src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts) |
+
 ### Using cadence-web
 
 The latest version of `cadence-web` is included in the `cadence` composed docker containers in the [main Cadence repository][cadence]. Follow the instructions there to get started.

--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ Feature flags in `cadence-web` are configured as separate resolvers in the dynam
 
 | Feature Flag | Description | Resolver |
 |-------------|-------------|----------|
-| `WORKFLOW_ACTIONS_ENABLED` | Controls whether users can access workflow actions (terminate, cancel, restart, reset, signal) in the UI | [`src/config/dynamic/resolvers/workflow-actions-enabled.ts`](src/config/dynamic/resolvers/workflow-actions-enabled.ts) |
-| `EXTENDED_DOMAIN_INFO_ENABLED` | Controls the display of extended domain information including metadata and issues sections | [`src/config/dynamic/resolvers/extended-domain-info-enabled.ts`](src/config/dynamic/resolvers/extended-domain-info-enabled.ts) |
-| `WORKFLOW_DIAGNOSTICS_ENABLED` | Controls the availability of workflow diagnostics features | [`src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts`](src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts) |
+| `EXTENDED_DOMAIN_INFO_ENABLED` | Controls the display of extended domain information including metadata and issues sections | [`extended-domain-info-enabled.ts`](src/config/dynamic/resolvers/extended-domain-info-enabled.ts) |
+| `WORKFLOW_DIAGNOSTICS_ENABLED` | Controls the availability of workflow diagnostics features | [`workflow-diagnostics-enabled.ts`](src/config/dynamic/resolvers/workflow-diagnostics-enabled.ts) |
 
 ### Using cadence-web
 

--- a/src/config/dynamic/resolvers/extended-domain-info-enabled.ts
+++ b/src/config/dynamic/resolvers/extended-domain-info-enabled.ts
@@ -2,7 +2,10 @@ import { type ExtendedDomainInfoEnabledConfig } from './extended-domain-info-ena
 
 export default async function extendedDomainInfoEnabled(): Promise<ExtendedDomainInfoEnabledConfig> {
   return {
-    metadata: false,
+    // TODO: @adhitya.mamallan - clean up this feature flag
+    metadata:
+      process.env.CADENCE_EXTENDED_DOMAIN_INFO_METADATA_ENABLED === 'true',
+    // Unused feature flag
     issues: false,
   };
 }


### PR DESCRIPTION
## Summary
- Add a section in README.md to explain the available feature flags and how to enable them
- Add env variable configuration for extended domain information

## Test plan
Ran locally.

<img width="2554" height="1287" alt="Screenshot 2025-08-08 at 1 13 07 PM" src="https://github.com/user-attachments/assets/ea77e7eb-5db7-4935-8be5-9d7b18d0b68a" />
