### PR TITLE
Remove copy button from pending events in workflow history

### DIFF
--- a/src/views/workflow-history/workflow-history-events-card/__tests__/workflow-history-events-card.test.tsx
+++ b/src/views/workflow-history/workflow-history-events-card/__tests__/workflow-history-events-card.test.tsx
@@ -4,6 +4,7 @@ import {
   scheduleActivityTaskEvent,
   startActivityTaskEvent,
 } from '../../__fixtures__/workflow-history-activity-events';
+import { pendingActivityTaskStartEvent } from '../../__fixtures__/workflow-history-pending-events';
 import WorkflowHistoryEventsCard from '../workflow-history-events-card';
 import type { Props } from '../workflow-history-events-card.types';
 
@@ -101,6 +102,44 @@ describe('WorkflowHistoryEventsCard', () => {
       'data-event-id',
       scheduleActivityTaskEvent.eventId
     );
+  });
+
+  it('should show copy button when event is expanded', () => {
+    const events: Props['events'] = [scheduleActivityTaskEvent];
+    const eventsMetadata: Props['eventsMetadata'] = [
+      {
+        label: 'First event',
+        status: 'COMPLETED',
+      },
+    ];
+    setup({
+      events,
+      eventsMetadata,
+      getIsEventExpanded: jest.fn().mockReturnValue(true),
+    });
+
+    expect(screen.getByTestId('event-link-button')).toBeInTheDocument();
+    expect(screen.getByTestId('event-link-button')).toHaveAttribute(
+      'data-event-id',
+      scheduleActivityTaskEvent.eventId
+    );
+  });
+
+  it('should not show copy button for pending event even when expanded', () => {
+    const events: Props['events'] = [pendingActivityTaskStartEvent];
+    const eventsMetadata: Props['eventsMetadata'] = [
+      {
+        label: 'Pending event',
+        status: 'WAITING',
+      },
+    ];
+    setup({
+      events,
+      eventsMetadata,
+      getIsEventExpanded: jest.fn().mockReturnValue(true),
+    });
+
+    expect(screen.queryByTestId('event-link-button')).not.toBeInTheDocument();
   });
 
   it('should call onEventToggle callback on click', async () => {

--- a/src/views/workflow-history/workflow-history-events-card/workflow-history-events-card.tsx
+++ b/src/views/workflow-history/workflow-history-events-card/workflow-history-events-card.tsx
@@ -56,7 +56,7 @@ export default function WorkflowHistoryEventsCard({
                 />
                 <div className={cls.eventLabel}>
                   {eventMetadata.label}
-                  {isPanelExpanded && (
+                  {event.eventId && isPanelExpanded && (
                     <WorkflowHistoryEventLinkButton historyEventId={id} />
                   )}
                 </div>

--- a/src/views/workflow-history/workflow-history-ungrouped-event/__tests__/workflow-history-ungrouped-event.test.tsx
+++ b/src/views/workflow-history/workflow-history-ungrouped-event/__tests__/workflow-history-ungrouped-event.test.tsx
@@ -224,6 +224,29 @@ describe(WorkflowHistoryUngroupedEvent.name, () => {
 
     expect(mockOnReset).toHaveBeenCalledTimes(1);
   });
+
+  it('should show copy button for regular event when expanded', () => {
+    setup({ isExpanded: true });
+
+    expect(screen.getByTestId('event-link-button')).toBeInTheDocument();
+    expect(screen.getByTestId('event-link-button')).toHaveAttribute(
+      'data-event-id',
+      startWorkflowExecutionEvent.eventId
+    );
+    expect(screen.getByTestId('event-link-button')).toHaveAttribute(
+      'data-ungrouped',
+      'true'
+    );
+  });
+
+  it('should not show copy button for pending event even when expanded', () => {
+    setup({
+      eventInfo: mockPendingActivityEventInfo,
+      isExpanded: true,
+    });
+
+    expect(screen.queryByTestId('event-link-button')).not.toBeInTheDocument();
+  });
 });
 
 function setup({

--- a/src/views/workflow-history/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
+++ b/src/views/workflow-history/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
@@ -50,7 +50,7 @@ export default function WorkflowHistoryUngroupedEvent({
                 label={eventInfo.label}
                 shortLabel={eventInfo.shortLabel}
               />
-              {isExpanded && (
+              {eventInfo.event.eventId && isExpanded && (
                 <WorkflowHistoryEventLinkButton
                   historyEventId={eventInfo.id}
                   isUngroupedView


### PR DESCRIPTION
## Summary
Since pending events in the workflow history are only present temporarily, we do not want to support deep-linking to them because the deep link will no longer be valid once the event is actually written to history. This PR hides the Copy Link to Event button for pending events.

## Test plan
Added unit tests + ran locally.

In grouped view:
<img width="1260" height="955" alt="Screenshot 2025-08-06 at 12 54 58 PM" src="https://github.com/user-attachments/assets/1bcf4299-c113-4306-bbb1-2c030d252465" />

In ungrouped view:
<img width="1596" height="944" alt="Screenshot 2025-08-06 at 12 55 08 PM" src="https://github.com/user-attachments/assets/7aab21db-0114-412a-bccf-03d0d2faed42" />
