### PR TITLE
Correlating logs to traces

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,7 +19,12 @@ const nextConfig = {
       '@': path.resolve(__dirname, './src'),
     };
     if (options.isServer) {
-      config.externals.push('@grpc/grpc-js', 'require-in-the-middle', '@opentelemetry/exporter-jaeger');
+      config.externals.push(
+        '@grpc/grpc-js',
+        'require-in-the-middle',
+        'pino',
+        /^@opentelemetry\//
+      );
     }
     return config;
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@opentelemetry/exporter-trace-otlp-grpc": "^0.200.0",
         "@opentelemetry/instrumentation-grpc": "^0.200.0",
         "@opentelemetry/instrumentation-http": "^0.200.0",
+        "@opentelemetry/instrumentation-pino": "^0.50.0",
         "@opentelemetry/instrumentation-undici": "^0.11.0",
         "@opentelemetry/propagator-jaeger": "^2.0.0",
         "@opentelemetry/resources": "^2.0.0",
@@ -2594,6 +2595,52 @@
         "@opentelemetry/instrumentation": "0.200.0",
         "@opentelemetry/semantic-conventions": "^1.29.0",
         "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pino": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pino/-/instrumentation-pino-0.50.0.tgz",
+      "integrity": "sha512-Pi0cWGp4f2gresq2xqef4IsuunLdebJ9n9tZxytDz2ci4euIfW36ILpszQmRNhwCVDCZLmUgGDKZGj4PXyPd0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "^0.203.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.203.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pino/node_modules/@opentelemetry/api-logs": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.203.0.tgz",
+      "integrity": "sha512-9B9RU0H7Ya1Dx/Rkyc4stuBZSGVQF27WigitInx2QQoj6KUpEFYPKoWjdFTunJYxmXmh17HeBvbMa1EhGyPmqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pino/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.203.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.203.0.tgz",
+      "integrity": "sha512-ke1qyM+3AK2zPuBPb6Hk/GCsc5ewbLvPNkEuELx/JmANeEp6ZjnZ+wypPAJSucTw0wvCGrUaibDSdcrGFoWxKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.203.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
       },
       "engines": {
         "node": "^18.19.0 || >=20.6.0"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@opentelemetry/exporter-trace-otlp-grpc": "^0.200.0",
     "@opentelemetry/instrumentation-grpc": "^0.200.0",
     "@opentelemetry/instrumentation-http": "^0.200.0",
+    "@opentelemetry/instrumentation-pino": "^0.50.0",
     "@opentelemetry/instrumentation-undici": "^0.11.0",
     "@opentelemetry/propagator-jaeger": "^2.0.0",
     "@opentelemetry/resources": "^2.0.0",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,16 +1,32 @@
-import logger, { registerLoggers } from '@/utils/logger';
+import { type Instrumentation } from '@opentelemetry/instrumentation';
 
 import getTransformedConfigs from './utils/config/get-transformed-configs';
 import { setLoadedGlobalConfigs } from './utils/config/global-configs-ref';
 
 export async function register() {
+  let instrumentations: (Instrumentation | Instrumentation[])[] = [];
+  // register instrumentations before any other code is executed
+  if (
+    process.env.NEXT_RUNTIME === 'nodejs' &&
+    process.env.OTEL_SDK_DISABLED === 'false'
+  ) {
+    instrumentations = (
+      await import('@/utils/otel/otel-register-instrumentations')
+    ).otelRegisterInstrumentations({});
+  }
+
+  // register loggers after instrumentations are registered to have instrumented pino with logs correlation
+  const { registerLoggers, default: logger } = await import('@/utils/logger');
   registerLoggers();
 
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     if (process.env.OTEL_SDK_DISABLED === 'false') {
-      (await import('@/utils/otel/otel-register')).register();
+      await (
+        await import('@/utils/otel/otel-register')
+      ).otelRegister({
+        instrumentations,
+      });
     }
-
     try {
       const configs = await getTransformedConfigs();
       setLoadedGlobalConfigs(configs);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -15,7 +15,7 @@ export async function register() {
     ).otelRegisterInstrumentations({});
   }
 
-  // register loggers after instrumentations are registered to have instrumented pino with logs correlation
+  // import/register loggers after instrumentations are registered to have instrumented pino along with logs correlation
   const { registerLoggers, default: logger } = await import('@/utils/logger');
   registerLoggers();
 

--- a/src/utils/otel/otel-register-instrumentations.ts
+++ b/src/utils/otel/otel-register-instrumentations.ts
@@ -1,0 +1,35 @@
+import {
+  GrpcInstrumentation,
+  type GrpcInstrumentationConfig,
+} from '@opentelemetry/instrumentation-grpc';
+import {
+  HttpInstrumentation,
+  type HttpInstrumentationConfig,
+} from '@opentelemetry/instrumentation-http';
+import {
+  PinoInstrumentation,
+  type PinoInstrumentationConfig,
+} from '@opentelemetry/instrumentation-pino';
+import {
+  UndiciInstrumentation,
+  type UndiciInstrumentationConfig,
+} from '@opentelemetry/instrumentation-undici';
+
+export function otelRegisterInstrumentations({
+  grpcInstrumentationConfig,
+  httpInstrumentationConfig,
+  undiciInstrumentationConfig,
+  pinoInstrumentationConfig,
+}: {
+  grpcInstrumentationConfig?: GrpcInstrumentationConfig;
+  httpInstrumentationConfig?: HttpInstrumentationConfig;
+  undiciInstrumentationConfig?: UndiciInstrumentationConfig;
+  pinoInstrumentationConfig?: PinoInstrumentationConfig;
+} = {}) {
+  return [
+    new GrpcInstrumentation(grpcInstrumentationConfig),
+    new HttpInstrumentation(httpInstrumentationConfig),
+    new UndiciInstrumentation(undiciInstrumentationConfig),
+    new PinoInstrumentation(pinoInstrumentationConfig),
+  ];
+}

--- a/src/utils/otel/otel-register.ts
+++ b/src/utils/otel/otel-register.ts
@@ -1,7 +1,4 @@
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import { GrpcInstrumentation } from '@opentelemetry/instrumentation-grpc';
-import { HttpInstrumentation } from '@opentelemetry/instrumentation-http';
-import { UndiciInstrumentation } from '@opentelemetry/instrumentation-undici';
 import { JaegerPropagator } from '@opentelemetry/propagator-jaeger';
 import { resourceFromAttributes } from '@opentelemetry/resources';
 import { NodeSDK } from '@opentelemetry/sdk-node';
@@ -11,20 +8,14 @@ import logger from '@/utils/logger';
 
 import { type OtelRegisterConfig } from './otel.types';
 
-export async function register(config?: OtelRegisterConfig) {
-  const { grpcInstrumentationConfig, ...sdkConfig } = config || {};
+export async function otelRegister(config?: OtelRegisterConfig) {
   const sdk = new NodeSDK({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: 'cadence-web',
     }),
-    instrumentations: [
-      new GrpcInstrumentation(grpcInstrumentationConfig),
-      new HttpInstrumentation(),
-      new UndiciInstrumentation(),
-    ],
     textMapPropagator: new JaegerPropagator(),
     traceExporter: new OTLPTraceExporter(),
-    ...sdkConfig,
+    ...config,
   });
   try {
     await sdk.start();

--- a/src/utils/otel/otel.types.ts
+++ b/src/utils/otel/otel.types.ts
@@ -1,6 +1,3 @@
-import { type GrpcInstrumentationConfig } from '@opentelemetry/instrumentation-grpc';
 import { type NodeSDKConfiguration } from '@opentelemetry/sdk-node';
 
-export type OtelRegisterConfig = Partial<NodeSDKConfiguration> & {
-  grpcInstrumentationConfig?: GrpcInstrumentationConfig;
-};
+export type OtelRegisterConfig = Partial<NodeSDKConfiguration>;


### PR DESCRIPTION
**Summary**
Adding `trace_id`, `span_id` & `trace_flags` to logs for better debugging.

**Changes**
- Add `PinoInstrumentation` to automatically add tracing fields to logs
-  Add `pino` to external packages to allow instrumenting the module. This is not possible with webpack bundled packages.
- Split instrumentation registration from otel registration to be able to move as the first registration in the app. So it correctly instrument the logger.
- Pass Instrumentation instances to `otelRegister` method
-  Added all @opentelemetry packages as external services as they show webpack warnings since they are not webpack friendly.
- Tried reusing a variable that has `process.env.NEXT_RUNTIME === 'nodejs'` but it wasn't working correctly as it seems like NextJs depend on it for code static analysis.

**Testing**
Tested logging in production builds:
<img width="2634" height="242" alt="Screenshot 2025-08-06 at 17 22 47" src="https://github.com/user-attachments/assets/a5b17cbd-075b-4caa-9553-9c774ae3fbdf" />
