### PR TITLE
Show zero heartbeatTimeout as not set

### DIFF
--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -26,10 +26,11 @@ const workflowHistoryEventDetailsConfig = [
       return (
         value === 0 &&
         new RegExp(
-          'retryPolicy.(maximumAttempts|expirationIntervalInSeconds)$'
+          '(heartbeatTimeoutSeconds|retryPolicy.(maximumAttempts|expirationIntervalInSeconds))$'
         ).test(path)
       );
     },
+    getLabel: ({ key }) => key.replace(/InSeconds|Seconds|$/, ''), // remove seconds suffix from label as formatted duration can be minutes/hours etc.
     valueComponent: () =>
       createElement(WorkflowHistoryEventDetailsPlaceholderText),
   },
@@ -57,9 +58,9 @@ const workflowHistoryEventDetailsConfig = [
     forceWrap: true,
   },
   {
-    name: 'Duration timeout & backoff seconds',
-    pathRegex: '(TimeoutSeconds|BackoffSeconds)$',
-    getLabel: ({ key }) => key.replace(/Seconds$/, ''), // remove seconds suffix from label as formatted duration can be minutes/hours etc.
+    name: 'Duration & interval seconds',
+    pathRegex: '(TimeoutSeconds|BackoffSeconds|InSeconds)$',
+    getLabel: ({ key }) => key.replace(/InSeconds|Seconds|$/, ''), // remove seconds suffix from label as formatted duration can be minutes/hours etc.
     valueComponent: ({ entryValue }) =>
       formatDuration({ seconds: entryValue > 0 ? entryValue : 0, nanos: 0 }),
   },


### PR DESCRIPTION
**Summary**
Showing timeout as 0 is confusing since this just means that timeout is not configured while it can be understood that value is set to 0.

**Changes**
- added `heartbeatTimeoutSeconds` to Not set placeholders
- Add `getLabel` to remove `Seconds` Postfix to match the label shown in cases were value is not 0.
- Also noticed that fields ending with `InSeconds` are not formatted, so added them to matchers

**Screenshots**
Before:
<img width="572" height="490" alt="Screenshot 2025-08-07 at 16 59 33" src="https://github.com/user-attachments/assets/b4159717-b323-4fee-8409-214ebd200dbb" />


After:
<img width="658" height="416" alt="Screenshot 2025-08-07 at 16 50 05" src="https://github.com/user-attachments/assets/e60f38b5-d657-4239-80d4-a6fd09de230e" />

