### PR TITLE
Fix args inference for resolvers

### DIFF
--- a/src/utils/config/__tests__/config.types.tst.ts
+++ b/src/utils/config/__tests__/config.types.tst.ts
@@ -6,6 +6,8 @@ import type {
   ConfigEnvDefinition,
   PublicConfigsDefinitions,
   InferLoadedConfig,
+  ArgsOfLoadedConfigsResolvers,
+  ArgsOfConfigsResolvers,
 } from '../config.types.js';
 
 describe('ConfigEnvDefinition', () => {
@@ -261,6 +263,36 @@ describe('InferLoadedConfig', () => {
       DATABASE_URL: string;
       API_URL: string;
       API_PORT: number;
+    }>();
+  });
+});
+
+describe('ArgsOfLoadedConfigsResolvers', () => {
+  it('should have the type of the args of the loaded configs resolvers', () => {
+    type ArgsType = ArgsOfConfigsResolvers<
+      InferLoadedConfig<{
+        DATABASE_URL: ConfigEnvDefinition;
+        API_URL: ConfigSyncResolverDefinition<undefined, string, 'request'>;
+        API_URL_WITH_ARGS: ConfigAsyncResolverDefinition<
+          string,
+          string,
+          'request'
+        >;
+        API_PORT: ConfigAsyncResolverDefinition<undefined, number, 'request'>;
+        API_PORT_WITH_ARGS: ConfigAsyncResolverDefinition<
+          number,
+          number,
+          'request'
+        >;
+      }>
+    >;
+
+    expect<ArgsType>().type.toBe<{
+      DATABASE_URL: undefined;
+      API_URL: undefined;
+      API_URL_WITH_ARGS: string;
+      API_PORT: undefined;
+      API_PORT_WITH_ARGS: number;
     }>();
   });
 });

--- a/src/utils/config/__tests__/config.types.tst.ts
+++ b/src/utils/config/__tests__/config.types.tst.ts
@@ -246,8 +246,8 @@ describe('InferLoadedConfig', () => {
       API_PORT: ConfigAsyncResolverDefinition<undefined, number, 'request'>;
     }>;
     expect<LoadedConfig>().type.toBe<{
-      API_URL: () => string;
-      API_PORT: () => Promise<number>;
+      API_URL: (args?: undefined) => string;
+      API_PORT: (args?: undefined) => Promise<number>;
     }>();
   });
 

--- a/src/utils/config/__tests__/config.types.tst.ts
+++ b/src/utils/config/__tests__/config.types.tst.ts
@@ -6,7 +6,6 @@ import type {
   ConfigEnvDefinition,
   PublicConfigsDefinitions,
   InferLoadedConfig,
-  ArgsOfLoadedConfigsResolvers,
   ArgsOfConfigsResolvers,
 } from '../config.types.js';
 

--- a/src/utils/config/config.types.ts
+++ b/src/utils/config/config.types.ts
@@ -5,7 +5,7 @@ import type dynamicConfigs from '@/config/dynamic/dynamic.config';
 type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
 
 type ConfigResolver<Args, ReturnType> = Args extends undefined
-  ? () => ReturnType
+  ? (args?: undefined) => ReturnType
   : (args: Args) => ReturnType;
 
 export type ConfigAsyncResolverDefinition<


### PR DESCRIPTION
**Summary**
Empty arguments for resolvers aren't infered correctly in `ArgsOfLoadedConfigsResolvers`. Since `ConfigResolver` tried to match resolver on `()=> ReturnType` Args were infered as `unknown` in `ArgsOfConfigsResolvers`.

Adding optional undefined argument to `ConfigResolver` helped with the inference

**Screenshots**
Before:
<img width="1346" height="452" alt="Screenshot 2025-08-11 at 14 30 12" src="https://github.com/user-attachments/assets/39e240f5-38aa-4977-8233-1ed2b64fd074" />
After:
<img width="1316" height="432" alt="Screenshot 2025-08-11 at 14 39 24" src="https://github.com/user-attachments/assets/5fe439e1-c275-496b-adfd-e61b3d980881" />
