### PR TITLE
Add feature flag for archival default search

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ CADENCE_CLUSTERS_NAMES=cluster0,cluster1
 
 Feature flags control various UI features and functionality in `cadence-web`. These can be configured using environment variables.
 
-| Feature | Description | Environment Variable Configuration | Minimum Cadence server Version |
-|---------|-------------|---------------------|------------------------|
-| Extended Domain Information | Enhanced domain metadata display and help menu UI | `CADENCE_EXTENDED_DOMAIN_INFO_METADATA_ENABLED=true` | N/A |
-| Workflow Diagnostics | Workflow diagnostics APIs and UI for debugging workflows | `CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED=true` | 1.2.13+ (1.3.1+ for full functionality) |
+| Feature                        | Description                                                                                                                                                             | Environment Variable Configuration                   | Minimum Cadence server Version          |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | --------------------------------------- |
+| Extended Domain Information    | Enhanced domain metadata display and help menu UI                                                                                                                       | `CADENCE_EXTENDED_DOMAIN_INFO_METADATA_ENABLED=true` | N/A                                     |
+| Workflow Diagnostics           | Workflow diagnostics APIs and UI for debugging workflows                                                                                                                | `CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED=true`          | 1.2.13+ (1.3.1+ for full functionality) |
+| Enable Default Archival Search | Shows the default workflow search input + query input for archival workflows page. Default search is disabled by default as it doesn't work well with S3 implementation | `CADENCE_ARCHIVAL_DEFAULT_SEARCH_ENABLED=true`       | N/A                                     |
+
 
 **Note:** For advanced customization, feature flags can be modified through resolvers in the dynamic config system ([`src/config/dynamic/resolvers`](src/config/dynamic/resolvers)).
 

--- a/src/config/dynamic/dynamic.config.ts
+++ b/src/config/dynamic/dynamic.config.ts
@@ -6,6 +6,7 @@ import type {
   ConfigSyncResolverDefinition,
 } from '../../utils/config/config.types';
 
+import archivalDefaultSearchEnabled from './resolvers/archival-default-search-enabled';
 import clusters from './resolvers/clusters';
 import clustersPublic from './resolvers/clusters-public';
 import { type PublicClustersConfigs } from './resolvers/clusters-public.types';
@@ -51,6 +52,12 @@ const dynamicConfigs: {
     'request',
     true
   >;
+  ARCHIVAL_DEFAULT_SEARCH_ENABLED: ConfigAsyncResolverDefinition<
+    undefined,
+    boolean,
+    'request',
+    true
+  >;
 } = {
   CADENCE_WEB_PORT: {
     env: 'CADENCE_WEB_PORT',
@@ -82,6 +89,11 @@ const dynamicConfigs: {
   },
   WORKFLOW_DIAGNOSTICS_ENABLED: {
     resolver: workflowDiagnosticsEnabled,
+    evaluateOn: 'request',
+    isPublic: true,
+  },
+  ARCHIVAL_DEFAULT_SEARCH_ENABLED: {
+    resolver: archivalDefaultSearchEnabled,
     evaluateOn: 'request',
     isPublic: true,
   },

--- a/src/config/dynamic/resolvers/archival-default-search-enabled.ts
+++ b/src/config/dynamic/resolvers/archival-default-search-enabled.ts
@@ -1,0 +1,6 @@
+export default async function archivalDefaultSearchEnabled(): Promise<boolean> {
+  const enabled =
+    process.env.CADENCE_ARCHIVAL_DEFAULT_SEARCH_ENABLED === 'true';
+
+  return enabled;
+}

--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -54,6 +54,10 @@ const resolverSchemas: ResolverSchemas = {
     args: z.undefined(),
     returnType: z.boolean(),
   },
+  ARCHIVAL_DEFAULT_SEARCH_ENABLED: {
+    args: z.undefined(),
+    returnType: z.boolean(),
+  },
 };
 
 export default resolverSchemas;

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -39,5 +39,6 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
     issues: false,
   },
   WORKFLOW_DIAGNOSTICS_ENABLED: false,
+  ARCHIVAL_DEFAULT_SEARCH_ENABLED: false,
 };
 export default mockResolvedConfigValues;


### PR DESCRIPTION
**Summary**
Add flag to enable/disable showing the default search input for archival workflows page. This won't affect the query input, so users can still write queries to filter archival workflows. This change is needed since default search supported by other pages (basic workflows list, advanced workflow list) uses querying features that is not supported by S3 (The default archival storage).

The search input can be shown by setting environment variable `CADENCE_ARCHIVAL_DEFAULT_SEARCH_ENABLED=true`. This can be useful in cases were archival storage implementation supports advanced querying tokens such as `<` `>` `<=` `>=`.