### PR TITLE
Fix missing workflow error message flicker

### DIFF
--- a/src/views/workflow-page/workflow-page-header/workflow-page-header.tsx
+++ b/src/views/workflow-page/workflow-page-header/workflow-page-header.tsx
@@ -65,9 +65,7 @@ export default function WorkflowPageHeader({
         </StyledLink>
         <div className={cls.breadcrumbItemContainer}>
           {runId}
-          <Suspense fallback={null}>
-            <WorkflowPageStatusTag />
-          </Suspense>
+          <WorkflowPageStatusTag />
         </div>
       </Breadcrumbs>
     </PageSection>

--- a/src/views/workflow-page/workflow-page-status-tag/workflow-page-status-tag.tsx
+++ b/src/views/workflow-page/workflow-page-status-tag/workflow-page-status-tag.tsx
@@ -7,7 +7,7 @@ import { useParams } from 'next/navigation';
 import WorkflowStatusTag from '@/views/shared/workflow-status-tag/workflow-status-tag';
 
 import getWorkflowStatusTagProps from '../helpers/get-workflow-status-tag-props';
-import { useSuspenseDescribeWorkflow } from '../hooks/use-describe-workflow';
+import { useDescribeWorkflow } from '../hooks/use-describe-workflow';
 import type { WorkflowPageParams } from '../workflow-page.types';
 
 export default function WorkflowPageStatusTag() {
@@ -20,11 +20,12 @@ export default function WorkflowPageStatusTag() {
     'domain'
   );
 
-  const { data: workflowDetails, isError } = useSuspenseDescribeWorkflow({
+  const { data: workflowDetails, isLoading } = useDescribeWorkflow({
     ...workflowDetailsParams,
+    throwOnError: true,
   });
 
-  if (isError) {
+  if (isLoading || !workflowDetails) {
     return null;
   }
 


### PR DESCRIPTION
**Summary**
Error message for missing workflow is flicker due to different order of failurs of the same request in differen error boundries. This is happening since some `describeWorkflow` requests are handled on server and some on client. 

By changing the usage of the `useSuspenseDescribeWorkflow` to `useDescribeWorkflow` all requests in the workflow summary page are evaluated on client which **decreases** the flicker.


**Screenshots**
Before:


https://github.com/user-attachments/assets/3ecec269-1715-4d2e-8e82-d59a8572a887



After:


https://github.com/user-attachments/assets/413b05a2-2b9c-4d78-aacb-e5e41da32358











