### PR TITLE
Show message for missing archival result

### DIFF
--- a/src/views/workflow-summary-tab/workflow-summary-tab-json-view/__tests__/workflow-summary-tab-json-view.test.tsx
+++ b/src/views/workflow-summary-tab/workflow-summary-tab-json-view/__tests__/workflow-summary-tab-json-view.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { render, fireEvent, screen } from '@/test-utils/rtl';
+import { render, fireEvent, screen, queryByRole } from '@/test-utils/rtl';
 
 import losslessJsonStringify from '@/utils/lossless-json-stringify';
 
 import WorkflowSummaryTabJsonView from '../workflow-summary-tab-json-view';
+import { type Props } from '../workflow-summary-tab-json-view.types';
 
 jest.mock('@/components/copy-text-button/copy-text-button', () =>
   jest.fn(({ textToCopy }) => <div>Copy Button: {textToCopy}</div>)
@@ -27,36 +28,15 @@ jest.mock('@/components/pretty-json-skeleton/pretty-json-skeleton', () =>
 );
 
 describe('WorkflowSummaryTabJsonView Component', () => {
-  const losslessInputJson = {
-    input: 'inputJson',
-    long: BigInt('12345678901234567890'),
-  };
-  const losselessResultJson = {
-    result: 'resultJson',
-    long: BigInt('12345678901234567891'),
-  };
-
   it('renders correctly with initial props', () => {
-    const { getByText } = render(
-      <WorkflowSummaryTabJsonView
-        inputJson={losslessInputJson}
-        resultJson={losselessResultJson}
-        isWorkflowRunning={false}
-      />
-    );
+    const { getByText } = setup({});
 
     expect(getByText('SegmentedControlRounded Mock')).toBeInTheDocument();
     expect(getByText('PrettyJson Mock')).toBeInTheDocument();
   });
 
   it('handles tab change', () => {
-    render(
-      <WorkflowSummaryTabJsonView
-        inputJson={losslessInputJson}
-        resultJson={losselessResultJson}
-        isWorkflowRunning={false}
-      />
-    );
+    setup({});
 
     // Mock the onChange event for SegmentedControlRounded
     const segmentedControl = screen.getByText('SegmentedControlRounded Mock');
@@ -65,13 +45,7 @@ describe('WorkflowSummaryTabJsonView Component', () => {
   });
 
   it('renders loading state correctly', () => {
-    const { getByText } = render(
-      <WorkflowSummaryTabJsonView
-        inputJson={losslessInputJson}
-        resultJson={losselessResultJson}
-        isWorkflowRunning={true}
-      />
-    );
+    const { getByText } = setup({ isWorkflowRunning: true });
 
     // Mock the onChange event for SegmentedControlRounded
     const segmentedControl = screen.getByText('SegmentedControlRounded Mock');
@@ -80,17 +54,76 @@ describe('WorkflowSummaryTabJsonView Component', () => {
   });
 
   it('renders copy text button and pass the correct text', () => {
-    const { getByText } = render(
-      <WorkflowSummaryTabJsonView
-        inputJson={losslessInputJson}
-        resultJson={losselessResultJson}
-        isWorkflowRunning={true}
-      />
-    );
+    const { getByText } = setup({ isWorkflowRunning: true });
     const copyButton = getByText(/Copy Button/);
     expect(copyButton).toBeInTheDocument();
     expect(copyButton.innerHTML).toMatch(
       losslessJsonStringify(losslessInputJson, null, '\t')
     );
   });
+
+  it('renders archived result correctly', () => {
+    const { getByText, getByRole } = setup({ isArchived: true });
+    const segmentedControl = getByText('SegmentedControlRounded Mock');
+    fireEvent.click(segmentedControl);
+    expect(
+      getByText('Workflow is archived, result is only available through')
+    ).toBeInTheDocument();
+    expect(getByRole('link', { name: 'history' })).toBeInTheDocument();
+  });
+
+  it('should not render  loading skeleton when isArchived is true and isWorkflowRunning is true', () => {
+    const { queryByText, getByText } = setup({
+      isArchived: true,
+      isWorkflowRunning: true,
+    });
+    const segmentedControl = getByText('SegmentedControlRounded Mock');
+    fireEvent.click(segmentedControl);
+    expect(queryByText('Mock JSON skeleton')).not.toBeInTheDocument();
+    expect(
+      queryByText('Workflow is archived, result is only available through')
+    ).toBeInTheDocument();
+  });
+
+  it('should not render result when isArchived is true and isWorkflowRunning is false', () => {
+    const { queryByText, getByText } = setup({
+      isArchived: true,
+      isWorkflowRunning: false,
+    });
+    const segmentedControl = getByText('SegmentedControlRounded Mock');
+    fireEvent.click(segmentedControl);
+    expect(queryByText('PrettyJson Mock')).not.toBeInTheDocument();
+    expect(
+      queryByText('Workflow is archived, result is only available through')
+    ).toBeInTheDocument();
+  });
 });
+
+const losslessInputJson = {
+  input: 'inputJson',
+  long: BigInt('12345678901234567890'),
+};
+const losselessResultJson = {
+  result: 'resultJson',
+  long: BigInt('12345678901234567891'),
+};
+
+const setup = ({
+  inputJson = losslessInputJson,
+  resultJson = losselessResultJson,
+  isWorkflowRunning = false,
+  isArchived = false,
+}: Partial<Props>) => {
+  return render(
+    <WorkflowSummaryTabJsonView
+      inputJson={inputJson}
+      resultJson={resultJson}
+      isWorkflowRunning={isWorkflowRunning}
+      isArchived={isArchived}
+      domain="test-domain"
+      cluster="test-cluster"
+      runId="test-run-id"
+      workflowId="test-workflow-id"
+    />
+  );
+};

--- a/src/views/workflow-summary-tab/workflow-summary-tab-json-view/workflow-summary-tab-json-view.styles.ts
+++ b/src/views/workflow-summary-tab/workflow-summary-tab-json-view/workflow-summary-tab-json-view.styles.ts
@@ -17,6 +17,12 @@ const cssStylesObj = {
     gap: theme.sizing.scale600,
     marginBottom: theme.sizing.scale700,
   }),
+  archivedResult: (theme) => ({
+    padding: theme.sizing.scale600,
+    color: theme.colors.contentTertiary,
+    textAlign: 'center',
+    ...theme.typography.ParagraphSmall,
+  }),
 } satisfies StyletronCSSObject;
 
 export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =

--- a/src/views/workflow-summary-tab/workflow-summary-tab-json-view/workflow-summary-tab-json-view.tsx
+++ b/src/views/workflow-summary-tab/workflow-summary-tab-json-view/workflow-summary-tab-json-view.tsx
@@ -2,6 +2,7 @@
 import React, { useMemo, useState } from 'react';
 
 import CopyTextButton from '@/components/copy-text-button/copy-text-button';
+import Link from '@/components/link/link';
 import PrettyJson from '@/components/pretty-json/pretty-json';
 import { type PrettyJsonValue } from '@/components/pretty-json/pretty-json.types';
 import PrettyJsonSkeleton from '@/components/pretty-json-skeleton/pretty-json-skeleton';
@@ -17,6 +18,11 @@ export default function WorkflowSummaryTabJsonView({
   inputJson,
   resultJson,
   isWorkflowRunning,
+  isArchived,
+  domain,
+  cluster,
+  runId,
+  workflowId,
 }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
   const jsonMap: Record<string, PrettyJsonValue> = useMemo(
@@ -47,10 +53,24 @@ export default function WorkflowSummaryTabJsonView({
           overrides={overrides.copyButton}
         />
       </div>
-      {activeTab === 'result' && isWorkflowRunning ? (
-        <PrettyJsonSkeleton width="200px" />
-      ) : (
-        <PrettyJson json={jsonMap[activeTab]} />
+      {activeTab === 'input' && <PrettyJson json={jsonMap[activeTab]} />}
+      {activeTab === 'result' && isArchived && (
+        <>
+          <div className={cls.archivedResult}>
+            Workflow is archived, result is only available through{' '}
+            <Link
+              href={`/domains/${domain}/${cluster}/workflows/${workflowId}/${runId}/history`}
+            >
+              history
+            </Link>
+          </div>
+        </>
+      )}
+      {activeTab === 'result' && !isArchived && (
+        <>
+          {isWorkflowRunning && <PrettyJsonSkeleton width="200px" />}
+          {!isWorkflowRunning && <PrettyJson json={jsonMap[activeTab]} />}
+        </>
       )}
     </div>
   );

--- a/src/views/workflow-summary-tab/workflow-summary-tab-json-view/workflow-summary-tab-json-view.types.ts
+++ b/src/views/workflow-summary-tab/workflow-summary-tab-json-view/workflow-summary-tab-json-view.types.ts
@@ -4,4 +4,9 @@ export type Props = {
   inputJson: PrettyJsonValue;
   resultJson: PrettyJsonValue;
   isWorkflowRunning: boolean;
+  isArchived: boolean;
+  domain: string;
+  cluster: string;
+  runId: string;
+  workflowId: string;
 };

--- a/src/views/workflow-summary-tab/workflow-summary-tab.tsx
+++ b/src/views/workflow-summary-tab/workflow-summary-tab.tsx
@@ -66,6 +66,7 @@ export default function WorkflowSummaryTab({
   const historyEvents = workflowHistory?.history?.events || [];
   const firstEvent = historyEvents[0];
   const closeEvent = workflowDetails.workflowExecutionInfo?.closeEvent || null;
+  const isArchived = workflowDetails.workflowExecutionInfo?.isArchived || false;
   const formattedWorkflowHistory = formatWorkflowHistory(workflowHistory);
   const formattedStartEvent = formattedWorkflowHistory?.history
     ?.events?.[0] as FormattedHistoryEventForType<'WorkflowExecutionStarted'>;
@@ -107,6 +108,11 @@ export default function WorkflowSummaryTab({
             }
             resultJson={resultJson}
             isWorkflowRunning={isWorkflowRunning}
+            isArchived={isArchived}
+            domain={params.domain}
+            cluster={params.cluster}
+            runId={params.runId}
+            workflowId={params.workflowId}
           />
         </div>
       </div>


### PR DESCRIPTION
**Summary**
Close event is not available in the response of `describeWorkflow` for archival events. This makes result tab keeps showing loading. Instead we need to show users a message indicating that result won't be available in summary page for archival workflows


**Screenshots**