### PR TITLE
Add summary fields to history group event metadata

### DIFF
--- a/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
+++ b/src/views/workflow-history/helpers/__tests__/get-common-history-group-fields.test.ts
@@ -131,14 +131,14 @@ describe('getCommonHistoryGroupFields', () => {
     }
   );
 
-  it('should include negativeFields when eventStatusToNegativeFieldsMap is provided', () => {
-    const eventStatusToNegativeFieldsMap = {
+  it('should include negativeFields when eventToNegativeFieldsMap is provided', () => {
+    const eventToNegativeFieldsMap = {
       timerStartedEventAttributes: ['startReason', 'startDetails'],
       timerFiredEventAttributes: ['fireReason', 'fireDetails'],
     };
 
     const group = setup({
-      eventStatusToNegativeFieldsMap,
+      eventToNegativeFieldsMap,
     });
 
     expect(group.eventsMetadata[0].negativeFields).toEqual([
@@ -151,7 +151,7 @@ describe('getCommonHistoryGroupFields', () => {
     ]);
   });
 
-  it('should not include negativeFields when eventStatusToNegativeFieldsMap is not provided', () => {
+  it('should not include negativeFields when eventToNegativeFieldsMap is not provided', () => {
     const group = setup({});
 
     group.eventsMetadata.forEach((metadata) => {
@@ -159,9 +159,9 @@ describe('getCommonHistoryGroupFields', () => {
     });
   });
 
-  it('should not include negativeFields when eventStatusToNegativeFieldsMap is empty', () => {
+  it('should not include negativeFields when eventToNegativeFieldsMap is empty', () => {
     const group = setup({
-      eventStatusToNegativeFieldsMap: {},
+      eventToNegativeFieldsMap: {},
     });
 
     group.eventsMetadata.forEach((metadata) => {
@@ -170,15 +170,86 @@ describe('getCommonHistoryGroupFields', () => {
   });
 
   it('should only include negativeFields for events that have mappings', () => {
-    const eventStatusToNegativeFieldsMap = {
+    const eventToNegativeFieldsMap = {
       timerStartedEventAttributes: ['startReason'],
     };
 
     const group = setup({
-      eventStatusToNegativeFieldsMap,
+      eventToNegativeFieldsMap,
     });
 
     expect(group.eventsMetadata[0].negativeFields).toEqual(['startReason']);
+    expect(group.eventsMetadata[1].negativeFields).toBeUndefined();
+  });
+
+  it('should include summaryFields when eventToSummaryFieldsMap is provided', () => {
+    const eventToSummaryFieldsMap = {
+      timerStartedEventAttributes: ['startReason', 'startDetails'],
+      timerFiredEventAttributes: ['fireReason', 'fireDetails'],
+    };
+
+    const group = setup({
+      eventToSummaryFieldsMap,
+    });
+
+    expect(group.eventsMetadata[0].summaryFields).toEqual([
+      'startReason',
+      'startDetails',
+    ]);
+    expect(group.eventsMetadata[1].summaryFields).toEqual([
+      'fireReason',
+      'fireDetails',
+    ]);
+  });
+
+  it('should not include summaryFields when eventToSummaryFieldsMap is not provided', () => {
+    const group = setup({});
+
+    group.eventsMetadata.forEach((metadata) => {
+      expect(metadata.summaryFields).toBeUndefined();
+    });
+  });
+
+  it('should not include summaryFields when eventToSummaryFieldsMap is empty', () => {
+    const group = setup({
+      eventToSummaryFieldsMap: {},
+    });
+
+    group.eventsMetadata.forEach((metadata) => {
+      expect(metadata.summaryFields).toBeUndefined();
+    });
+  });
+
+  it('should only include summaryFields for events that have mappings', () => {
+    const eventToSummaryFieldsMap = {
+      timerStartedEventAttributes: ['startReason'],
+    };
+
+    const group = setup({
+      eventToSummaryFieldsMap,
+    });
+
+    expect(group.eventsMetadata[0].summaryFields).toEqual(['startReason']);
+    expect(group.eventsMetadata[1].summaryFields).toBeUndefined();
+  });
+
+  it('should include both negativeFields and summaryFields when both maps are provided', () => {
+    const eventToNegativeFieldsMap = {
+      timerStartedEventAttributes: ['startReason'],
+    };
+    const eventToSummaryFieldsMap = {
+      timerStartedEventAttributes: ['startDetails'],
+      timerFiredEventAttributes: ['fireDetails'],
+    };
+
+    const group = setup({
+      eventToNegativeFieldsMap,
+      eventToSummaryFieldsMap,
+    });
+
+    expect(group.eventsMetadata[0].negativeFields).toEqual(['startReason']);
+    expect(group.eventsMetadata[0].summaryFields).toEqual(['startDetails']);
+    expect(group.eventsMetadata[1].summaryFields).toEqual(['fireDetails']);
     expect(group.eventsMetadata[1].negativeFields).toBeUndefined();
   });
 
@@ -195,7 +266,8 @@ function setup({
   eventToLabel,
   eventToStatus,
   closeEvent,
-  eventStatusToNegativeFieldsMap,
+  eventToNegativeFieldsMap,
+  eventToSummaryFieldsMap,
 }: {
   events?: TimerHistoryEvent[];
   eventToStatus?: HistoryGroupEventToStatusMap<TimerHistoryGroup>;
@@ -204,7 +276,8 @@ function setup({
     HistoryGroupEventToStringMap<TimerHistoryGroup>
   >;
   closeEvent?: TimerHistoryEvent;
-  eventStatusToNegativeFieldsMap?: any;
+  eventToNegativeFieldsMap?: any;
+  eventToSummaryFieldsMap?: any;
 }) {
   const mockEvents: TimerHistoryEvent[] = events || [
     startTimerTaskEvent,
@@ -229,6 +302,8 @@ function setup({
     mockedEventToLabel,
     eventToTimeLabelPrefixMap,
     closeEvent,
-    eventStatusToNegativeFieldsMap
+    eventToNegativeFieldsMap,
+    undefined,
+    eventToSummaryFieldsMap
   );
 }

--- a/src/views/workflow-history/helpers/get-common-history-group-fields.ts
+++ b/src/views/workflow-history/helpers/get-common-history-group-fields.ts
@@ -3,11 +3,12 @@ import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 
 import { type WorkflowEventStatus } from '../workflow-history-event-status-badge/workflow-history-event-status-badge.types';
 import {
-  type HistoryGroupEventStatusToNegativeFieldsMap,
+  type HistoryGroupEventToNegativeFieldsMap,
   type HistoryEventsGroup,
   type HistoryGroupEventToStatusMap,
   type HistoryGroupEventToStringMap,
   type HistoryGroupEventToAdditionalDetailsMap,
+  type HistoryGroupEventToSummaryFieldsMap,
 } from '../workflow-history.types';
 
 export default function getCommonHistoryGroupFields<
@@ -18,8 +19,9 @@ export default function getCommonHistoryGroupFields<
   eventToLabelMap: HistoryGroupEventToStringMap<GroupT>,
   eventToTimeLabelPrefixMap: Partial<HistoryGroupEventToStringMap<GroupT>>,
   closeEvent: GroupT['events'][number] | null | undefined,
-  eventStatusToNegativeFieldsMap?: HistoryGroupEventStatusToNegativeFieldsMap<GroupT>,
-  eventToAdditionalDetailsMap?: HistoryGroupEventToAdditionalDetailsMap<GroupT>
+  eventToNegativeFieldsMap?: HistoryGroupEventToNegativeFieldsMap<GroupT>,
+  eventToAdditionalDetailsMap?: HistoryGroupEventToAdditionalDetailsMap<GroupT>,
+  eventToSummaryFieldsMap?: HistoryGroupEventToSummaryFieldsMap<GroupT>
 ): Pick<
   GroupT,
   | 'eventsMetadata'
@@ -43,8 +45,9 @@ export default function getCommonHistoryGroupFields<
       ? eventToTimeLabelPrefixMap[attrs]
       : `${eventToLabelMap[attrs]} at`;
 
-    const negativeFields = eventStatusToNegativeFieldsMap?.[attrs];
+    const negativeFields = eventToNegativeFieldsMap?.[attrs];
     const additionalDetails = eventToAdditionalDetailsMap?.[attrs];
+    const summaryFields = eventToSummaryFieldsMap?.[attrs];
 
     return {
       label: eventToLabelMap[attrs],
@@ -53,6 +56,7 @@ export default function getCommonHistoryGroupFields<
       timeLabel: timeMs ? `${prefix} ${formatDate(timeMs)}` : '',
       ...(negativeFields?.length ? { negativeFields } : {}),
       ...(additionalDetails ? { additionalDetails } : {}),
+      ...(summaryFields?.length ? { summaryFields } : {}),
     };
   });
 

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -388,6 +388,50 @@ describe('getActivityGroupFromEvents', () => {
     });
   });
 
+  it('should include summaryFields for activity events', () => {
+    const events: ExtendedActivityHistoryEvent[] = [
+      scheduleActivityTaskEvent,
+      startActivityTaskEvent,
+      completeActivityTaskEvent,
+    ];
+    const group = getActivityGroupFromEvents(events);
+
+    // The scheduled event should have summaryFields
+    const scheduledEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Scheduled'
+    );
+    expect(scheduledEventMetadata?.summaryFields).toEqual([
+      'input',
+      'scheduleToCloseTimeoutSeconds',
+    ]);
+
+    // The started event should also have summaryFields
+    const startedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Started'
+    );
+    expect(startedEventMetadata?.summaryFields).toEqual([
+      'lastHeartbeatTime',
+      'heartbeatDetails',
+    ]);
+
+    // The completed event should also have summaryFields
+    const completedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Completed'
+    );
+    expect(completedEventMetadata?.summaryFields).toEqual(['result']);
+  });
+
+  it('should include summaryFields for failed activity events', () => {
+    const events: ExtendedActivityHistoryEvent[] = [failedActivityTaskEvent];
+    const group = getActivityGroupFromEvents(events);
+
+    // The failed event should have summaryFields
+    const failedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.status === 'FAILED'
+    );
+    expect(failedEventMetadata?.summaryFields).toEqual(['details', 'reason']);
+  });
+
   it('should include heartbeat details in additionalDetails when pending activity start event is present', () => {
     const events: ExtendedActivityHistoryEvent[] = [
       scheduleActivityTaskEvent,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -277,4 +277,44 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
       expect(metadata.negativeFields).toBeUndefined();
     });
   });
+
+  it('should include summaryFields for child workflow events', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      startChildWorkflowEvent,
+      completeChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+
+    // The initiated event should have summaryFields
+    const initiatedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Initiated'
+    );
+    expect(initiatedEventMetadata?.summaryFields).toEqual(['input']);
+
+    // The started event should also have summaryFields
+    const startedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Started'
+    );
+    expect(startedEventMetadata?.summaryFields).toEqual(['workflowExecution']);
+
+    // The completed event should also have summaryFields
+    const completedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Completed'
+    );
+    expect(completedEventMetadata?.summaryFields).toEqual(['result']);
+  });
+
+  it('should include summaryFields for failed child workflow event', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      failChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+
+    // The failed event should have summaryFields
+    const failedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.status === 'FAILED'
+    );
+    expect(failedEventMetadata?.summaryFields).toEqual(['details', 'reason']);
+  });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-decision-group-from-events.test.ts
@@ -355,4 +355,29 @@ describe('getDecisionGroupFromEvents', () => {
       expect(metadata.negativeFields).toBeUndefined();
     });
   });
+
+  it('should include summaryFields for scheduled decision events', () => {
+    const events: ExtendedDecisionHistoryEvent[] = [
+      scheduleDecisionTaskEvent,
+      startDecisionTaskEvent,
+      completeDecisionTaskEvent,
+    ];
+    const group = getDecisionGroupFromEvents(events);
+
+    // The scheduled event should have summaryFields
+    const scheduledEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Scheduled'
+    );
+    expect(scheduledEventMetadata?.summaryFields).toEqual([
+      'startToCloseTimeoutSeconds',
+    ]);
+
+    // Other events should not have summaryFields
+    const otherEventsMetadata = group.eventsMetadata.filter(
+      (metadata) => metadata.label !== 'Scheduled'
+    );
+    otherEventsMetadata.forEach((metadata) => {
+      expect(metadata.summaryFields).toBeUndefined();
+    });
+  });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -137,4 +137,29 @@ describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
       ]);
     expect(groupWithMissingCloseEvent.closeTimeMs).toEqual(null);
   });
+
+  it('should include summaryFields for initiated signal external workflow events', () => {
+    const events: SignalExternalWorkflowExecutionHistoryEvent[] = [
+      initiateSignalExternalWorkflowEvent,
+      signalExternalWorkflowEvent,
+    ];
+    const group = getSignalExternalWorkflowExecutionGroupFromEvents(events);
+
+    // The initiated event should have summaryFields
+    const initiatedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Initiated'
+    );
+    expect(initiatedEventMetadata?.summaryFields).toEqual([
+      'input',
+      'signalName',
+    ]);
+
+    // Other events should not have summaryFields
+    const otherEventsMetadata = group.eventsMetadata.filter(
+      (metadata) => metadata.label !== 'Initiated'
+    );
+    otherEventsMetadata.forEach((metadata) => {
+      expect(metadata.summaryFields).toBeUndefined();
+    });
+  });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -169,4 +169,57 @@ describe('getSingleEventGroupFromEvents', () => {
       'failureReason',
     ]);
   });
+
+  it('should include summaryFields for started workflow execution events', () => {
+    const group = getSingleEventGroupFromEvents([startWorkflowExecutionEvent]);
+    const eventMetadata = group.eventsMetadata[0];
+
+    expect(eventMetadata.status).toBe('COMPLETED');
+    expect(eventMetadata.summaryFields).toEqual([
+      'input',
+      'executionStartToCloseTimeoutSeconds',
+    ]);
+  });
+
+  it('should include summaryFields for completed workflow execution events', () => {
+    const group = getSingleEventGroupFromEvents([
+      completeWorkflowExecutionEvent,
+    ]);
+    const eventMetadata = group.eventsMetadata[0];
+
+    expect(eventMetadata.status).toBe('COMPLETED');
+    expect(eventMetadata.summaryFields).toEqual(['result']);
+  });
+
+  it('should include summaryFields for failed workflow execution events', () => {
+    const group = getSingleEventGroupFromEvents([failWorkflowExecutionEvent]);
+    const eventMetadata = group.eventsMetadata[0];
+
+    expect(eventMetadata.status).toBe('FAILED');
+    expect(eventMetadata.summaryFields).toEqual(['details', 'reason']);
+  });
+
+  it('should include summaryFields for terminated workflow execution events', () => {
+    const group = getSingleEventGroupFromEvents([
+      terminateWorkflowExecutionEvent,
+    ]);
+    const eventMetadata = group.eventsMetadata[0];
+
+    expect(eventMetadata.status).toBe('FAILED');
+    expect(eventMetadata.summaryFields).toEqual(['details', 'reason']);
+  });
+
+  it('should include summaryFields for continued as new workflow execution events', () => {
+    const group = getSingleEventGroupFromEvents([
+      continueAsNewWorkflowExecutionEvent,
+    ]);
+    const eventMetadata = group.eventsMetadata[0];
+
+    expect(eventMetadata.status).toBe('COMPLETED');
+    expect(eventMetadata.summaryFields).toEqual([
+      'failureDetails',
+      'failureReason',
+      'newExecutionRunId',
+    ]);
+  });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -127,4 +127,28 @@ describe('getTimerGroupFromEvents', () => {
     ]);
     expect(groupWithMissingCloseEvent.closeTimeMs).toEqual(null);
   });
+
+  it('should include summaryFields for started timer events', () => {
+    const events: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      fireTimerTaskEvent,
+    ];
+    const group = getTimerGroupFromEvents(events);
+
+    // The started event should have summaryFields
+    const startedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Started'
+    );
+    expect(startedEventMetadata?.summaryFields).toEqual([
+      'startToFireTimeoutSeconds',
+    ]);
+
+    // Other events should not have summaryFields
+    const otherEventsMetadata = group.eventsMetadata.filter(
+      (metadata) => metadata.label !== 'Started'
+    );
+    otherEventsMetadata.forEach((metadata) => {
+      expect(metadata.summaryFields).toBeUndefined();
+    });
+  });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -1,9 +1,10 @@
 import type {
   ChildWorkflowExecutionHistoryEvent,
   ChildWorkflowExecutionHistoryGroup,
-  HistoryGroupEventStatusToNegativeFieldsMap,
+  HistoryGroupEventToNegativeFieldsMap,
   HistoryGroupEventToStatusMap,
   HistoryGroupEventToStringMap,
+  HistoryGroupEventToSummaryFieldsMap,
 } from '../../workflow-history.types';
 import getCommonHistoryGroupFields from '../get-common-history-group-fields';
 
@@ -74,10 +75,18 @@ export default function getChildWorkflowExecutionGroupFromEvents(
       childWorkflowExecutionTerminatedEventAttributes: 'FAILED',
     };
 
-  const eventStatusToNegativeFields: HistoryGroupEventStatusToNegativeFieldsMap<ChildWorkflowExecutionHistoryGroup> =
+  const eventToNegativeFields: HistoryGroupEventToNegativeFieldsMap<ChildWorkflowExecutionHistoryGroup> =
     {
       childWorkflowExecutionFailedEventAttributes: ['details', 'reason'],
       childWorkflowExecutionTimedOutEventAttributes: ['details', 'reason'],
+    };
+
+  const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<ChildWorkflowExecutionHistoryGroup> =
+    {
+      startChildWorkflowExecutionInitiatedEventAttributes: ['input'],
+      childWorkflowExecutionStartedEventAttributes: ['workflowExecution'],
+      childWorkflowExecutionCompletedEventAttributes: ['result'],
+      childWorkflowExecutionFailedEventAttributes: ['details', 'reason'],
     };
 
   return {
@@ -90,7 +99,9 @@ export default function getChildWorkflowExecutionGroupFromEvents(
       eventToLabel,
       {},
       closeEvent || startFailedEvent,
-      eventStatusToNegativeFields
+      eventToNegativeFields,
+      undefined,
+      eventToSummaryFields
     ),
   };
 }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-decision-group-from-events.ts
@@ -1,11 +1,10 @@
-import { type PendingDecisionInfo } from '@/__generated__/proto-ts/uber/cadence/api/v1/PendingDecisionInfo';
-
 import type {
   DecisionHistoryGroup,
   ExtendedDecisionHistoryEvent,
-  HistoryGroupEventStatusToNegativeFieldsMap,
+  HistoryGroupEventToNegativeFieldsMap,
   HistoryGroupEventToStatusMap,
   HistoryGroupEventToStringMap,
+  HistoryGroupEventToSummaryFieldsMap,
   PendingDecisionTaskStartEvent,
 } from '../../workflow-history.types';
 import getCommonHistoryGroupFields from '../get-common-history-group-fields';
@@ -116,9 +115,14 @@ export default function getDecisionGroupFromEvents(
     ? 'Started at'
     : 'Scheduled at';
 
-  const eventStatusToNegativeFields: HistoryGroupEventStatusToNegativeFieldsMap<DecisionHistoryGroup> =
+  const eventToNegativeFields: HistoryGroupEventToNegativeFieldsMap<DecisionHistoryGroup> =
     {
       decisionTaskFailedEventAttributes: ['reason', 'details'],
+    };
+
+  const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<DecisionHistoryGroup> =
+    {
+      decisionTaskScheduledEventAttributes: ['startToCloseTimeoutSeconds'],
     };
 
   return {
@@ -135,7 +139,9 @@ export default function getDecisionGroupFromEvents(
         pendingDecisionTaskStartEventAttributes: pendingStartEventTimePrefix,
       },
       closeEvent || timeoutEvent,
-      eventStatusToNegativeFields
+      eventToNegativeFields,
+      undefined,
+      eventToSummaryFields
     ),
   };
 }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
@@ -1,6 +1,7 @@
 import type {
   HistoryGroupEventToStatusMap,
   HistoryGroupEventToStringMap,
+  HistoryGroupEventToSummaryFieldsMap,
   SignalExternalWorkflowExecutionHistoryEvent,
   SignalExternalWorkflowExecutionHistoryGroup,
 } from '../../workflow-history.types';
@@ -52,6 +53,14 @@ export default function getSignalExternalWorkflowExecutionGroupFromEvents(
       externalWorkflowExecutionSignaledEventAttributes: 'COMPLETED',
     };
 
+  const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<SignalExternalWorkflowExecutionHistoryGroup> =
+    {
+      signalExternalWorkflowExecutionInitiatedEventAttributes: [
+        'input',
+        'signalName',
+      ],
+    };
+
   return {
     label,
     hasMissingEvents,
@@ -61,7 +70,10 @@ export default function getSignalExternalWorkflowExecutionGroupFromEvents(
       eventToStatus,
       eventToLabel,
       {},
-      closeEvent
+      closeEvent,
+      undefined,
+      undefined,
+      eventToSummaryFields
     ),
   };
 }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -1,7 +1,8 @@
 import type {
-  HistoryGroupEventStatusToNegativeFieldsMap,
+  HistoryGroupEventToNegativeFieldsMap,
   HistoryGroupEventToStatusMap,
   HistoryGroupEventToStringMap,
+  HistoryGroupEventToSummaryFieldsMap,
   SingleEventHistoryGroup,
   SingleHistoryEvent,
 } from '../../workflow-history.types';
@@ -80,13 +81,29 @@ export default function getSingleEventGroupFromEvents(
     workflowExecutionContinuedAsNewEventAttributes: 'COMPLETED',
   };
 
-  const eventStatusToNegativeFields: HistoryGroupEventStatusToNegativeFieldsMap<SingleEventHistoryGroup> =
+  const eventToNegativeFields: HistoryGroupEventToNegativeFieldsMap<SingleEventHistoryGroup> =
     {
       workflowExecutionFailedEventAttributes: ['details', 'reason'],
       workflowExecutionTerminatedEventAttributes: ['details', 'reason'],
       workflowExecutionContinuedAsNewEventAttributes: [
         'failureDetails',
         'failureReason',
+      ],
+    };
+
+  const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<SingleEventHistoryGroup> =
+    {
+      workflowExecutionStartedEventAttributes: [
+        'input',
+        'executionStartToCloseTimeoutSeconds',
+      ],
+      workflowExecutionCompletedEventAttributes: ['result'],
+      workflowExecutionFailedEventAttributes: ['details', 'reason'],
+      workflowExecutionTerminatedEventAttributes: ['details', 'reason'],
+      workflowExecutionContinuedAsNewEventAttributes: [
+        'failureDetails',
+        'failureReason',
+        'newExecutionRunId',
       ],
     };
 
@@ -101,7 +118,9 @@ export default function getSingleEventGroupFromEvents(
       eventToLabel,
       {},
       undefined,
-      eventStatusToNegativeFields
+      eventToNegativeFields,
+      undefined,
+      eventToSummaryFields
     ),
   };
 }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
@@ -1,6 +1,7 @@
 import type {
   HistoryGroupEventToStatusMap,
   HistoryGroupEventToStringMap,
+  HistoryGroupEventToSummaryFieldsMap,
   TimerHistoryEvent,
   TimerHistoryGroup,
 } from '../../workflow-history.types';
@@ -43,6 +44,11 @@ export default function getTimerGroupFromEvents(
     timerCanceledEventAttributes: 'CANCELED',
   };
 
+  const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<TimerHistoryGroup> =
+    {
+      timerStartedEventAttributes: ['startToFireTimeoutSeconds'],
+    };
+
   return {
     label,
     hasMissingEvents,
@@ -52,7 +58,10 @@ export default function getTimerGroupFromEvents(
       eventToStatus,
       eventToLabel,
       {},
-      closeEvent
+      closeEvent,
+      undefined,
+      undefined,
+      eventToSummaryFields
     ),
   };
 }

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -28,6 +28,7 @@ export type HistoryGroupEventMetadata = {
   timeLabel: string;
   negativeFields?: Array<string>;
   additionalDetails?: Record<string, any>;
+  summaryFields?: Array<string>;
 };
 
 export type HistoryGroupBadge = {
@@ -48,8 +49,11 @@ export type HistoryGroupEventToStatusMap<GroupT extends HistoryEventsGroup> =
 export type HistoryGroupEventToStringMap<GroupT extends HistoryEventsGroup> =
   Record<GroupT['events'][number]['attributes'], string>;
 
-// TODO: It would be nice if we could map to an explicit fieldKey type instead of a plain string
-export type HistoryGroupEventStatusToNegativeFieldsMap<
+export type HistoryGroupEventToNegativeFieldsMap<
+  GroupT extends HistoryEventsGroup,
+> = Partial<Record<GroupT['events'][number]['attributes'], Array<string>>>;
+
+export type HistoryGroupEventToSummaryFieldsMap<
   GroupT extends HistoryEventsGroup,
 > = Partial<Record<GroupT['events'][number]['attributes'], Array<string>>>;
 


### PR DESCRIPTION
## Summary
- Add new field `summaryFields` to event metadata, which mentions a list of top-level fields to highlight in an event summary
- Rename `HistoryGroupEventStatusToNegativeFieldsMap` to `HistoryGroupEventToNegativeFieldsMap`, since it is a mapping from event and not event status

## Test plan
Updated unit tests.