### PR TITLE
Correctly render active-active domains in the domain listing page

### DIFF
--- a/src/views/domains-page/domains-table-domain-name-cell/__tests__/domains-table-domain-name-cell.test.tsx
+++ b/src/views/domains-page/domains-table-domain-name-cell/__tests__/domains-table-domain-name-cell.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { render, screen } from '@/test-utils/rtl';
 
+import { mockActiveActiveDomain } from '@/views/shared/active-active/__fixtures__/active-active-domain';
+
 import { globalDomain } from '../../__fixtures__/domains';
 import DomainsTableDomainNameCell from '../domains-table-domain-name-cell';
 
@@ -9,6 +11,11 @@ jest.mock('@/views/shared/domain-status-tag/domain-status-tag', () =>
   jest.fn(({ status }: { status: string }) => (
     <div>Mock domain status: {status}</div>
   ))
+);
+
+jest.mock('@/views/shared/active-active/helpers/is-active-active-domain');
+jest.mock(
+  '@/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain'
 );
 
 describe('DomainTableClusterCell', () => {
@@ -20,6 +27,18 @@ describe('DomainTableClusterCell', () => {
       expect(clusterLink).toHaveAttribute(
         'href',
         `/domains/${globalDomain.name}/${globalDomain.activeClusterName}`
+      );
+    });
+  });
+
+  it('should render link for domain if domain is active-active using default cluster', async () => {
+    render(<DomainsTableDomainNameCell {...mockActiveActiveDomain} />);
+    const clusterLinks = await screen.findAllByRole('link');
+    clusterLinks.forEach((clusterLink) => {
+      expect(clusterLink.innerHTML).toBe(mockActiveActiveDomain.name);
+      expect(clusterLink).toHaveAttribute(
+        'href',
+        `/domains/${mockActiveActiveDomain.name}/cluster0`
       );
     });
   });

--- a/src/views/domains-page/domains-table-domain-name-cell/domains-table-domain-name-cell.tsx
+++ b/src/views/domains-page/domains-table-domain-name-cell/domains-table-domain-name-cell.tsx
@@ -7,6 +7,8 @@ import cadenceIcon from '@/assets/cadence-logo.svg';
 import Link from '@/components/link/link';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 import type { DomainData } from '@/views/domains-page/domains-page.types';
+import getDefaultClusterForActiveActiveDomain from '@/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain';
+import isActiveActiveDomain from '@/views/shared/active-active/helpers/is-active-active-domain';
 import DomainStatusTag from '@/views/shared/domain-status-tag/domain-status-tag';
 
 import { cssStyles } from './domains-table-domain-name-cell.styles';
@@ -14,12 +16,14 @@ import { cssStyles } from './domains-table-domain-name-cell.styles';
 function DomainsTableDomainNameCell(props: DomainData) {
   const { cls } = useStyletronClasses(cssStyles);
 
+  const clusterName = isActiveActiveDomain(props)
+    ? getDefaultClusterForActiveActiveDomain(props)
+    : props.activeClusterName;
+
   return (
     <div className={cls.domainNameCell}>
       <Image width={16} height={16} alt="Cadence Icon" src={cadenceIcon} />
-      <Link href={`/domains/${props.name}/${props.activeClusterName}`}>
-        {props.name}
-      </Link>
+      <Link href={`/domains/${props.name}/${clusterName}`}>{props.name}</Link>
       {props.status !== 'DOMAIN_STATUS_REGISTERED' && (
         <DomainStatusTag status={props.status} />
       )}

--- a/src/views/domains-page/helpers/__tests__/get-unique-domains.test.ts
+++ b/src/views/domains-page/helpers/__tests__/get-unique-domains.test.ts
@@ -1,6 +1,14 @@
+import { mockActiveActiveDomain } from '@/views/shared/active-active/__fixtures__/active-active-domain';
+
 import { getDomainObj } from '../../__fixtures__/domains';
 import { type DomainData } from '../../domains-page.types';
 import getUniqueDomains from '../get-unique-domains';
+
+jest.mock('@/views/shared/active-active/helpers/is-active-active-domain');
+
+jest.mock(
+  '@/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain'
+);
 
 describe('getUniqueDomains', () => {
   it('should return unique domains based on id-name-activeClusterName', () => {
@@ -62,5 +70,31 @@ describe('getUniqueDomains', () => {
         clusters: [],
       }),
     ]);
+  });
+
+  it('should handle active-active domains using their default cluster for uniqueness', () => {
+    const domains: DomainData[] = [
+      mockActiveActiveDomain,
+      getDomainObj({
+        id: mockActiveActiveDomain.id,
+        name: mockActiveActiveDomain.name,
+        activeClusterName: 'cluster0', // Same as default cluster from mock
+        clusters: [],
+      }),
+      getDomainObj({
+        id: '2',
+        name: 'Domain2',
+        activeClusterName: 'ClusterB',
+        clusters: [],
+      }),
+    ];
+
+    const uniqueDomains = getUniqueDomains(domains);
+
+    // Should return only 2 domains since the first two are duplicates
+    // (active-active domain and regular domain with same id-name-defaultCluster)
+    expect(uniqueDomains).toHaveLength(2);
+    expect(uniqueDomains).toContain(domains[0]); // mockActiveActiveDomain
+    expect(uniqueDomains).toContain(domains[2]); // Domain2
   });
 });

--- a/src/views/domains-page/helpers/get-unique-domains.ts
+++ b/src/views/domains-page/helpers/get-unique-domains.ts
@@ -1,12 +1,18 @@
+import getDefaultClusterForActiveActiveDomain from '@/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain';
+import isActiveActiveDomain from '@/views/shared/active-active/helpers/is-active-active-domain';
+
 import { type DomainData } from '../domains-page.types';
 
 export default function getUniqueDomains(domains: DomainData[]) {
   const allUniqueDomains: Record<string, boolean> = {};
   return domains.filter((d: DomainData) => {
-    if (allUniqueDomains[`${d.id}-${d.name}-${d.activeClusterName}`])
-      return false;
+    const defaultCluster = isActiveActiveDomain(d)
+      ? getDefaultClusterForActiveActiveDomain(d)
+      : d.activeClusterName;
 
-    allUniqueDomains[`${d.id}-${d.name}-${d.activeClusterName}`] = true;
+    if (allUniqueDomains[`${d.id}-${d.name}-${defaultCluster}`]) return false;
+
+    allUniqueDomains[`${d.id}-${d.name}-${defaultCluster}`] = true;
     return true;
   });
 }

--- a/src/views/redirect-domain/redirect-domain.tsx
+++ b/src/views/redirect-domain/redirect-domain.tsx
@@ -1,9 +1,10 @@
 import { notFound, redirect } from 'next/navigation';
 import queryString from 'query-string';
 
+import getDefaultClusterForActiveActiveDomain from '@/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain';
+import isActiveActiveDomain from '@/views/shared/active-active/helpers/is-active-active-domain';
+
 import { getCachedAllDomains } from '../domains-page/helpers/get-all-domains';
-import getDefaultClusterForActiveActiveDomain from '../shared/active-active/helpers/get-default-cluster-for-active-active-domain';
-import isActiveActiveDomain from '../shared/active-active/helpers/is-active-active-domain';
 
 import { type Props } from './redirect-domain.types';
 

--- a/src/views/redirect-domain/redirect-domain.tsx
+++ b/src/views/redirect-domain/redirect-domain.tsx
@@ -2,6 +2,8 @@ import { notFound, redirect } from 'next/navigation';
 import queryString from 'query-string';
 
 import { getCachedAllDomains } from '../domains-page/helpers/get-all-domains';
+import getDefaultClusterForActiveActiveDomain from '../shared/active-active/helpers/get-default-cluster-for-active-active-domain';
+import isActiveActiveDomain from '../shared/active-active/helpers/is-active-active-domain';
 
 import { type Props } from './redirect-domain.types';
 
@@ -33,7 +35,11 @@ export default async function RedirectDomain(props: Props) {
     );
   }
 
-  const baseUrl = `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(domainDetails.activeClusterName)}`;
+  const clusterToRedirectTo = isActiveActiveDomain(domainDetails)
+    ? getDefaultClusterForActiveActiveDomain(domainDetails)
+    : domainDetails.activeClusterName;
+
+  const baseUrl = `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(clusterToRedirectTo)}`;
 
   redirect(
     queryString.stringifyUrl({

--- a/src/views/shared/active-active/__fixtures__/active-active-domain.ts
+++ b/src/views/shared/active-active/__fixtures__/active-active-domain.ts
@@ -1,0 +1,54 @@
+import { type ActiveActiveDomain } from '../active-active.types';
+
+export const mockActiveActiveDomain: ActiveActiveDomain = {
+  clusters: [
+    {
+      clusterName: 'cluster0',
+    },
+    {
+      clusterName: 'cluster1',
+    },
+  ],
+  data: {},
+  id: 'ac531e7e-2915-4d71-ba11-a18f11db09fd',
+  name: 'mock-domain-active-active',
+  status: 'DOMAIN_STATUS_REGISTERED',
+  description: '',
+  ownerEmail: '',
+  workflowExecutionRetentionPeriod: {
+    seconds: '86400',
+    nanos: 0,
+  },
+  badBinaries: {
+    binaries: {},
+  },
+  historyArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  historyArchivalUri: '',
+  visibilityArchivalStatus: 'ARCHIVAL_STATUS_DISABLED',
+  visibilityArchivalUri: '',
+  activeClusterName: '',
+  failoverVersion: '-24',
+  isGlobalDomain: true,
+  failoverInfo: null,
+  isolationGroups: {
+    isolationGroups: [],
+  },
+  asyncWorkflowConfig: {
+    enabled: false,
+    predefinedQueueName: '',
+    queueType: '',
+    queueConfig: null,
+  },
+  activeClusters: {
+    regionToCluster: {
+      region0: {
+        activeClusterName: 'cluster0',
+        failoverVersion: '0',
+      },
+      region1: {
+        activeClusterName: 'cluster1',
+        failoverVersion: '2',
+      },
+    },
+  },
+};

--- a/src/views/shared/active-active/active-active.types.ts
+++ b/src/views/shared/active-active/active-active.types.ts
@@ -1,0 +1,6 @@
+import { type ActiveClusters } from '@/__generated__/proto-ts/uber/cadence/api/v1/ActiveClusters';
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
+
+export type ActiveActiveDomain = Domain & {
+  activeClusters: ActiveClusters;
+};

--- a/src/views/shared/active-active/helpers/__mocks__/get-default-cluster-for-active-active-domain.ts
+++ b/src/views/shared/active-active/helpers/__mocks__/get-default-cluster-for-active-active-domain.ts
@@ -1,0 +1,8 @@
+import { type ActiveActiveDomain } from '../../active-active.types';
+
+export default function getDefaultClusterForActiveActiveDomain(
+  domain: ActiveActiveDomain
+) {
+  return Object.values(domain.activeClusters.regionToCluster)[0]
+    .activeClusterName;
+}

--- a/src/views/shared/active-active/helpers/__mocks__/is-active-active-domain.ts
+++ b/src/views/shared/active-active/helpers/__mocks__/is-active-active-domain.ts
@@ -1,0 +1,9 @@
+import { type DomainData } from '@/views/domains-page/domains-page.types';
+
+// Manual mock for isActiveActiveDomain
+export default function isActiveActiveDomain(domain: DomainData) {
+  return Boolean(
+    domain.activeClusters?.regionToCluster &&
+      Object.entries(domain.activeClusters.regionToCluster).length > 0
+  );
+}

--- a/src/views/shared/active-active/helpers/__tests__/get-default-cluster-for-active-active-domain.test.ts
+++ b/src/views/shared/active-active/helpers/__tests__/get-default-cluster-for-active-active-domain.test.ts
@@ -1,0 +1,46 @@
+import { mockActiveActiveDomain } from '../../__fixtures__/active-active-domain';
+import getDefaultClusterForActiveActiveDomain from '../get-default-cluster-for-active-active-domain';
+
+describe(getDefaultClusterForActiveActiveDomain.name, () => {
+  it('should return the lexicographically smallest cluster name when multiple clusters exist', () => {
+    const domain = {
+      ...mockActiveActiveDomain,
+      activeClusters: {
+        regionToCluster: {
+          region0: {
+            activeClusterName: 'cluster2',
+            failoverVersion: '0',
+          },
+          region1: {
+            activeClusterName: 'cluster1',
+            failoverVersion: '2',
+          },
+          region2: {
+            activeClusterName: 'cluster3',
+            failoverVersion: '1',
+          },
+        },
+      },
+    };
+
+    const result = getDefaultClusterForActiveActiveDomain(domain);
+    expect(result).toBe('cluster1');
+  });
+
+  it('should return the only cluster name when only one cluster exists', () => {
+    const domain = {
+      ...mockActiveActiveDomain,
+      activeClusters: {
+        regionToCluster: {
+          region0: {
+            activeClusterName: 'single-cluster',
+            failoverVersion: '0',
+          },
+        },
+      },
+    };
+
+    const result = getDefaultClusterForActiveActiveDomain(domain);
+    expect(result).toBe('single-cluster');
+  });
+});

--- a/src/views/shared/active-active/helpers/__tests__/is-active-active-domain.test.ts
+++ b/src/views/shared/active-active/helpers/__tests__/is-active-active-domain.test.ts
@@ -1,0 +1,74 @@
+import { getDomainObj } from '@/views/domains-page/__fixtures__/domains';
+
+import { mockActiveActiveDomain } from '../../__fixtures__/active-active-domain';
+import isActiveActiveDomain from '../is-active-active-domain';
+
+const regularDomain = getDomainObj({
+  id: 'test-regular-domain-id',
+  name: 'test-regular-domain',
+  activeClusters: null,
+});
+
+const domainWithEmptyActiveClusters = getDomainObj({
+  id: 'test-empty-active-clusters-id',
+  name: 'test-empty-active-clusters',
+  activeClusters: {
+    regionToCluster: {},
+  },
+});
+
+const domainWithNullActiveClusters = getDomainObj({
+  id: 'test-null-active-clusters-id',
+  name: 'test-null-active-clusters',
+  activeClusters: null,
+});
+
+const domainWithUndefinedActiveClusters = getDomainObj({
+  id: 'test-undefined-active-clusters-id',
+  name: 'test-undefined-active-clusters',
+  activeClusters: undefined,
+});
+
+describe(isActiveActiveDomain.name, () => {
+  it('should return true for a domain with active clusters and non-empty regionToCluster', () => {
+    const result = isActiveActiveDomain(mockActiveActiveDomain);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for a domain with null activeClusters', () => {
+    const result = isActiveActiveDomain(regularDomain);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for a domain with empty regionToCluster object', () => {
+    const result = isActiveActiveDomain(domainWithEmptyActiveClusters);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for a domain with undefined activeClusters', () => {
+    const result = isActiveActiveDomain(domainWithUndefinedActiveClusters);
+    expect(result).toBe(false);
+  });
+
+  it('should return false for a domain with null activeClusters property', () => {
+    const result = isActiveActiveDomain(domainWithNullActiveClusters);
+    expect(result).toBe(false);
+  });
+
+  it('should return true for a domain with at least one region in regionToCluster', () => {
+    const domainWithSingleRegion = getDomainObj({
+      id: 'test-single-region-id',
+      name: 'test-single-region',
+      activeClusters: {
+        regionToCluster: {
+          region0: {
+            activeClusterName: 'cluster0',
+            failoverVersion: '0',
+          },
+        },
+      },
+    });
+    const result = isActiveActiveDomain(domainWithSingleRegion);
+    expect(result).toBe(true);
+  });
+});

--- a/src/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain.ts
+++ b/src/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain.ts
@@ -5,7 +5,7 @@ export default function getDefaultClusterForActiveActiveDomain(
 ): string {
   return Object.values(domain.activeClusters.regionToCluster).reduce<string>(
     (defaultClusterName, c) =>
-      c.activeClusterName < defaultClusterName
+      !defaultClusterName || c.activeClusterName < defaultClusterName
         ? c.activeClusterName
         : defaultClusterName,
     ''

--- a/src/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain.ts
+++ b/src/views/shared/active-active/helpers/get-default-cluster-for-active-active-domain.ts
@@ -1,0 +1,13 @@
+import { type ActiveActiveDomain } from '../active-active.types';
+
+export default function getDefaultClusterForActiveActiveDomain(
+  domain: ActiveActiveDomain
+): string {
+  return Object.values(domain.activeClusters.regionToCluster).reduce<string>(
+    (defaultClusterName, c) =>
+      c.activeClusterName < defaultClusterName
+        ? c.activeClusterName
+        : defaultClusterName,
+    ''
+  );
+}

--- a/src/views/shared/active-active/helpers/is-active-active-domain.ts
+++ b/src/views/shared/active-active/helpers/is-active-active-domain.ts
@@ -1,0 +1,12 @@
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
+
+import { type ActiveActiveDomain } from '../active-active.types';
+
+export default function isActiveActiveDomain(
+  domain: Domain
+): domain is ActiveActiveDomain {
+  return Boolean(
+    domain.activeClusters &&
+      Object.entries(domain.activeClusters.regionToCluster).length > 0
+  );
+}


### PR DESCRIPTION
## Summary
To support rendering active-active domains in the Cadence UI, a few changes had to be made in places that rely on activeClusterName.
### Changes
- Create types and helpers for active-active domains (one to check if domain is active-active and one to evaluate the default active cluster for an active-active domain)
- Use default active cluster in domain page redirect
- Use default active cluster in domains list

## Test plan
Updated unit tests + ran locally.
(The unit test for redirect-domain needed a minor fix to work correctly)

<img width="1728" height="1036" alt="Screenshot 2025-08-25 at 1 36 54 PM" src="https://github.com/user-attachments/assets/8db07173-95ef-4ff1-9d3a-208f9bf13848" />
