### PR TITLE
Change global/local field to Cluster Operation Mode

### DIFF
--- a/src/views/domain-page/config/domain-page-metadata-extended-table.config.ts
+++ b/src/views/domain-page/config/domain-page-metadata-extended-table.config.ts
@@ -2,6 +2,7 @@ import { createElement } from 'react';
 
 import DomainPageMetadataClusters from '../domain-page-metadata-clusters/domain-page-metadata-clusters';
 import DomainPageMetadataDescription from '../domain-page-metadata-description/domain-page-metadata-description';
+import DomainPageMetadataMode from '../domain-page-metadata-mode/domain-page-metadata-mode';
 import { type MetadataItem } from '../domain-page-metadata-table/domain-page-metadata-table.types';
 import DomainPageMetadataViewJson from '../domain-page-metadata-view-json/domain-page-metadata-view-json';
 
@@ -40,13 +41,12 @@ const domainPageMetadataExtendedTableConfig = [
       createElement(DomainPageMetadataClusters, domainDescription),
   },
   {
-    key: 'globalOrLocal',
-    label: 'Global/Local',
-    description:
-      'Whether the domain is global (operates in multiple clusters) or not',
+    key: 'mode',
+    label: 'Mode',
+    description: 'Domain operation mode in multi-cluster setup',
     kind: 'simple',
     getValue: ({ domainDescription }) =>
-      domainDescription.isGlobalDomain ? 'Global' : 'Local',
+      createElement(DomainPageMetadataMode, domainDescription),
   },
   {
     key: 'failoverVersion',

--- a/src/views/domain-page/config/domain-page-metadata-table.config.ts
+++ b/src/views/domain-page/config/domain-page-metadata-table.config.ts
@@ -1,6 +1,7 @@
 import type { ListTableItem } from '@/components/list-table/list-table.types';
 
 import DomainPageMetadataClusters from '../domain-page-metadata-clusters/domain-page-metadata-clusters';
+import DomainPageMetadataMode from '../domain-page-metadata-mode/domain-page-metadata-mode';
 import { type DomainDescription } from '../domain-page.types';
 
 const domainPageMetadataTableConfig: Array<ListTableItem<DomainDescription>> = [
@@ -21,10 +22,9 @@ const domainPageMetadataTableConfig: Array<ListTableItem<DomainDescription>> = [
     renderValue: DomainPageMetadataClusters,
   },
   {
-    key: 'globalOrLocal',
-    label: 'Global/Local',
-    renderValue: (domainDescription: DomainDescription) =>
-      domainDescription.isGlobalDomain ? 'Global' : 'Local',
+    key: 'mode',
+    label: 'Mode',
+    renderValue: DomainPageMetadataMode,
   },
   {
     key: 'failoverVersion',

--- a/src/views/domain-page/domain-page-metadata-mode/__tests__/domain-page-metadata-mode.test.tsx
+++ b/src/views/domain-page/domain-page-metadata-mode/__tests__/domain-page-metadata-mode.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import { mockActiveActiveDomain } from '@/views/shared/active-active/__fixtures__/active-active-domain';
+
+import {
+  mockDomainDescription,
+  mockDomainDescriptionSingleCluster,
+} from '../../__fixtures__/domain-description';
+import DomainPageMetadataMode from '../domain-page-metadata-mode';
+
+jest.mock('@/views/shared/active-active/helpers/is-active-active-domain');
+
+describe(DomainPageMetadataMode.name, () => {
+  it('renders Active-Active when domain is active-active', () => {
+    render(<DomainPageMetadataMode {...mockActiveActiveDomain} />);
+
+    expect(screen.getByText('Active-Active')).toBeInTheDocument();
+  });
+
+  it('renders Active-Passive when domain is global but not active-active', () => {
+    render(<DomainPageMetadataMode {...mockDomainDescription} />);
+
+    expect(screen.getByText('Active-Passive')).toBeInTheDocument();
+  });
+
+  it('renders Local when domain is not global', () => {
+    render(
+      <DomainPageMetadataMode
+        {...{
+          ...mockDomainDescriptionSingleCluster,
+          isGlobalDomain: false,
+        }}
+      />
+    );
+
+    expect(screen.getByText('Local')).toBeInTheDocument();
+  });
+});

--- a/src/views/domain-page/domain-page-metadata-mode/domain-page-metadata-mode.tsx
+++ b/src/views/domain-page/domain-page-metadata-mode/domain-page-metadata-mode.tsx
@@ -1,0 +1,17 @@
+import isActiveActiveDomain from '@/views/shared/active-active/helpers/is-active-active-domain';
+
+import { type DomainDescription } from '../domain-page.types';
+
+export default function DomainPageMetadataMode(
+  domainDescription: DomainDescription
+) {
+  if (isActiveActiveDomain(domainDescription)) {
+    return 'Active-Active';
+  }
+
+  if (domainDescription.isGlobalDomain) {
+    return 'Active-Passive';
+  }
+
+  return 'Local';
+}

--- a/src/views/redirect-domain/redirect-domain.tsx
+++ b/src/views/redirect-domain/redirect-domain.tsx
@@ -5,6 +5,8 @@ import getDefaultClusterForActiveActiveDomain from '@/views/shared/active-active
 import isActiveActiveDomain from '@/views/shared/active-active/helpers/is-active-active-domain';
 
 import { getCachedAllDomains } from '../domains-page/helpers/get-all-domains';
+import getDefaultClusterForActiveActiveDomain from '../shared/active-active/helpers/get-default-cluster-for-active-active-domain';
+import isActiveActiveDomain from '../shared/active-active/helpers/is-active-active-domain';
 
 import { type Props } from './redirect-domain.types';
 

--- a/src/views/redirect-domain/redirect-domain.tsx
+++ b/src/views/redirect-domain/redirect-domain.tsx
@@ -5,8 +5,6 @@ import getDefaultClusterForActiveActiveDomain from '@/views/shared/active-active
 import isActiveActiveDomain from '@/views/shared/active-active/helpers/is-active-active-domain';
 
 import { getCachedAllDomains } from '../domains-page/helpers/get-all-domains';
-import getDefaultClusterForActiveActiveDomain from '../shared/active-active/helpers/get-default-cluster-for-active-active-domain';
-import isActiveActiveDomain from '../shared/active-active/helpers/is-active-active-domain';
 
 import { type Props } from './redirect-domain.types';
 


### PR DESCRIPTION
## Summary
Change global/local field to Cluster Operation Mode, with three possible values: Active-Active, Active-Passive (formerly Global), and Local

## Test plan
Unit tests + ran locally.

With Extended Domain Info disabled:
<img width="586" height="602" alt="Screenshot 2025-08-26 at 11 23 57 AM" src="https://github.com/user-attachments/assets/b7226694-e7a3-4374-90be-d87f9f9eb4df" />

With Extended Domain Info enabled:
<img width="1649" height="884" alt="Screenshot 2025-08-26 at 11 24 49 AM" src="https://github.com/user-attachments/assets/21669735-c193-4cc3-8fbe-313b025480ef" />

For non active-active domains:
<img width="595" height="580" alt="Screenshot 2025-08-26 at 11 36 41 AM" src="https://github.com/user-attachments/assets/1b842a4a-ddc1-4d7d-b593-8256eaa0415e" />
<img width="601" height="615" alt="Screenshot 2025-08-26 at 11 36 53 AM" src="https://github.com/user-attachments/assets/aa67b2d5-0470-4fe7-953a-f67817f32958" />
