### PR TITLE
Revert history filters persistence changes

### DIFF
--- a/src/views/workflow-history/__tests__/workflow-history.test.tsx
+++ b/src/views/workflow-history/__tests__/workflow-history.test.tsx
@@ -24,7 +24,6 @@ import { completedActivityTaskEvents } from '../__fixtures__/workflow-history-ac
 import { completedDecisionTaskEvents } from '../__fixtures__/workflow-history-decision-events';
 import WorkflowHistory from '../workflow-history';
 import { WorkflowHistoryContext } from '../workflow-history-context-provider/workflow-history-context-provider';
-import { type WorkflowHistoryEventFilteringType } from '../workflow-history-filters-type/workflow-history-filters-type.types';
 
 jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
   jest.fn(() => [{ historySelectedEventId: '1' }, jest.fn()])
@@ -299,34 +298,6 @@ describe('WorkflowHistory', () => {
     expect(await screen.findByText('Ungrouped Table')).toBeInTheDocument();
     expect(screen.getByText('Group')).toBeInTheDocument();
   });
-
-  it('should override history event types preference when query param is set', async () => {
-    const {
-      mockSetUngroupedViewUserPreference,
-      mockSetHistoryEventTypesUserPreference,
-    } = await setup({
-      pageQueryParamsValues: {
-        historyEventTypes: ['TIMER', 'SIGNAL'],
-        ungroupedHistoryViewEnabled: false,
-      },
-      historyEventTypesPreference: ['ACTIVITY', 'DECISION'],
-    });
-
-    expect(mockSetUngroupedViewUserPreference).not.toHaveBeenCalled();
-    expect(mockSetHistoryEventTypesUserPreference).not.toHaveBeenCalled();
-  });
-
-  it('should use preference when history event types query param is undefined', async () => {
-    const { mockSetHistoryEventTypesUserPreference } = await setup({
-      pageQueryParamsValues: {
-        historyEventTypes: undefined,
-        ungroupedHistoryViewEnabled: false,
-      },
-      historyEventTypesPreference: ['TIMER', 'SIGNAL'],
-    });
-
-    expect(mockSetHistoryEventTypesUserPreference).not.toHaveBeenCalled();
-  });
 });
 
 async function setup({
@@ -338,7 +309,6 @@ async function setup({
   emptyEvents,
   withResetModal,
   ungroupedViewPreference,
-  historyEventTypesPreference,
 }: {
   error?: boolean;
   summaryError?: boolean;
@@ -350,7 +320,6 @@ async function setup({
   emptyEvents?: boolean;
   withResetModal?: boolean;
   ungroupedViewPreference?: boolean;
-  historyEventTypesPreference?: Array<WorkflowHistoryEventFilteringType>;
 }) {
   const user = userEvent.setup();
 
@@ -365,8 +334,6 @@ async function setup({
   }
 
   const mockSetUngroupedViewUserPreference = jest.fn();
-  const mockSetHistoryEventTypesUserPreference = jest.fn();
-  const mockClearHistoryEventTypesUserPreference = jest.fn();
 
   type ReqResolver = (r: GetWorkflowHistoryResponse) => void;
   let requestResolver: ReqResolver = () => {};
@@ -381,11 +348,6 @@ async function setup({
         value={{
           ungroupedViewUserPreference: ungroupedViewPreference ?? null,
           setUngroupedViewUserPreference: mockSetUngroupedViewUserPreference,
-          historyEventTypesUserPreference: historyEventTypesPreference ?? null,
-          setHistoryEventTypesUserPreference:
-            mockSetHistoryEventTypesUserPreference,
-          clearHistoryEventTypesUserPreference:
-            mockClearHistoryEventTypesUserPreference,
         }}
       >
         <WorkflowHistory
@@ -490,7 +452,5 @@ async function setup({
     ...renderResult,
     mockSetQueryParams,
     mockSetUngroupedViewUserPreference,
-    mockSetHistoryEventTypesUserPreference,
-    mockClearHistoryEventTypesUserPreference,
   };
 }

--- a/src/views/workflow-history/config/workflow-history-user-preferences.config.ts
+++ b/src/views/workflow-history/config/workflow-history-user-preferences.config.ts
@@ -1,8 +1,5 @@
-import { isArray } from 'lodash';
 import { z } from 'zod';
 
-import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES } from '../workflow-history-filters-type/workflow-history-filters-type.constants';
-import { type WorkflowHistoryEventFilteringType } from '../workflow-history-filters-type/workflow-history-filters-type.types';
 import { type WorkflowHistoryUserPreferenceConfig } from '../workflow-history.types';
 
 const workflowHistoryUserPreferencesConfig = {
@@ -12,27 +9,6 @@ const workflowHistoryUserPreferencesConfig = {
       .string()
       .refine((val) => val === 'true' || val === 'false')
       .transform((val) => val === 'true'),
-  },
-  historyEventTypes: {
-    key: 'history-event-types',
-    schema: z
-      .string()
-      .transform((arg) => {
-        try {
-          return JSON.parse(arg);
-        } catch {
-          return null;
-        }
-      })
-      .refine(
-        (val) =>
-          isArray(val) &&
-          val.every(
-            (item): item is WorkflowHistoryEventFilteringType =>
-              WORKFLOW_HISTORY_EVENT_FILTERING_TYPES.find((v) => v === item) !==
-              undefined
-          )
-      ),
   },
 } as const satisfies Record<string, WorkflowHistoryUserPreferenceConfig<any>>;
 

--- a/src/views/workflow-history/workflow-history-context-provider/__tests__/workflow-history-context-provider.test.tsx
+++ b/src/views/workflow-history/workflow-history-context-provider/__tests__/workflow-history-context-provider.test.tsx
@@ -18,26 +18,11 @@ const TestConsumer = () => {
           ? 'null'
           : String(context.ungroupedViewUserPreference)}
       </div>
-      <div data-testid="event-types-preference">
-        {context.historyEventTypesUserPreference === null
-          ? 'null'
-          : context.historyEventTypesUserPreference.join(',')}
-      </div>
       <button onClick={() => context.setUngroupedViewUserPreference(true)}>
         Set Ungrouped True
       </button>
       <button onClick={() => context.setUngroupedViewUserPreference(false)}>
         Set Ungrouped False
-      </button>
-      <button
-        onClick={() =>
-          context.setHistoryEventTypesUserPreference(['TIMER', 'SIGNAL'])
-        }
-      >
-        Set Event Types
-      </button>
-      <button onClick={() => context.clearHistoryEventTypesUserPreference()}>
-        Clear Event Types
       </button>
     </div>
   );
@@ -58,10 +43,6 @@ describe(WorkflowHistoryContextProvider.name, () => {
     const { mockGetLocalStorageValue } = setup({
       localStorageValues: {
         [workflowHistoryUserPreferencesConfig.ungroupedViewEnabled.key]: true,
-        [workflowHistoryUserPreferencesConfig.historyEventTypes.key]: [
-          'TIMER',
-          'SIGNAL',
-        ],
       },
     });
 
@@ -69,16 +50,9 @@ describe(WorkflowHistoryContextProvider.name, () => {
       workflowHistoryUserPreferencesConfig.ungroupedViewEnabled.key,
       workflowHistoryUserPreferencesConfig.ungroupedViewEnabled.schema
     );
-    expect(mockGetLocalStorageValue).toHaveBeenCalledWith(
-      workflowHistoryUserPreferencesConfig.historyEventTypes.key,
-      workflowHistoryUserPreferencesConfig.historyEventTypes.schema
-    );
 
     expect(screen.getByTestId('ungrouped-preference')).toHaveTextContent(
       'true'
-    );
-    expect(screen.getByTestId('event-types-preference')).toHaveTextContent(
-      'TIMER,SIGNAL'
     );
   });
 
@@ -89,15 +63,8 @@ describe(WorkflowHistoryContextProvider.name, () => {
       workflowHistoryUserPreferencesConfig.ungroupedViewEnabled.key,
       workflowHistoryUserPreferencesConfig.ungroupedViewEnabled.schema
     );
-    expect(mockGetLocalStorageValue).toHaveBeenCalledWith(
-      workflowHistoryUserPreferencesConfig.historyEventTypes.key,
-      workflowHistoryUserPreferencesConfig.historyEventTypes.schema
-    );
 
     expect(screen.getByTestId('ungrouped-preference')).toHaveTextContent(
-      'null'
-    );
-    expect(screen.getByTestId('event-types-preference')).toHaveTextContent(
       'null'
     );
   });
@@ -125,46 +92,6 @@ describe(WorkflowHistoryContextProvider.name, () => {
     );
     expect(screen.getByTestId('ungrouped-preference')).toHaveTextContent(
       'false'
-    );
-  });
-
-  it('should update history event types preference and localStorage', () => {
-    const { mockSetLocalStorageValue } = setup();
-
-    const setEventTypesButton = screen.getByText('Set Event Types');
-    fireEvent.click(setEventTypesButton);
-
-    expect(mockSetLocalStorageValue).toHaveBeenCalledWith(
-      workflowHistoryUserPreferencesConfig.historyEventTypes.key,
-      JSON.stringify(['TIMER', 'SIGNAL'])
-    );
-    expect(screen.getByTestId('event-types-preference')).toHaveTextContent(
-      'TIMER,SIGNAL'
-    );
-  });
-
-  it('should clear history event types preference and localStorage', () => {
-    const { mockClearLocalStorageValue } = setup({
-      localStorageValues: {
-        [workflowHistoryUserPreferencesConfig.historyEventTypes.key]: [
-          'TIMER',
-          'SIGNAL',
-        ],
-      },
-    });
-
-    expect(screen.getByTestId('event-types-preference')).toHaveTextContent(
-      'TIMER,SIGNAL'
-    );
-
-    const clearButton = screen.getByText('Clear Event Types');
-    fireEvent.click(clearButton);
-
-    expect(mockClearLocalStorageValue).toHaveBeenCalledWith(
-      workflowHistoryUserPreferencesConfig.historyEventTypes.key
-    );
-    expect(screen.getByTestId('event-types-preference')).toHaveTextContent(
-      'null'
     );
   });
 

--- a/src/views/workflow-history/workflow-history-context-provider/workflow-history-context-provider.tsx
+++ b/src/views/workflow-history/workflow-history-context-provider/workflow-history-context-provider.tsx
@@ -28,14 +28,6 @@ export default function WorkflowHistoryContextProvider({
     )
   );
 
-  const [historyEventTypesPreference, setHistoryEventTypesPreference] =
-    useState(() =>
-      getLocalStorageValue(
-        workflowHistoryUserPreferencesConfig.historyEventTypes.key,
-        workflowHistoryUserPreferencesConfig.historyEventTypes.schema
-      )
-    );
-
   const setUngroupedViewUserPreference = useCallback(
     (isUngroupedHistoryViewEnabled: boolean) => {
       setLocalStorageValue(
@@ -47,32 +39,11 @@ export default function WorkflowHistoryContextProvider({
     []
   );
 
-  const setHistoryEventTypesUserPreference = useCallback(
-    (historyEventTypes: Array<WorkflowHistoryEventFilteringType>) => {
-      setLocalStorageValue(
-        workflowHistoryUserPreferencesConfig.historyEventTypes.key,
-        JSON.stringify(historyEventTypes)
-      );
-      setHistoryEventTypesPreference(historyEventTypes);
-    },
-    []
-  );
-
-  const clearHistoryEventTypesUserPreference = useCallback(() => {
-    clearLocalStorageValue(
-      workflowHistoryUserPreferencesConfig.historyEventTypes.key
-    );
-    setHistoryEventTypesPreference(null);
-  }, []);
-
   return (
     <WorkflowHistoryContext.Provider
       value={{
         ungroupedViewUserPreference: ungroupedViewPreference,
         setUngroupedViewUserPreference,
-        historyEventTypesUserPreference: historyEventTypesPreference,
-        setHistoryEventTypesUserPreference,
-        clearHistoryEventTypesUserPreference,
       }}
     >
       {children}

--- a/src/views/workflow-history/workflow-history-context-provider/workflow-history-context-provider.types.ts
+++ b/src/views/workflow-history/workflow-history-context-provider/workflow-history-context-provider.types.ts
@@ -3,9 +3,4 @@ import { type WorkflowHistoryEventFilteringType } from '../workflow-history-filt
 export type WorkflowHistoryContextType = {
   ungroupedViewUserPreference: boolean | null;
   setUngroupedViewUserPreference: (v: boolean) => void;
-  historyEventTypesUserPreference: Array<WorkflowHistoryEventFilteringType> | null;
-  setHistoryEventTypesUserPreference: (
-    v: Array<WorkflowHistoryEventFilteringType>
-  ) => void;
-  clearHistoryEventTypesUserPreference: () => void;
 };

--- a/src/views/workflow-history/workflow-history-filters-type/__tests__/workflow-history-filters-type.test.tsx
+++ b/src/views/workflow-history/workflow-history-filters-type/__tests__/workflow-history-filters-type.test.tsx
@@ -39,123 +39,35 @@ describe('WorkflowHistoryFiltersType', () => {
       fireEvent.click(decisionOption);
     });
     expect(mockSetValue).toHaveBeenCalledWith({
-      historyEventTypes: [
-        'ACTIVITY',
-        'CHILDWORKFLOW',
-        'SIGNAL',
-        'TIMER',
-        'WORKFLOW',
-        'DECISION',
-      ],
+      historyEventTypes: ['DECISION'],
     });
   });
 
-  it('should override preference when query param is set', () => {
-    const { mockSetHistoryEventTypesUserPreference } = setup({
+  it('calls the setQueryParams function when the filter is cleared', () => {
+    const { mockSetValue } = setup({
       overrides: {
-        historyEventTypes: ['TIMER', 'SIGNAL'],
+        historyEventTypes: ['ACTIVITY'],
       },
     });
-
-    expect(screen.getByText('Timer')).toBeInTheDocument();
-    expect(screen.getByText('Signal')).toBeInTheDocument();
-    expect(screen.queryByText('Activity')).toBeNull();
-    expect(screen.queryByText('Decision')).toBeNull();
-
-    expect(mockSetHistoryEventTypesUserPreference).not.toHaveBeenCalled();
-  });
-
-  it('should use preference when query param is undefined', () => {
-    const { mockSetHistoryEventTypesUserPreference } = setup({
-      historyEventTypesPreference: ['TIMER', 'SIGNAL'],
-    });
-
-    expect(screen.getByText('Timer')).toBeInTheDocument();
-    expect(screen.getByText('Signal')).toBeInTheDocument();
-    expect(screen.queryByText('Activity')).toBeNull();
-    expect(screen.queryByText('Decision')).toBeNull();
-
-    expect(mockSetHistoryEventTypesUserPreference).not.toHaveBeenCalled();
-  });
-
-  it('should use default values when both query param and preference are undefined', () => {
-    const { mockSetHistoryEventTypesUserPreference } = setup({});
-
-    expect(screen.getByText('Activity')).toBeInTheDocument();
-    expect(screen.getByText('Timer')).toBeInTheDocument();
-    expect(screen.getByText('Signal')).toBeInTheDocument();
-    expect(screen.getByText('Child Workflow')).toBeInTheDocument();
-    expect(screen.getByText('Workflow')).toBeInTheDocument();
-
-    expect(screen.queryByText('Decision')).toBeNull();
-
-    expect(mockSetHistoryEventTypesUserPreference).not.toHaveBeenCalled();
-  });
-
-  it('should save preference when user changes selection', () => {
-    const { mockSetValue, mockSetHistoryEventTypesUserPreference } = setup({
-      overrides: {
-        historyEventTypes: ['TIMER'],
-      },
-    });
-
-    const selectFilter = screen.getByRole('combobox');
+    const clearButton = screen.getByLabelText('Clear all');
     act(() => {
-      fireEvent.click(selectFilter);
+      fireEvent.click(clearButton);
     });
-
-    const activityOption = screen.getByText('Activity');
-    act(() => {
-      fireEvent.click(activityOption);
-    });
-
-    expect(mockSetValue).toHaveBeenCalledWith({
-      historyEventTypes: ['TIMER', 'ACTIVITY'],
-    });
-
-    expect(mockSetHistoryEventTypesUserPreference).toHaveBeenCalledWith([
-      'TIMER',
-      'ACTIVITY',
-    ]);
+    expect(mockSetValue).toHaveBeenCalledWith({ historyEventTypes: undefined });
   });
 });
 
-function setup({
-  overrides,
-  historyEventTypesPreference,
-}: {
-  overrides?: WorkflowHistoryFiltersTypeValue;
-  historyEventTypesPreference?:
-    | Array<WorkflowHistoryEventFilteringType>
-    | undefined;
-}) {
+function setup({ overrides }: { overrides?: WorkflowHistoryFiltersTypeValue }) {
   const mockSetValue = jest.fn();
-  const mockSetHistoryEventTypesUserPreference = jest.fn();
-
-  const renderResult = render(
-    <WorkflowHistoryContext.Provider
+  render(
+    <WorkflowHistoryFiltersType
       value={{
-        ungroupedViewUserPreference: null,
-        setUngroupedViewUserPreference: jest.fn(),
-        historyEventTypesUserPreference: historyEventTypesPreference ?? null,
-        setHistoryEventTypesUserPreference:
-          mockSetHistoryEventTypesUserPreference,
-        clearHistoryEventTypesUserPreference: jest.fn(),
+        historyEventTypes: undefined,
+        ...overrides,
       }}
-    >
-      <WorkflowHistoryFiltersType
-        value={{
-          historyEventTypes: undefined,
-          ...overrides,
-        }}
-        setValue={mockSetValue}
-      />
-    </WorkflowHistoryContext.Provider>
+      setValue={mockSetValue}
+    />
   );
 
-  return {
-    mockSetValue,
-    mockSetHistoryEventTypesUserPreference,
-    ...renderResult,
-  };
+  return { mockSetValue };
 }

--- a/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants.ts
+++ b/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.constants.ts
@@ -5,9 +5,6 @@ import { type WorkflowHistoryEventFilteringType } from './workflow-history-filte
 export const WORKFLOW_HISTORY_EVENT_FILTERING_TYPES: WorkflowHistoryEventFilteringType[] =
   ['ACTIVITY', 'CHILDWORKFLOW', 'DECISION', 'SIGNAL', 'TIMER', 'WORKFLOW'];
 
-export const DEFAULT_EVENT_FILTERING_TYPES: WorkflowHistoryEventFilteringType[] =
-  ['ACTIVITY', 'CHILDWORKFLOW', 'SIGNAL', 'TIMER', 'WORKFLOW'];
-
 export const WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_LABEL_MAP = {
   DECISION: 'Decision',
   ACTIVITY: 'Activity',

--- a/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.tsx
+++ b/src/views/workflow-history/workflow-history-filters-type/workflow-history-filters-type.tsx
@@ -1,17 +1,12 @@
 'use client';
-import React, { useContext, useMemo } from 'react';
+import React from 'react';
 
 import { FormControl } from 'baseui/form-control';
 import { Select, SIZE } from 'baseui/select';
 
 import { type PageFilterComponentProps } from '@/components/page-filters/page-filters.types';
 
-import { WorkflowHistoryContext } from '../workflow-history-context-provider/workflow-history-context-provider';
-
-import {
-  DEFAULT_EVENT_FILTERING_TYPES,
-  WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_LABEL_MAP,
-} from './workflow-history-filters-type.constants';
+import { WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_LABEL_MAP } from './workflow-history-filters-type.constants';
 import { overrides } from './workflow-history-filters-type.styles';
 import {
   type WorkflowHistoryEventFilteringType,
@@ -22,19 +17,8 @@ export default function WorkflowHistoryFiltersType({
   value,
   setValue,
 }: PageFilterComponentProps<WorkflowHistoryFiltersTypeValue>) {
-  const {
-    historyEventTypesUserPreference,
-    setHistoryEventTypesUserPreference,
-  } = useContext(WorkflowHistoryContext);
-
-  const historyEventTypes = useMemo(() => {
-    if (value.historyEventTypes !== undefined) return value.historyEventTypes;
-
-    return historyEventTypesUserPreference ?? DEFAULT_EVENT_FILTERING_TYPES;
-  }, [value.historyEventTypes, historyEventTypesUserPreference]);
-
   const typeOptionsValue =
-    historyEventTypes.map((type: WorkflowHistoryEventFilteringType) => ({
+    value.historyEventTypes?.map((type) => ({
       id: type,
       label: WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_LABEL_MAP[type],
     })) ?? [];
@@ -43,28 +27,21 @@ export default function WorkflowHistoryFiltersType({
     <FormControl label="Type" overrides={overrides.selectFormControl}>
       <Select
         multi
-        clearable={false}
         size={SIZE.compact}
         value={typeOptionsValue}
         options={Object.entries(
           WORKFLOW_HISTORY_EVENT_FILTERING_TYPES_LABEL_MAP
         ).map(([id, label]) => ({ id, label }))}
-        onChange={(params) => {
-          const newHistoryEventTypes =
-            params.value.length > 0
-              ? params.value.map(
-                  (v) => v.id as WorkflowHistoryEventFilteringType
-                )
-              : undefined;
-
+        onChange={(params) =>
           setValue({
-            historyEventTypes: newHistoryEventTypes,
-          });
-
-          if (newHistoryEventTypes) {
-            setHistoryEventTypesUserPreference(newHistoryEventTypes);
-          }
-        }}
+            historyEventTypes:
+              params.value.length > 0
+                ? params.value.map(
+                    (v) => v.id as WorkflowHistoryEventFilteringType
+                  )
+                : undefined,
+          })
+        }
         placeholder="All"
       />
     </FormControl>


### PR DESCRIPTION
**Summary**
Experience of persisting filters & hiding decision tasks by default is causing some inconvenience users:
- Manual clearing of filters
- Missing important events after navigating to another workflow because of previous filters.
- Decision tasks is needed in debugging some cases and they are not visibile by default.

**Screenshots**
<img width="3456" height="1250" alt="Screenshot 2025-08-26 at 14 09 24" src="https://github.com/user-attachments/assets/115aa441-c24b-47b1-b73c-d8bb965469d8" />
<img width="3456" height="1458" alt="Screenshot 2025-08-26 at 14 09 17" src="https://github.com/user-attachments/assets/7ffd84c4-24f2-4ddf-9eca-5d8a33af5628" />
