### PR TITLE
Added cancel/terminate cli commands

### DIFF
--- a/src/views/workflow-page/config/workflow-page-cli-commands.config.ts
+++ b/src/views/workflow-page/config/workflow-page-cli-commands.config.ts
@@ -86,6 +86,18 @@ const workflowPageCliCommandsConfig: CliCommandConfig[] = [
       'cadence workflow {list|listall} --query \'(CustomKeywordField = "keyword1" and CustomIntField >= 5) or CustomKeywordField = "keyword2" and CloseTime = missing\'',
     group: 'workflow',
   },
+  {
+    label: 'Cancel a workflow',
+    command:
+      'cadence --env {staging|prod|(others)} --proxy_region {dca|phx} --domain {domain-name} workflow cancel -w {workflow-id} -r {run-id} --reason {reason details}',
+    group: 'workflow',
+},
+{
+    label: 'Terminate a workflow',
+    command:
+      'cadence --env {staging|prod|(others)} --proxy_region {dca|phx} --domain {domain-name} workflow terminate -w {workflow-id} -r {run-id} --reason {reason details}',
+    group: 'workflow',
+},
 ];
 
 export default workflowPageCliCommandsConfig;

--- a/src/views/workflow-page/config/workflow-page-cli-commands.config.ts
+++ b/src/views/workflow-page/config/workflow-page-cli-commands.config.ts
@@ -90,14 +90,18 @@ const workflowPageCliCommandsConfig: CliCommandConfig[] = [
     label: 'Cancel a workflow',
     command:
       'cadence --env {staging|prod|(others)} --proxy_region {dca|phx} --domain {domain-name} workflow cancel -w {workflow-id} -r {run-id} --reason {reason details}',
+    description:
+      'Cancel a workflow, recording WorkflowExecutionCancelRequested event and allowing for clean up work after cancellation',
     group: 'workflow',
-},
-{
+  },
+  {
     label: 'Terminate a workflow',
     command:
       'cadence --env {staging|prod|(others)} --proxy_region {dca|phx} --domain {domain-name} workflow terminate -w {workflow-id} -r {run-id} --reason {reason details}',
+    description:
+      'Terminate a workflow immediately, recording WorkflowExecutionTerminated event as the closing event in the history',
     group: 'workflow',
-},
+  },
 ];
 
 export default workflowPageCliCommandsConfig;

--- a/src/views/workflow-page/config/workflow-page-cli-commands.config.ts
+++ b/src/views/workflow-page/config/workflow-page-cli-commands.config.ts
@@ -89,7 +89,7 @@ const workflowPageCliCommandsConfig: CliCommandConfig[] = [
   {
     label: 'Cancel a workflow',
     command:
-      'cadence --env {staging|prod|(others)} --proxy_region {dca|phx} --domain {domain-name} workflow cancel -w {workflow-id} -r {run-id} --reason {reason details}',
+      'cadence --domain {domain-name} workflow cancel -w {workflow-id} -r {run-id} --reason {reason details}',
     description:
       'Cancel a workflow, recording WorkflowExecutionCancelRequested event and allowing for clean up work after cancellation',
     group: 'workflow',
@@ -97,7 +97,7 @@ const workflowPageCliCommandsConfig: CliCommandConfig[] = [
   {
     label: 'Terminate a workflow',
     command:
-      'cadence --env {staging|prod|(others)} --proxy_region {dca|phx} --domain {domain-name} workflow terminate -w {workflow-id} -r {run-id} --reason {reason details}',
+      'cadence --domain {domain-name} workflow terminate -w {workflow-id} -r {run-id} --reason {reason details}',
     description:
       'Terminate a workflow immediately, recording WorkflowExecutionTerminated event as the closing event in the history',
     group: 'workflow',

--- a/src/views/workflow-page/workflow-page-cli-commands-modal/workflow-page-cli-commands-modal.styles.ts
+++ b/src/views/workflow-page/workflow-page-cli-commands-modal/workflow-page-cli-commands-modal.styles.ts
@@ -54,6 +54,11 @@ const cssStylesObj = {
     marginTop: theme.sizing.scale300,
     ...theme.typography.ParagraphXSmall,
   }),
+  commandsScrollContainer: (theme) => ({
+    maxHeight: '60vh',
+    overflowY: 'auto',
+    paddingRight: theme.sizing.scale300,
+  }),
 } satisfies StyletronCSSObject;
 
 export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =

--- a/src/views/workflow-page/workflow-page-cli-commands-modal/workflow-page-cli-commands-modal.tsx
+++ b/src/views/workflow-page/workflow-page-cli-commands-modal/workflow-page-cli-commands-modal.tsx
@@ -58,7 +58,7 @@ export default function WorkflowPageCliCommandsModal({
             <Tab key={name} title={title} />
           ))}
         </Tabs>
-        <div>
+        <div className={cls.commandsScrollContainer}>
           {currentTabCommands.map(({ label, command, description }) => (
             <div key={label} className={cls.rowContainer}>
               <div className={cls.rowLabel}>{label}</div>


### PR DESCRIPTION
## Summary
- Added cancel/terminate cli commands.
- Also made sure the modal stays within screen boundaries and commands are scrollable.

### Key Features Added:

1. Cancel and terminate CLI commands for workflows with short description on each command (because cancel/terminate terminology might create confusion)
2. Modal positioning fixes to prevent overflow outside screen boundaries
3. Scrollable command interface for better UX

### Screenshots

<img width="1511" height="820" alt="image" src="https://github.com/user-attachments/assets/5bd22fce-e628-4d78-90fd-43be0a2e525b" />
