### PR TITLE
Hide invalid cron overlap policy from Workflow Started event

### DIFF
--- a/src/views/workflow-history/config/workflow-history-event-details.config.ts
+++ b/src/views/workflow-history/config/workflow-history-event-details.config.ts
@@ -21,6 +21,11 @@ const workflowHistoryEventDetailsConfig = [
     hide: () => true,
   },
   {
+    name: 'Filter invalid/unset CronOverlapPolicy',
+    path: 'cronOverlapPolicy',
+    hide: ({ value }) => !value || value === 'CRON_OVERLAP_POLICY_INVALID',
+  },
+  {
     name: 'Not set placeholder',
     customMatcher: ({ value, path }) => {
       return (


### PR DESCRIPTION
## Summary
Hide Invalid CronOverlapPolicy from Workflow Started event in history.

## Test plan
Ran locally.

Hidden:

Shown:
<img width="1633" height="1021" alt="Screenshot 2025-09-02 at 11 24 38 AM" src="https://github.com/user-attachments/assets/bb905806-110b-4112-8620-8ee3ea7f49ad" />
