### PR TITLE
Add waitTimerInfo field to Workflow History Group

### DIFF
--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -234,11 +234,8 @@ describe('getSingleEventGroupFromEvents', () => {
   it('should calculate expectedEndTimeInfo for workflow execution started events with firstDecisionTaskBackoff', () => {
     const group = getSingleEventGroupFromEvents([startWorkflowExecutionEvent]);
 
-    // eventTime: seconds: '1724747315', nanos: 549377718 = 1724747315549 ms
-    // firstDecisionTaskBackoff: seconds: '55', nanos: 0 = 55000 ms
-    // Expected calculation: 1724747315549 + 55000 = 1724747370549 ms
     expect(group.expectedEndTimeInfo).toEqual({
-      timeMs: 1724747370549,
+      timeMs: 1724747370549.3777,
       prefix: 'Starts in',
     });
   });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -231,15 +231,18 @@ describe('getSingleEventGroupFromEvents', () => {
     ]);
   });
 
-  it('should calculate expectedDurationMs for workflow execution started events with firstDecisionTaskBackoff', () => {
+  it('should calculate waitTimerInfo for workflow execution started events with firstDecisionTaskBackoff', () => {
     const group = getSingleEventGroupFromEvents([startWorkflowExecutionEvent]);
 
     // firstDecisionTaskBackoff has seconds: '55', nanos: 0
     // Expected calculation: 55 * 1000 + 0 / 1000000 = 55000 ms
-    expect(group.expectedDurationMs).toBe(55000);
+    expect(group.waitTimerInfo).toEqual({
+      timeMs: 55000,
+      prefix: 'Starts in',
+    });
   });
 
-  it('should not calculate expectedDurationMs for non-workflow-started events', () => {
+  it('should not calculate waitTimerInfo for non-workflow-started events', () => {
     const nonStartedEvents = [
       signalWorkflowExecutionEvent,
       recordMarkerExecutionEvent,
@@ -249,11 +252,11 @@ describe('getSingleEventGroupFromEvents', () => {
 
     for (const event of nonStartedEvents) {
       const group = getSingleEventGroupFromEvents([event]);
-      expect(group.expectedDurationMs).toBeUndefined();
+      expect(group.waitTimerInfo).toBeUndefined();
     }
   });
 
-  it('should not calculate expectedDurationMs for workflow started events with zero firstDecisionTaskBackoff', () => {
+  it('should not calculate waitTimerInfo for workflow started events with zero firstDecisionTaskBackoff', () => {
     const eventWithoutBackoff = {
       ...startWorkflowExecutionEvent,
       workflowExecutionStartedEventAttributes: {
@@ -266,10 +269,10 @@ describe('getSingleEventGroupFromEvents', () => {
     };
 
     const group = getSingleEventGroupFromEvents([eventWithoutBackoff]);
-    expect(group.expectedDurationMs).toBeUndefined();
+    expect(group.waitTimerInfo).toBeUndefined();
   });
 
-  it('should not calculate expectedDurationMs for workflow started events without firstDecisionTaskBackoff', () => {
+  it('should not calculate waitTimerInfo for workflow started events without firstDecisionTaskBackoff', () => {
     const eventWithoutBackoff = {
       ...startWorkflowExecutionEvent,
       workflowExecutionStartedEventAttributes: {
@@ -279,6 +282,6 @@ describe('getSingleEventGroupFromEvents', () => {
     };
 
     const group = getSingleEventGroupFromEvents([eventWithoutBackoff]);
-    expect(group.expectedDurationMs).toBeUndefined();
+    expect(group.waitTimerInfo).toBeUndefined();
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -231,18 +231,19 @@ describe('getSingleEventGroupFromEvents', () => {
     ]);
   });
 
-  it('should calculate waitTimerInfo for workflow execution started events with firstDecisionTaskBackoff', () => {
+  it('should calculate expectedEndTimeInfo for workflow execution started events with firstDecisionTaskBackoff', () => {
     const group = getSingleEventGroupFromEvents([startWorkflowExecutionEvent]);
 
-    // firstDecisionTaskBackoff has seconds: '55', nanos: 0
-    // Expected calculation: 55 * 1000 + 0 / 1000000 = 55000 ms
-    expect(group.waitTimerInfo).toEqual({
-      timeMs: 55000,
+    // eventTime: seconds: '1724747315', nanos: 549377718 = 1724747315549 ms
+    // firstDecisionTaskBackoff: seconds: '55', nanos: 0 = 55000 ms
+    // Expected calculation: 1724747315549 + 55000 = 1724747370549 ms
+    expect(group.expectedEndTimeInfo).toEqual({
+      timeMs: 1724747370549,
       prefix: 'Starts in',
     });
   });
 
-  it('should not calculate waitTimerInfo for non-workflow-started events', () => {
+  it('should not calculate expectedEndTimeInfo for non-workflow-started events', () => {
     const nonStartedEvents = [
       signalWorkflowExecutionEvent,
       recordMarkerExecutionEvent,
@@ -252,11 +253,11 @@ describe('getSingleEventGroupFromEvents', () => {
 
     for (const event of nonStartedEvents) {
       const group = getSingleEventGroupFromEvents([event]);
-      expect(group.waitTimerInfo).toBeUndefined();
+      expect(group.expectedEndTimeInfo).toBeUndefined();
     }
   });
 
-  it('should not calculate waitTimerInfo for workflow started events with zero firstDecisionTaskBackoff', () => {
+  it('should not calculate expectedEndTimeInfo for workflow started events with zero firstDecisionTaskBackoff', () => {
     const eventWithoutBackoff = {
       ...startWorkflowExecutionEvent,
       workflowExecutionStartedEventAttributes: {
@@ -269,10 +270,10 @@ describe('getSingleEventGroupFromEvents', () => {
     };
 
     const group = getSingleEventGroupFromEvents([eventWithoutBackoff]);
-    expect(group.waitTimerInfo).toBeUndefined();
+    expect(group.expectedEndTimeInfo).toBeUndefined();
   });
 
-  it('should not calculate waitTimerInfo for workflow started events without firstDecisionTaskBackoff', () => {
+  it('should not calculate expectedEndTimeInfo for workflow started events without firstDecisionTaskBackoff', () => {
     const eventWithoutBackoff = {
       ...startWorkflowExecutionEvent,
       workflowExecutionStartedEventAttributes: {
@@ -282,6 +283,6 @@ describe('getSingleEventGroupFromEvents', () => {
     };
 
     const group = getSingleEventGroupFromEvents([eventWithoutBackoff]);
-    expect(group.waitTimerInfo).toBeUndefined();
+    expect(group.expectedEndTimeInfo).toBeUndefined();
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -230,4 +230,39 @@ describe('getSingleEventGroupFromEvents', () => {
       'newExecutionRunId',
     ]);
   });
+
+  it('should calculate expectedDurationMs for workflow execution started events with firstDecisionTaskBackoff', () => {
+    const group = getSingleEventGroupFromEvents([startWorkflowExecutionEvent]);
+
+    // firstDecisionTaskBackoff has seconds: '55', nanos: 0
+    // Expected calculation: 55 * 1000 + 0 / 1000000 = 55000 ms
+    expect(group.expectedDurationMs).toBe(55000);
+  });
+
+  it('should not calculate expectedDurationMs for non-workflow-started events', () => {
+    const nonStartedEvents = [
+      signalWorkflowExecutionEvent,
+      recordMarkerExecutionEvent,
+      failWorkflowExecutionEvent,
+      completeWorkflowExecutionEvent,
+    ];
+
+    for (const event of nonStartedEvents) {
+      const group = getSingleEventGroupFromEvents([event]);
+      expect(group.expectedDurationMs).toBeUndefined();
+    }
+  });
+
+  it('should not calculate expectedDurationMs for workflow started events without firstDecisionTaskBackoff', () => {
+    const eventWithoutBackoff = {
+      ...startWorkflowExecutionEvent,
+      workflowExecutionStartedEventAttributes: {
+        ...startWorkflowExecutionEvent.workflowExecutionStartedEventAttributes,
+        firstDecisionTaskBackoff: null,
+      },
+    };
+
+    const group = getSingleEventGroupFromEvents([eventWithoutBackoff]);
+    expect(group.expectedDurationMs).toBeUndefined();
+  });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -253,6 +253,22 @@ describe('getSingleEventGroupFromEvents', () => {
     }
   });
 
+  it('should not calculate expectedDurationMs for workflow started events with zero firstDecisionTaskBackoff', () => {
+    const eventWithoutBackoff = {
+      ...startWorkflowExecutionEvent,
+      workflowExecutionStartedEventAttributes: {
+        ...startWorkflowExecutionEvent.workflowExecutionStartedEventAttributes,
+        firstDecisionTaskBackoff: {
+          seconds: '0',
+          nanos: 0,
+        },
+      },
+    };
+
+    const group = getSingleEventGroupFromEvents([eventWithoutBackoff]);
+    expect(group.expectedDurationMs).toBeUndefined();
+  });
+
   it('should not calculate expectedDurationMs for workflow started events without firstDecisionTaskBackoff', () => {
     const eventWithoutBackoff = {
       ...startWorkflowExecutionEvent,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -146,35 +146,38 @@ describe('getTimerGroupFromEvents', () => {
     expect(otherEventMetadata.summaryFields).toBeUndefined();
   });
 
-  it('should calculate expectedDurationMs for started timer events without close event', () => {
+  it('should calculate waitTimerInfo for started timer events without close event', () => {
     const eventsWithoutClose: TimerHistoryEvent[] = [startTimerTaskEvent];
     const group = getTimerGroupFromEvents(eventsWithoutClose);
 
     // startToFireTimeout has seconds: '5', nanos: 0
     // Expected calculation: 5 * 1000 + 0 / 1000000 = 5000 ms
-    expect(group.expectedDurationMs).toBe(5000);
+    expect(group.waitTimerInfo).toEqual({
+      timeMs: 5000,
+      prefix: 'Fires in',
+    });
   });
 
-  it('should not calculate expectedDurationMs for timer events with close event', () => {
+  it('should not calculate waitTimerInfo for timer events with close event', () => {
     const eventsWithClose: TimerHistoryEvent[] = [
       startTimerTaskEvent,
       fireTimerTaskEvent,
     ];
     const group = getTimerGroupFromEvents(eventsWithClose);
 
-    // Should not calculate expectedDurationMs when there's a close event
-    expect(group.expectedDurationMs).toBeUndefined();
+    // Should not calculate waitTimerInfo when there's a close event
+    expect(group.waitTimerInfo).toBeUndefined();
   });
 
-  it('should not calculate expectedDurationMs for timer events without started event', () => {
+  it('should not calculate waitTimerInfo for timer events without started event', () => {
     const eventsWithoutStart: TimerHistoryEvent[] = [fireTimerTaskEvent];
     const group = getTimerGroupFromEvents(eventsWithoutStart);
 
-    // Should not calculate expectedDurationMs when there's no started event
-    expect(group.expectedDurationMs).toBeUndefined();
+    // Should not calculate waitTimerInfo when there's no started event
+    expect(group.waitTimerInfo).toBeUndefined();
   });
 
-  it('should not calculate expectedDurationMs for started timer events without startToFireTimeout', () => {
+  it('should not calculate waitTimerInfo for started timer events without startToFireTimeout', () => {
     const eventWithoutTimeout = {
       ...startTimerTaskEvent,
       timerStartedEventAttributes: {
@@ -184,6 +187,6 @@ describe('getTimerGroupFromEvents', () => {
     };
 
     const group = getTimerGroupFromEvents([eventWithoutTimeout]);
-    expect(group.expectedDurationMs).toBeUndefined();
+    expect(group.waitTimerInfo).toBeUndefined();
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -136,19 +136,54 @@ describe('getTimerGroupFromEvents', () => {
     const group = getTimerGroupFromEvents(events);
 
     // The started event should have summaryFields
-    const startedEventMetadata = group.eventsMetadata.find(
-      (metadata) => metadata.label === 'Started'
-    );
-    expect(startedEventMetadata?.summaryFields).toEqual([
+    const startedEventMetadata = group.eventsMetadata[0];
+    expect(startedEventMetadata.summaryFields).toEqual([
       'startToFireTimeoutSeconds',
     ]);
 
     // Other events should not have summaryFields
-    const otherEventsMetadata = group.eventsMetadata.filter(
-      (metadata) => metadata.label !== 'Started'
-    );
-    otherEventsMetadata.forEach((metadata) => {
-      expect(metadata.summaryFields).toBeUndefined();
-    });
+    const otherEventMetadata = group.eventsMetadata[1];
+    expect(otherEventMetadata.summaryFields).toBeUndefined();
+  });
+
+  it('should calculate expectedDurationMs for started timer events without close event', () => {
+    const eventsWithoutClose: TimerHistoryEvent[] = [startTimerTaskEvent];
+    const group = getTimerGroupFromEvents(eventsWithoutClose);
+
+    // startToFireTimeout has seconds: '5', nanos: 0
+    // Expected calculation: 5 * 1000 + 0 / 1000000 = 5000 ms
+    expect(group.expectedDurationMs).toBe(5000);
+  });
+
+  it('should not calculate expectedDurationMs for timer events with close event', () => {
+    const eventsWithClose: TimerHistoryEvent[] = [
+      startTimerTaskEvent,
+      fireTimerTaskEvent,
+    ];
+    const group = getTimerGroupFromEvents(eventsWithClose);
+
+    // Should not calculate expectedDurationMs when there's a close event
+    expect(group.expectedDurationMs).toBeUndefined();
+  });
+
+  it('should not calculate expectedDurationMs for timer events without started event', () => {
+    const eventsWithoutStart: TimerHistoryEvent[] = [fireTimerTaskEvent];
+    const group = getTimerGroupFromEvents(eventsWithoutStart);
+
+    // Should not calculate expectedDurationMs when there's no started event
+    expect(group.expectedDurationMs).toBeUndefined();
+  });
+
+  it('should not calculate expectedDurationMs for started timer events without startToFireTimeout', () => {
+    const eventWithoutTimeout = {
+      ...startTimerTaskEvent,
+      timerStartedEventAttributes: {
+        ...startTimerTaskEvent.timerStartedEventAttributes,
+        startToFireTimeout: null,
+      },
+    };
+
+    const group = getTimerGroupFromEvents([eventWithoutTimeout]);
+    expect(group.expectedDurationMs).toBeUndefined();
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -150,11 +150,8 @@ describe('getTimerGroupFromEvents', () => {
     const eventsWithoutClose: TimerHistoryEvent[] = [startTimerTaskEvent];
     const group = getTimerGroupFromEvents(eventsWithoutClose);
 
-    // eventTime: seconds: '1725748370', nanos: 632072806 = 1725748370632 ms
-    // startToFireTimeout: seconds: '5', nanos: 0 = 5000 ms
-    // Expected calculation: 1725748370632 + 5000 = 1725748375632 ms
     expect(group.expectedEndTimeInfo).toEqual({
-      timeMs: 1725748375632,
+      timeMs: 1725748375632.0728,
       prefix: 'Fires in',
     });
   });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-timer-group-from-events.test.ts
@@ -146,38 +146,39 @@ describe('getTimerGroupFromEvents', () => {
     expect(otherEventMetadata.summaryFields).toBeUndefined();
   });
 
-  it('should calculate waitTimerInfo for started timer events without close event', () => {
+  it('should calculate expectedEndTimeInfo for started timer events without close event', () => {
     const eventsWithoutClose: TimerHistoryEvent[] = [startTimerTaskEvent];
     const group = getTimerGroupFromEvents(eventsWithoutClose);
 
-    // startToFireTimeout has seconds: '5', nanos: 0
-    // Expected calculation: 5 * 1000 + 0 / 1000000 = 5000 ms
-    expect(group.waitTimerInfo).toEqual({
-      timeMs: 5000,
+    // eventTime: seconds: '1725748370', nanos: 632072806 = 1725748370632 ms
+    // startToFireTimeout: seconds: '5', nanos: 0 = 5000 ms
+    // Expected calculation: 1725748370632 + 5000 = 1725748375632 ms
+    expect(group.expectedEndTimeInfo).toEqual({
+      timeMs: 1725748375632,
       prefix: 'Fires in',
     });
   });
 
-  it('should not calculate waitTimerInfo for timer events with close event', () => {
+  it('should not calculate expectedEndTimeInfo for timer events with close event', () => {
     const eventsWithClose: TimerHistoryEvent[] = [
       startTimerTaskEvent,
       fireTimerTaskEvent,
     ];
     const group = getTimerGroupFromEvents(eventsWithClose);
 
-    // Should not calculate waitTimerInfo when there's a close event
-    expect(group.waitTimerInfo).toBeUndefined();
+    // Should not calculate expectedEndTimeInfo when there's a close event
+    expect(group.expectedEndTimeInfo).toBeUndefined();
   });
 
-  it('should not calculate waitTimerInfo for timer events without started event', () => {
+  it('should not calculate expectedEndTimeInfo for timer events without started event', () => {
     const eventsWithoutStart: TimerHistoryEvent[] = [fireTimerTaskEvent];
     const group = getTimerGroupFromEvents(eventsWithoutStart);
 
-    // Should not calculate waitTimerInfo when there's no started event
-    expect(group.waitTimerInfo).toBeUndefined();
+    // Should not calculate expectedEndTimeInfo when there's no started event
+    expect(group.expectedEndTimeInfo).toBeUndefined();
   });
 
-  it('should not calculate waitTimerInfo for started timer events without startToFireTimeout', () => {
+  it('should not calculate expectedEndTimeInfo for started timer events without startToFireTimeout', () => {
     const eventWithoutTimeout = {
       ...startTimerTaskEvent,
       timerStartedEventAttributes: {
@@ -187,6 +188,6 @@ describe('getTimerGroupFromEvents', () => {
     };
 
     const group = getTimerGroupFromEvents([eventWithoutTimeout]);
-    expect(group.waitTimerInfo).toBeUndefined();
+    expect(group.expectedEndTimeInfo).toBeUndefined();
   });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -110,7 +110,7 @@ export default function getSingleEventGroupFromEvents(
       ],
     };
 
-  let expectedDurationMs: number | undefined = undefined;
+  let expectedDurationMs: number | undefined;
   if (
     event.attributes === 'workflowExecutionStartedEventAttributes' &&
     event.workflowExecutionStartedEventAttributes?.firstDecisionTaskBackoff

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -110,17 +110,20 @@ export default function getSingleEventGroupFromEvents(
       ],
     };
 
-  let expectedDurationMs: number | undefined;
+  let expectedFirstDecisionScheduleTimeMs: number | undefined;
   if (
+    event.eventTime &&
     event.attributes === 'workflowExecutionStartedEventAttributes' &&
     event.workflowExecutionStartedEventAttributes?.firstDecisionTaskBackoff
   ) {
-    const firstDecisionTaskBackoffMs = parseGrpcTimestamp(
-      event.workflowExecutionStartedEventAttributes.firstDecisionTaskBackoff
-    );
+    const firstDecisionTaskBackoffMs =
+      parseGrpcTimestamp(event.eventTime) +
+      parseGrpcTimestamp(
+        event.workflowExecutionStartedEventAttributes.firstDecisionTaskBackoff
+      );
 
     if (firstDecisionTaskBackoffMs > 0)
-      expectedDurationMs = firstDecisionTaskBackoffMs;
+      expectedFirstDecisionScheduleTimeMs = firstDecisionTaskBackoffMs;
   }
 
   return {
@@ -138,10 +141,10 @@ export default function getSingleEventGroupFromEvents(
       undefined,
       eventToSummaryFields
     ),
-    ...(expectedDurationMs
+    ...(expectedFirstDecisionScheduleTimeMs
       ? {
-          waitTimerInfo: {
-            timeMs: expectedDurationMs,
+          expectedEndTimeInfo: {
+            timeMs: expectedFirstDecisionScheduleTimeMs,
             prefix: 'Starts in',
           },
         }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -115,9 +115,12 @@ export default function getSingleEventGroupFromEvents(
     event.attributes === 'workflowExecutionStartedEventAttributes' &&
     event.workflowExecutionStartedEventAttributes?.firstDecisionTaskBackoff
   ) {
-    expectedDurationMs = parseGrpcTimestamp(
+    const firstDecisionTaskBackoffMs = parseGrpcTimestamp(
       event.workflowExecutionStartedEventAttributes.firstDecisionTaskBackoff
     );
+
+    if (firstDecisionTaskBackoffMs > 0)
+      expectedDurationMs = firstDecisionTaskBackoffMs;
   }
 
   return {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -1,3 +1,5 @@
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+
 import type {
   HistoryGroupEventToNegativeFieldsMap,
   HistoryGroupEventToStatusMap,
@@ -108,6 +110,16 @@ export default function getSingleEventGroupFromEvents(
       ],
     };
 
+  let expectedDurationMs: number | undefined = undefined;
+  if (
+    event.attributes === 'workflowExecutionStartedEventAttributes' &&
+    event.workflowExecutionStartedEventAttributes?.firstDecisionTaskBackoff
+  ) {
+    expectedDurationMs = parseGrpcTimestamp(
+      event.workflowExecutionStartedEventAttributes.firstDecisionTaskBackoff
+    );
+  }
+
   return {
     label,
     hasMissingEvents,
@@ -123,5 +135,6 @@ export default function getSingleEventGroupFromEvents(
       undefined,
       eventToSummaryFields
     ),
+    expectedDurationMs,
   };
 }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -116,14 +116,13 @@ export default function getSingleEventGroupFromEvents(
     event.attributes === 'workflowExecutionStartedEventAttributes' &&
     event.workflowExecutionStartedEventAttributes?.firstDecisionTaskBackoff
   ) {
-    const firstDecisionTaskBackoffMs =
-      parseGrpcTimestamp(event.eventTime) +
-      parseGrpcTimestamp(
-        event.workflowExecutionStartedEventAttributes.firstDecisionTaskBackoff
-      );
+    const firstDecisionTaskBackoffMs = parseGrpcTimestamp(
+      event.workflowExecutionStartedEventAttributes.firstDecisionTaskBackoff
+    );
 
     if (firstDecisionTaskBackoffMs > 0)
-      expectedFirstDecisionScheduleTimeMs = firstDecisionTaskBackoffMs;
+      expectedFirstDecisionScheduleTimeMs =
+        parseGrpcTimestamp(event.eventTime) + firstDecisionTaskBackoffMs;
   }
 
   return {

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -138,6 +138,13 @@ export default function getSingleEventGroupFromEvents(
       undefined,
       eventToSummaryFields
     ),
-    expectedDurationMs,
+    ...(expectedDurationMs
+      ? {
+          waitTimerInfo: {
+            timeMs: expectedDurationMs,
+            prefix: 'Starts in',
+          },
+        }
+      : {}),
   };
 }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
@@ -39,6 +39,7 @@ export default function getTimerGroupFromEvents(
     timerFiredEventAttributes: 'Fired',
     timerCanceledEventAttributes: 'Canceled',
   };
+
   const eventToStatus: HistoryGroupEventToStatusMap<TimerHistoryGroup> = {
     timerStartedEventAttributes: (_, events, index) =>
       index < events.length - 1 ? 'COMPLETED' : 'ONGOING',
@@ -51,7 +52,7 @@ export default function getTimerGroupFromEvents(
       timerStartedEventAttributes: ['startToFireTimeoutSeconds'],
     };
 
-  let expectedDurationMs: number | undefined = undefined;
+  let expectedDurationMs: number | undefined;
 
   if (
     startedEvent &&
@@ -77,6 +78,13 @@ export default function getTimerGroupFromEvents(
       undefined,
       eventToSummaryFields
     ),
-    expectedDurationMs,
+    ...(expectedDurationMs
+      ? {
+          waitTimerInfo: {
+            timeMs: expectedDurationMs,
+            prefix: 'Fires in',
+          },
+        }
+      : {}),
   };
 }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
@@ -52,16 +52,21 @@ export default function getTimerGroupFromEvents(
       timerStartedEventAttributes: ['startToFireTimeoutSeconds'],
     };
 
-  let expectedDurationMs: number | undefined;
+  let expectedTimerFireTimeMs: number | undefined;
 
   if (
     startedEvent &&
+    startedEvent.eventTime &&
     !closeEvent &&
     startedEvent.timerStartedEventAttributes?.startToFireTimeout
   ) {
-    expectedDurationMs = parseGrpcTimestamp(
+    const timeToFire = parseGrpcTimestamp(
       startedEvent.timerStartedEventAttributes.startToFireTimeout
     );
+
+    if (timeToFire > 0)
+      expectedTimerFireTimeMs =
+        parseGrpcTimestamp(startedEvent.eventTime) + timeToFire;
   }
 
   return {
@@ -78,10 +83,10 @@ export default function getTimerGroupFromEvents(
       undefined,
       eventToSummaryFields
     ),
-    ...(expectedDurationMs
+    ...(expectedTimerFireTimeMs
       ? {
-          waitTimerInfo: {
-            timeMs: expectedDurationMs,
+          expectedEndTimeInfo: {
+            timeMs: expectedTimerFireTimeMs,
             prefix: 'Fires in',
           },
         }

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-timer-group-from-events.ts
@@ -1,3 +1,5 @@
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+
 import type {
   HistoryGroupEventToStatusMap,
   HistoryGroupEventToStringMap,
@@ -49,6 +51,18 @@ export default function getTimerGroupFromEvents(
       timerStartedEventAttributes: ['startToFireTimeoutSeconds'],
     };
 
+  let expectedDurationMs: number | undefined = undefined;
+
+  if (
+    startedEvent &&
+    !closeEvent &&
+    startedEvent.timerStartedEventAttributes?.startToFireTimeout
+  ) {
+    expectedDurationMs = parseGrpcTimestamp(
+      startedEvent.timerStartedEventAttributes.startToFireTimeout
+    );
+  }
+
   return {
     label,
     hasMissingEvents,
@@ -63,5 +77,6 @@ export default function getTimerGroupFromEvents(
       undefined,
       eventToSummaryFields
     ),
+    expectedDurationMs,
   };
 }

--- a/src/views/workflow-history/workflow-history-timeline-chart/helpers/__tests__/convert-event-group-to-timeline-item.test.ts
+++ b/src/views/workflow-history/workflow-history-timeline-chart/helpers/__tests__/convert-event-group-to-timeline-item.test.ts
@@ -57,6 +57,10 @@ describe(convertEventGroupToTimelineItem.name, () => {
           ...mockTimerEventGroup,
           timeMs: null,
           status: 'ONGOING',
+          expectedEndTimeInfo: {
+            timeMs: 1725748375632,
+            prefix: 'Starts in',
+          },
         },
         index: 1,
         classes: {} as any,

--- a/src/views/workflow-history/workflow-history-timeline-chart/helpers/convert-event-group-to-timeline-item.ts
+++ b/src/views/workflow-history/workflow-history-timeline-chart/helpers/convert-event-group-to-timeline-item.ts
@@ -33,15 +33,10 @@ export default function convertEventGroupToTimelineItem({
 
   if (
     group.groupType === 'Timer' &&
-    ['ONGOING', 'WAITING'].includes(group.status)
+    ['ONGOING', 'WAITING'].includes(group.status) &&
+    group.expectedEndTimeInfo
   ) {
-    const timerDuration =
-      group.events[0].timerStartedEventAttributes?.startToFireTimeout;
-
-    if (timerDuration) {
-      const timerDurationMs = parseGrpcTimestamp(timerDuration);
-      groupEndDayjs = groupStartDayjs.add(timerDurationMs, 'milliseconds');
-    }
+    groupEndDayjs = dayjs(group.expectedEndTimeInfo.timeMs);
   } else if (
     group.timeMs &&
     ['COMPLETED', 'FAILED', 'CANCELED'].includes(group.status)

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -72,7 +72,10 @@ type BaseHistoryGroup = {
   timeMs: number | null;
   startTimeMs: number | null;
   closeTimeMs?: number | null;
-  expectedDurationMs?: number;
+  waitTimerInfo?: {
+    timeMs: number;
+    prefix: string;
+  };
   timeLabel: string;
   firstEventId: string | null;
   badges?: HistoryGroupBadge[];

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -72,7 +72,7 @@ type BaseHistoryGroup = {
   timeMs: number | null;
   startTimeMs: number | null;
   closeTimeMs?: number | null;
-  waitTimerInfo?: {
+  expectedEndTimeInfo?: {
     timeMs: number;
     prefix: string;
   };

--- a/src/views/workflow-history/workflow-history.types.ts
+++ b/src/views/workflow-history/workflow-history.types.ts
@@ -72,6 +72,7 @@ type BaseHistoryGroup = {
   timeMs: number | null;
   startTimeMs: number | null;
   closeTimeMs?: number | null;
+  expectedDurationMs?: number;
   timeLabel: string;
   firstEventId: string | null;
   badges?: HistoryGroupBadge[];


### PR DESCRIPTION
## Summary
- Add waitTimerInfo field to Workflow History Group, which contains the expected duration of a task/group in the workflow's history, and the prefix to show with it
- Populate this field for Timer and Workflow Started groups
- (misc) Use the waitTimerInfo to render timer end time in Timeline Chart

## Test plan
Unit tests + tested in https://github.com/cadence-workflow/cadence-web/pull/1036