### PR TITLE
chore: Fixed docker URI for kafka image

### DIFF
--- a/docker-compose-backend-services.yml
+++ b/docker-compose-backend-services.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: docker.io/bitnami/kafka:3.7
+    image: docker.io/bitnamilegacy/kafka:3.7
     hostname: kafka
     container_name: kafka
     ports:


### PR DESCRIPTION
The docker URI for kafka was recently broken. 

More info: https://community.broadcom.com/tanzu/blogs/beltran-rueda-borrego/2025/08/18/how-to-prepare-for-the-bitnami-changes-coming-soon

The PR applies the same fix applied to cadence repo: https://github.com/cadence-workflow/cadence/pull/7219/files

Testing:
- $ docker-compose -f docker-compose-backend-services.yml up
- npm run dev
- Open http://localhost:8088/domains
- Verify at least one domain is displayed.