### PR TITLE
feat: New Cron Tab

### DIFF
--- a/src/views/domain-cron-list/domain-cron-list.styles.ts
+++ b/src/views/domain-cron-list/domain-cron-list.styles.ts
@@ -1,8 +1,11 @@
 import { styled as createStyled, type Theme } from 'baseui';
 
 export const styled = {
-  DomainCronListContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    marginTop: $theme.sizing.scale950,
-    marginBottom: $theme.sizing.scale900,
-  })),
-}
+  DomainCronListContainer: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }) => ({
+      marginTop: $theme.sizing.scale950,
+      marginBottom: $theme.sizing.scale900,
+    })
+  ),
+};

--- a/src/views/domain-cron-list/domain-cron-list.styles.ts
+++ b/src/views/domain-cron-list/domain-cron-list.styles.ts
@@ -1,0 +1,8 @@
+import { styled as createStyled, type Theme } from 'baseui';
+
+export const styled = {
+  DomainCronListContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    marginTop: $theme.sizing.scale950,
+    marginBottom: $theme.sizing.scale900,
+  })),
+}

--- a/src/views/domain-cron-list/domain-cron-list.tsx
+++ b/src/views/domain-cron-list/domain-cron-list.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import { styled } from './domain-cron-list.styles';
+
+export default function DomainCronList() {
+  return (
+    <styled.DomainCronListContainer>
+      Cron List, Coming Soon!
+    </styled.DomainCronListContainer>
+  );
+}

--- a/src/views/domain-page/config/domain-page-tabs.config.ts
+++ b/src/views/domain-page/config/domain-page-tabs.config.ts
@@ -1,14 +1,15 @@
-import { MdArchive, MdListAlt, MdSettings, MdSort } from 'react-icons/md';
+import { MdArchive, MdListAlt, MdSettings, MdSort, MdSchedule } from 'react-icons/md';
 
 import DomainWorkflows from '@/views/domain-workflows/domain-workflows';
 import DomainWorkflowsArchival from '@/views/domain-workflows-archival/domain-workflows-archival';
 
 import DomainPageMetadata from '../domain-page-metadata/domain-page-metadata';
 import DomainPageSettings from '../domain-page-settings/domain-page-settings';
+import DomainCronList from '@/views/domain-cron-list/domain-cron-list';
 import type { DomainPageTabsConfig } from '../domain-page-tabs/domain-page-tabs.types';
 
 const domainPageTabsConfig: DomainPageTabsConfig<
-  'workflows' | 'metadata' | 'settings' | 'archival'
+  'workflows' | 'cron-list' | 'metadata' | 'settings' | 'archival'
 > = {
   workflows: {
     title: 'Workflows',
@@ -16,6 +17,15 @@ const domainPageTabsConfig: DomainPageTabsConfig<
     content: DomainWorkflows,
     getErrorConfig: () => ({
       message: 'Failed to load workflows',
+      actions: [{ kind: 'retry', label: 'Retry' }],
+    }),
+  },
+  'cron-list': {
+    title: 'Cron',
+    artwork: MdSchedule,
+    content: DomainCronList,
+    getErrorConfig: () => ({
+      message: 'Failed to load cron list',
       actions: [{ kind: 'retry', label: 'Retry' }],
     }),
   },

--- a/src/views/domain-page/config/domain-page-tabs.config.ts
+++ b/src/views/domain-page/config/domain-page-tabs.config.ts
@@ -1,11 +1,17 @@
-import { MdArchive, MdListAlt, MdSettings, MdSort, MdSchedule } from 'react-icons/md';
+import {
+  MdArchive,
+  MdListAlt,
+  MdSettings,
+  MdSort,
+  MdSchedule,
+} from 'react-icons/md';
 
+import DomainCronList from '@/views/domain-cron-list/domain-cron-list';
 import DomainWorkflows from '@/views/domain-workflows/domain-workflows';
 import DomainWorkflowsArchival from '@/views/domain-workflows-archival/domain-workflows-archival';
 
 import DomainPageMetadata from '../domain-page-metadata/domain-page-metadata';
 import DomainPageSettings from '../domain-page-settings/domain-page-settings';
-import DomainCronList from '@/views/domain-cron-list/domain-cron-list';
 import type { DomainPageTabsConfig } from '../domain-page-tabs/domain-page-tabs.types';
 
 const domainPageTabsConfig: DomainPageTabsConfig<

--- a/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
+++ b/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
@@ -4,6 +4,7 @@ import React, { useMemo } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 
 import PageTabs from '@/components/page-tabs/page-tabs';
+import useSuspenseConfigValue from '@/hooks/use-config-value/use-suspense-config-value';
 import decodeUrlParams from '@/utils/decode-url-params';
 
 import domainPageTabsConfig from '../config/domain-page-tabs.config';
@@ -12,16 +13,14 @@ import DomainPageStartWorkflowButton from '../domain-page-start-workflow-button/
 
 import { styled } from './domain-page-tabs.styles';
 import type { DomainPageTabsParams } from './domain-page-tabs.types';
-import useSuspenseConfigValue from '@/hooks/use-config-value/use-suspense-config-value';
 
 export default function DomainPageTabs() {
   const router = useRouter();
   const params = useParams<DomainPageTabsParams>();
   const decodedParams = decodeUrlParams(params) as DomainPageTabsParams;
 
-  const { data: isCronListEnabled } = useSuspenseConfigValue(
-    'CRON_LIST_ENABLED'
-  );
+  const { data: isCronListEnabled } =
+    useSuspenseConfigValue('CRON_LIST_ENABLED');
 
   const tabList = useMemo(
     () =>

--- a/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
+++ b/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
@@ -12,20 +12,33 @@ import DomainPageStartWorkflowButton from '../domain-page-start-workflow-button/
 
 import { styled } from './domain-page-tabs.styles';
 import type { DomainPageTabsParams } from './domain-page-tabs.types';
+import useSuspenseConfigValue from '@/hooks/use-config-value/use-suspense-config-value';
 
 export default function DomainPageTabs() {
   const router = useRouter();
   const params = useParams<DomainPageTabsParams>();
   const decodedParams = decodeUrlParams(params) as DomainPageTabsParams;
 
+  const { data: isCronListEnabled } = useSuspenseConfigValue(
+    'CRON_LIST_ENABLED'
+  );
+
   const tabList = useMemo(
     () =>
-      Object.entries(domainPageTabsConfig).map(([key, tabConfig]) => ({
-        key,
-        title: tabConfig.title,
-        artwork: tabConfig.artwork,
-      })),
-    []
+      Object.entries(domainPageTabsConfig)
+        .filter(([key]) => {
+          // Include cron-list tab only when the feature flag is enabled.
+          if (key === 'cron-list') {
+            return isCronListEnabled;
+          }
+          return true;
+        })
+        .map(([key, tabConfig]) => ({
+          key,
+          title: tabConfig.title,
+          artwork: tabConfig.artwork,
+        })),
+    [isCronListEnabled]
   );
 
   return (


### PR DESCRIPTION
### Feature Flag On
<img width="1174" height="649" alt="Screenshot 2025-11-12 at 2 12 50 PM" src="https://github.com/user-attachments/assets/0739e8b2-36fa-41b5-9c8f-1331287b91bb" />

### Feature Flag Off 
![ff-off](https://github.com/user-attachments/assets/31486ba1-bc19-467b-ba15-a52394967766)


# Test Plan

### Feature Flag On 
- % CRON_LIST_ENABLED=true npm run dev
- http://localhost:8088/domains/cadence-system/cluster0
- Click the "Cron" tab.
- Verify that it renders.

### Feature Flag Off 
- % CRON_LIST_ENABLED=false npm run dev
- http://localhost:8088/domains/cadence-system/cluster0
- Verify that the "Cron" tab is hidden.

