### PR TITLE
fix(lint): remove lint warning

### DIFF
--- a/src/hooks/__tests__/use-debounced-value.test.tsx
+++ b/src/hooks/__tests__/use-debounced-value.test.tsx
@@ -72,7 +72,7 @@ describe('useDebouncedValue', () => {
   });
 
   it('should cancel pending debounce on unmount', () => {
-    const { result, rerender, unmount } = renderHook(
+    const { rerender, unmount } = renderHook(
       ({ value }) => useDebouncedValue(value, DEBOUNCE_MS),
       { initialProps: { value: 'initial' } }
     );


### PR DESCRIPTION
### Summary
Remove warning for unused result variable


### Testing
Ran lint command and no more warnings are showing