### PR TITLE
fix: auto-dismiss success snackbar for signal workflow button

### DIFF
--- a/src/components/markdown/markdoc-components/signal-button/signal-button.tsx
+++ b/src/components/markdown/markdoc-components/signal-button/signal-button.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { useMutation } from '@tanstack/react-query';
 import { Button } from 'baseui/button';
-import { useSnackbar } from 'baseui/snackbar';
+import { useSnackbar, DURATION } from 'baseui/snackbar';
 
 import losslessJsonStringify from '@/utils/lossless-json-stringify';
 import request from '@/utils/request';
@@ -45,10 +45,12 @@ export default function SignalButton({
       return response.json();
     },
     onSuccess: () => {
-      enqueue({
-        message: `Successfully sent signal "${signalName}"`,
-        actionMessage: 'OK',
-      });
+      enqueue(
+        {
+          message: `Successfully sent signal "${signalName}"`,
+        },
+        DURATION.medium
+      );
     },
     onError: (error: Error) => {
       enqueue({


### PR DESCRIPTION
## Summary

Fixes #1219.

Triggering a signal from a markdoc `{% signal ... /%}` button produced a success snackbar that required a manual "OK" click to go away. Rapidly triggering multiple signals stacked these snackbars and persisted them across navigation, interrupting the user's workflow.

## Change

In `signal-button.tsx`:

- Pass `DURATION.medium` (5 seconds) as the second argument to `enqueue` so the success toast auto-hides.
- Drop the redundant `actionMessage: 'OK'` on the success toast. With auto-dismissal the only purpose of the button was to clear the toast early, and showing an "OK" action on a self-dismissing toast would be misleading.

Error toasts are left unchanged so failures still require manual acknowledgement via "Dismiss" and are not missed by the user.

Scope is limited to `SignalButton`, per the issue; the sibling `StartWorkflowButton` intentionally still uses a persistent success toast because its success action is a meaningful "View" navigation rather than dismissal.

## Validation

- `npm run lint`, `npm run typecheck`, and `npm run test` all pass locally.
- `DURATION.medium` is baseui's exported 5000 ms constant (`baseui/snackbar/constants`), matching the ~5 s requested in the issue.