### PR TITLE
feat: Persist selected Workflow List columns in local storage

### DIFF
--- a/src/views/domain-workflows-archival/domain-workflows-archival.tsx
+++ b/src/views/domain-workflows-archival/domain-workflows-archival.tsx
@@ -33,6 +33,7 @@ export default function DomainWorkflowsArchival(
     resetColumns,
   } = useWorkflowsListColumns({
     cluster: props.cluster,
+    domain: props.domain,
   });
 
   const { data: isNewWorkflowsListEnabled } = useSuspenseConfigValue(

--- a/src/views/domain-workflows/domain-workflows-advanced/domain-workflows-advanced.tsx
+++ b/src/views/domain-workflows/domain-workflows-advanced/domain-workflows-advanced.tsx
@@ -25,7 +25,7 @@ export default function DomainWorkflowsAdvanced({
     selectedColumnIds,
     setSelectedColumnIds,
     resetColumns,
-  } = useWorkflowsListColumns({ cluster });
+  } = useWorkflowsListColumns({ cluster, domain });
 
   const timeRangeParams = useMemo(() => {
     const now = dayjs();

--- a/src/views/shared/workflows-list/helpers/__tests__/get-column-ids-local-storage-key.test.ts
+++ b/src/views/shared/workflows-list/helpers/__tests__/get-column-ids-local-storage-key.test.ts
@@ -1,0 +1,7 @@
+import getColumnIdsLocalStorageKey from '../get-column-ids-local-storage-key';
+
+describe(getColumnIdsLocalStorageKey.name, () => {
+  it('returns the expected local storage key for a given domain', () => {
+    expect(getColumnIdsLocalStorageKey('my-domain')).toBe('columns_my-domain');
+  });
+});

--- a/src/views/shared/workflows-list/helpers/get-column-ids-local-storage-key.ts
+++ b/src/views/shared/workflows-list/helpers/get-column-ids-local-storage-key.ts
@@ -1,0 +1,3 @@
+export default function getColumnIdsLocalStorageKey(domain: string) {
+  return `columns_${domain}`;
+}

--- a/src/views/shared/workflows-list/helpers/get-column-ids-local-storage-key.ts
+++ b/src/views/shared/workflows-list/helpers/get-column-ids-local-storage-key.ts
@@ -1,3 +1,9 @@
+/**
+ * Returns the local storage key for persisted column IDs.
+ *
+ * Keyed by domain name rather than domain ID intentionally —
+ * domains that share a name likely serve the same use case for a given user.
+ */
 export default function getColumnIdsLocalStorageKey(domain: string) {
   return `columns_${domain}`;
 }

--- a/src/views/shared/workflows-list/hooks/__tests__/use-workflows-list-columns.test.ts
+++ b/src/views/shared/workflows-list/hooks/__tests__/use-workflows-list-columns.test.ts
@@ -4,9 +4,17 @@ import { renderHook, act, waitFor } from '@/test-utils/rtl';
 
 import { type IndexedValueType } from '@/__generated__/proto-ts/uber/cadence/api/v1/IndexedValueType';
 import { type GetSearchAttributesResponse } from '@/route-handlers/get-search-attributes/get-search-attributes.types';
+import * as localStorageModule from '@/utils/local-storage';
 
+import getWorkflowsListColumnsLocalStorageKey from '../../helpers/get-column-ids-local-storage-key';
 import { DEFAULT_WORKFLOWS_LIST_COLUMNS } from '../../workflows-list.constants';
 import useWorkflowsListColumns from '../use-workflows-list-columns';
+
+jest.mock('@/utils/local-storage', () => ({
+  getLocalStorageValue: jest.fn(),
+  setLocalStorageValue: jest.fn(),
+  clearLocalStorageValue: jest.fn(),
+}));
 
 const MOCK_SEARCH_ATTRIBUTES_KEYS: Record<string, IndexedValueType> = {
   WorkflowID: 'INDEXED_VALUE_TYPE_KEYWORD',
@@ -30,6 +38,10 @@ const MOCK_CUSTOM_SEARCH_ATTRIBUTES_KEYS: Record<string, IndexedValueType> = {
 };
 
 describe(useWorkflowsListColumns.name, () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('returns empty availableColumns when the API returns an error', async () => {
     const { result } = setup({ apiError: true });
 
@@ -180,6 +192,116 @@ describe(useWorkflowsListColumns.name, () => {
       ...DEFAULT_WORKFLOWS_LIST_COLUMNS,
     ]);
   });
+
+  it('initializes selectedColumnIds from local storage when a valid value exists', async () => {
+    const storedColumns = ['WorkflowID', 'RunID'];
+
+    jest
+      .spyOn(localStorageModule, 'getLocalStorageValue')
+      .mockReturnValue(JSON.stringify(storedColumns));
+
+    const { result } = setup({ keys: MOCK_SEARCH_ATTRIBUTES_KEYS });
+
+    await waitFor(() => {
+      expect(result.current.selectedColumnIds).toEqual(storedColumns);
+    });
+
+    expect(localStorageModule.getLocalStorageValue).toHaveBeenCalledWith(
+      getWorkflowsListColumnsLocalStorageKey('test-domain')
+    );
+  });
+
+  it('falls back to defaults when local storage returns null', async () => {
+    jest
+      .spyOn(localStorageModule, 'getLocalStorageValue')
+      .mockReturnValue(null);
+
+    const { result } = setup({ keys: MOCK_SEARCH_ATTRIBUTES_KEYS });
+
+    await waitFor(() => {
+      expect(result.current.selectedColumnIds).toEqual([
+        ...DEFAULT_WORKFLOWS_LIST_COLUMNS,
+      ]);
+    });
+  });
+
+  it('falls back to defaults when local storage contains malformed JSON', async () => {
+    jest
+      .spyOn(localStorageModule, 'getLocalStorageValue')
+      .mockReturnValue('not-valid-json');
+
+    const { result } = setup({ keys: MOCK_SEARCH_ATTRIBUTES_KEYS });
+
+    await waitFor(() => {
+      expect(result.current.selectedColumnIds).toEqual([
+        ...DEFAULT_WORKFLOWS_LIST_COLUMNS,
+      ]);
+    });
+  });
+
+  it('falls back to defaults when local storage contains an empty array', async () => {
+    jest
+      .spyOn(localStorageModule, 'getLocalStorageValue')
+      .mockReturnValue(JSON.stringify([]));
+
+    const { result } = setup({ keys: MOCK_SEARCH_ATTRIBUTES_KEYS });
+
+    await waitFor(() => {
+      expect(result.current.selectedColumnIds).toEqual([
+        ...DEFAULT_WORKFLOWS_LIST_COLUMNS,
+      ]);
+    });
+  });
+
+  it('saves to local storage when setSelectedColumnIds is called', async () => {
+    const mockSetLocalStorageValue = jest.spyOn(
+      localStorageModule,
+      'setLocalStorageValue'
+    );
+
+    const { result } = setup({ keys: MOCK_SEARCH_ATTRIBUTES_KEYS });
+
+    await waitFor(() => {
+      expect(result.current.availableColumns.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      result.current.setSelectedColumnIds(['WorkflowID', 'RunID']);
+    });
+
+    expect(mockSetLocalStorageValue).toHaveBeenCalledWith(
+      getWorkflowsListColumnsLocalStorageKey('test-domain'),
+      JSON.stringify(['WorkflowID', 'RunID'])
+    );
+  });
+
+  it('saves defaults to local storage when resetColumns is called', async () => {
+    const mockSetLocalStorageValue = jest.spyOn(
+      localStorageModule,
+      'setLocalStorageValue'
+    );
+
+    const { result } = setup({ keys: MOCK_SEARCH_ATTRIBUTES_KEYS });
+
+    await waitFor(() => {
+      expect(result.current.availableColumns.length).toBeGreaterThan(0);
+    });
+
+    act(() => {
+      result.current.setSelectedColumnIds(['WorkflowID']);
+    });
+
+    mockSetLocalStorageValue.mockClear();
+
+    act(() => {
+      result.current.resetColumns();
+    });
+
+    expect(mockSetLocalStorageValue).toHaveBeenCalledWith(
+      getWorkflowsListColumnsLocalStorageKey('test-domain'),
+      JSON.stringify([...DEFAULT_WORKFLOWS_LIST_COLUMNS])
+    );
+  });
 });
 
 function setup({
@@ -190,7 +312,11 @@ function setup({
   apiError?: boolean;
 } = {}) {
   return renderHook(
-    () => useWorkflowsListColumns({ cluster: 'test-cluster' }),
+    () =>
+      useWorkflowsListColumns({
+        cluster: 'test-cluster',
+        domain: 'test-domain',
+      }),
     {
       endpointsMocks: [
         {

--- a/src/views/shared/workflows-list/hooks/use-workflows-list-columns.ts
+++ b/src/views/shared/workflows-list/hooks/use-workflows-list-columns.ts
@@ -7,16 +7,23 @@ import {
 } from 'react';
 
 import { SYSTEM_SEARCH_ATTRIBUTES } from '@/route-handlers/get-search-attributes/get-search-attributes.constants';
+import {
+  getLocalStorageValue,
+  setLocalStorageValue,
+} from '@/utils/local-storage';
 import useSearchAttributes from '@/views/shared/hooks/use-search-attributes/use-search-attributes';
 
+import getColumnIdsLocalStorageKey from '../helpers/get-column-ids-local-storage-key';
 import getWorkflowsListColumnFromSearchAttribute from '../helpers/get-workflows-list-column-from-search-attribute';
 import { DEFAULT_WORKFLOWS_LIST_COLUMNS } from '../workflows-list.constants';
 import { type WorkflowsListColumn } from '../workflows-list.types';
 
 export default function useWorkflowsListColumns({
   cluster,
+  domain,
 }: {
   cluster: string;
+  domain: string;
 }): {
   availableColumns: Array<WorkflowsListColumn>;
   visibleColumns: Array<WorkflowsListColumn>;
@@ -24,9 +31,23 @@ export default function useWorkflowsListColumns({
   setSelectedColumnIds: Dispatch<SetStateAction<Array<string>>>;
   resetColumns: () => void;
 } {
-  const [selectedColumnIds, setSelectedColumnIds] = useState<Array<string>>([
-    ...DEFAULT_WORKFLOWS_LIST_COLUMNS,
-  ]);
+  const localStorageKey = getColumnIdsLocalStorageKey(domain);
+
+  const [columnIds, setColumnIds] = useState<Array<string>>(() => {
+    const storedCols = getLocalStorageValue(localStorageKey);
+    if (storedCols) {
+      try {
+        const parsed = JSON.parse(storedCols);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return parsed;
+        }
+      } catch {
+        // ignore malformed data, fall through to defaults
+      }
+    }
+    return [...DEFAULT_WORKFLOWS_LIST_COLUMNS];
+  });
+
   const { data: searchAttributesData } = useSearchAttributes({
     cluster,
   });
@@ -53,19 +74,31 @@ export default function useWorkflowsListColumns({
 
   const visibleColumns = useMemo(() => {
     const columnById = new Map(availableColumns.map((col) => [col.id, col]));
-    return selectedColumnIds
+    return columnIds
       .map((id) => columnById.get(id))
       .filter((col): col is WorkflowsListColumn => col != null);
-  }, [availableColumns, selectedColumnIds]);
+  }, [availableColumns, columnIds]);
+
+  const setSelectedColumnIds: Dispatch<SetStateAction<Array<string>>> =
+    useCallback(
+      (action) => {
+        setColumnIds((prev) => {
+          const next = typeof action === 'function' ? action(prev) : action;
+          setLocalStorageValue(localStorageKey, JSON.stringify(next));
+          return next;
+        });
+      },
+      [localStorageKey]
+    );
 
   const resetColumns = useCallback(() => {
     setSelectedColumnIds([...DEFAULT_WORKFLOWS_LIST_COLUMNS]);
-  }, []);
+  }, [setSelectedColumnIds]);
 
   return {
     availableColumns,
     visibleColumns,
-    selectedColumnIds,
+    selectedColumnIds: columnIds,
     setSelectedColumnIds,
     resetColumns,
   };


### PR DESCRIPTION
## Summary
Save & load column names & order in browser local storage, so that the browser can remember users' column preferences per domain.

## Test plan
Unit tests + ran locally.

### Demonstration

https://github.com/user-attachments/assets/bea2cc84-04de-4303-ba14-b0b12415cfe4

The demo showcases the following behaviour:
- Settings are loaded for a domain on initial load
- Settings are saved in local storage when "Apply" is hit (this is visible when I reload)
- Settings don't apply to other domains

### Hitting "reset"

https://github.com/user-attachments/assets/dc4c877b-46ee-45ea-9fe6-c5feae3f999c

