### PR TITLE
chore: add missing PR template, guidance, and gitar quality rule

### DIFF
--- a/.gitar/rules/pr-description-quality.md
+++ b/.gitar/rules/pr-description-quality.md
@@ -1,0 +1,80 @@
+---
+title: PR Description Quality Standards
+description: Ensures PR descriptions meet cadence-web quality criteria using guidance from PR template
+when: PR description is created or updated
+actions: Read PR template for guidance then report requirement status
+---
+
+# PR Description Quality Standards
+
+When evaluating a pull request description:
+
+1. **Read the PR template guidance** at `.github/pull_request_guidance.md` to understand the expected guidance for each section
+2. Apply that guidance to evaluate the current PR description
+3. Provide recommendations for how to improve the description. 
+
+## Core Principle: Why Not How
+
+From https://cbea.ms/git-commit/#why-not-how:
+- **"A diff shows WHAT changed, but only the description can explain WHY"**
+- Focus on: the problem being solved, the reasoning behind the solution, context
+- The code itself documents HOW - the PR description documents WHY
+
+## Evaluation Criteria
+
+### Required Sections (must exist with substantive content per PR template guidance)
+
+1. **What changed?**
+   - 1-2 line summary of WHAT changed technically
+   - Focus on key modification, not implementation details
+   - Template has good/bad examples
+
+2. **Why?**
+   - Full context and motivation
+   - What problem does this solve? What's the use case?
+   - What's the impact if we don't make this change?
+   - **CRITICAL**: Technical rationale required for ALL changes (not just large ones)
+   - Must explain WHY this implementation approach was chosen
+
+3. **How did you test it?**
+   - Concrete, copyable commands with exact invocations
+   - GOOD: `npx jest src/views/workflow-list/workflow-list-filters.test.tsx`
+   - BAD: "Tested locally" or "See tests/foo.test.tsx"
+   - For full suite: `npm run test` or `npm run test:unit:browser` / `npm run test:unit:node`
+   - For UI changes: manual verification steps with dev server
+
+4. **Potential risks**
+   - IDL version or generated type breaking changes?
+   - Bundle size impact? SSR/hydration compatibility?
+   - Shared component changes affecting other views?
+   - Performance impact? What could break? Safe to rollback?
+
+5. **Release notes**
+   - If this completes a user-facing feature, describe it
+   - Skip for: incremental work, internal refactors, partial implementations
+
+6. **Documentation Changes**
+   - README or CONTRIBUTING.md updates needed?
+   - New features needing user docs?
+   - Only mark N/A if certain no docs affected
+
+### Quality Checks
+
+- **Skip obvious things** - Don't flag items clear from folder structure
+- **Skip trivial refactors** - Minor formatting/style changes don't need deep rationale
+- **Don't check automated items** - Issue links, CI, linting are automated
+
+## FORBIDDEN - Never Include
+
+- "Issues Found", "Testing Evidence Quality", "Documentation Reasoning", "Summary" sections
+- "Note:" paragraphs or explanatory text outside recommendations
+- Grouping recommendations by type
+
+## Section Names (Use EXACT Brackets)
+
+- **[What changed?]**
+- **[Why?]**
+- **[How did you test it?]**
+- **[Potential risks]**
+- **[Release notes]**
+- **[Documentation Changes]**

--- a/.github/pull_request_guidance.md
+++ b/.github/pull_request_guidance.md
@@ -1,0 +1,61 @@
+<!-- 1-2 line summary of WHAT changed technically:
+- Always link the relevant project's GitHub issue, unless it is a minor bugfix
+- Good: "Added workflow search filter component with debounced input #123"
+- Bad: "updated component" -->
+**What changed?**
+
+
+<!-- Your goal is to provide all the required context for a future maintainer
+to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
+How did this work previously (and what was wrong with it)? What has changed, and why did you solve it
+this way?
+- Good: "The workflow list page loaded all workflows upfront and filtered client-side,
+  causing significant lag for domains with thousands of workflows. Users reported the page
+  becoming unresponsive after ~5 seconds of loading. This change moves filtering to a
+  server-side gRPC query with debounced input, reducing initial payload and improving
+  perceived responsiveness from ~5s to <200ms."
+- Bad: "Improves workflow list" -->
+**Why?**
+
+
+<!-- Include specific test commands and setup. Please include the exact commands such that
+another maintainer or contributor can reproduce the test steps taken.
+- e.g. Unit test commands with exact invocation
+  `npx jest src/views/workflow-list/workflow-list-filters.test.tsx`
+- For running the full test suite
+  `npm run test`
+- For environment-specific tests (browser DOM vs Node.js server)
+  `npm run test:unit:browser` or `npm run test:unit:node`
+- For UI changes, include manual verification steps
+  Example: "Started local dev server with `npm run dev`, navigated to /domains/sample/workflows,
+  verified filter input debounces correctly and results update within 200ms"
+- Good: Full commands that reviewers can copy-paste to verify
+- Bad: "Tested locally" or "Added tests" -->
+**How did you test it?**
+
+
+<!-- If there are risks that the release engineer should know about, document them here.
+For example:
+- Has the IDL version been bumped? Do the generated types introduce breaking changes?
+- Has a shared component been modified? Could it affect other views that use it?
+- Is there a bundle size concern? Does this add a significant new dependency?
+- Is there an SSR/hydration compatibility issue? Does the change rely on browser-only APIs?
+- Has a feature flag been re-used for a new purpose?
+- Could this affect accessibility (screen readers, keyboard navigation)?
+- If truly N/A, you can mark it as such -->
+**Potential risks**
+
+
+<!-- If this PR completes a user-facing feature or changes functionality, add release notes here.
+Your release notes should allow a user and the release engineer to understand the changes with little context.
+Always ensure that the description contains a link to the relevant GitHub issue. -->
+**Release notes**
+
+
+<!-- Consider whether this change requires documentation updates
+- If yes: mention what needs updating (or link to docs PR) in the README, CONTRIBUTING.md,
+  or related documentation
+- If in doubt, add a note about potential doc needs
+- Only mark N/A if you're certain no docs are affected -->
+**Documentation Changes**
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
+**What changed?**
+
+
+**Why?**
+
+
+**How did you test it?**
+
+
+**Potential risks**
+
+
+**Release notes**
+
+
+**Documentation Changes**
+


### PR DESCRIPTION

## Summary
- Other cadence-workflow repos (e.g. cadence) already have standardized PR templates, guidance docs, and automated quality rules. cadence-web currently has none of these, leading to inconsistent PR descriptions.

- Adds `.github/pull_request_template.md` with the standard 6-section structure (What changed / Why / How did you test it / Potential risks / Release notes / Documentation Changes), matching the format used across other Cadence repos for cross-repo consistency.
- Adds `.github/pull_request_guidance.md` with detailed inline examples adapted for the cadence-web frontend stack (Jest test commands, IDL generation, SSR/hydration risks, bundle size concerns, shared component impact, etc.).
- Adds `.gitar/rules/pr-description-quality.md` to automate PR description quality checks against the template guidance, ensuring descriptions meet the same bar as other repos in the ecosystem.