### PR TITLE
feat: Make markdoc signal/start button params optional via page context

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ Feature flags control various UI features and functionality in `cadence-web`. Th
 
 **Note:** For advanced customization, feature flags can be modified through resolvers in the dynamic config system ([`src/config/dynamic/resolvers`](src/config/dynamic/resolvers)).
 
+#### Markdown in Queries
 
+Workflow queries can return markdown with interactive buttons for signaling and starting workflows, powered by [Markdoc](https://markdoc.io/). When rendered on a workflow page, buttons automatically inherit `domain`, `cluster`, `workflowId`, and `runId` from the page context so workflow authors don't need to hardcode them.
+
+A live reference and test page is available at `/docs` when cadence-web is running. See the [cadence-samples query example](https://github.com/cadence-workflow/cadence-samples/tree/master/new_samples) for a working implementation.
 
 ### Using TLS for gRPC
 

--- a/src/components/blocks/blocks.tsx
+++ b/src/components/blocks/blocks.tsx
@@ -94,7 +94,13 @@ export default function Blocks({
     if (section.format === 'text/markdown') {
       return (
         <styled.SectionContainer>
-          <Markdown markdown={content} />
+          <Markdown
+            markdown={content}
+            domain={domain}
+            cluster={cluster}
+            workflowId={workflowId}
+            runId={runId}
+          />
         </styled.SectionContainer>
       );
     }

--- a/src/components/markdown/__tests__/markdoc.test.tsx
+++ b/src/components/markdown/__tests__/markdoc.test.tsx
@@ -4,17 +4,42 @@ import { render, screen } from '@testing-library/react';
 
 import Markdown from '@/components/markdown/markdown';
 
-// Mock the signal button to avoid needing full workflow context
+// Mock the signal button, capturing all received props
+const mockSignalButtonProps: Record<string, unknown>[] = [];
 jest.mock(
   '@/components/markdown/markdoc-components/signal-button/signal-button',
   () => {
-    return function MockSignalButton({ label }: { label: string }) {
-      return <button data-testid="signal-button">{label}</button>;
+    return function MockSignalButton(props: Record<string, unknown>) {
+      mockSignalButtonProps.push(props);
+      return (
+        <button data-testid="signal-button">{props.label as string}</button>
+      );
+    };
+  }
+);
+
+// Mock the start workflow button, capturing all received props
+const mockStartButtonProps: Record<string, unknown>[] = [];
+jest.mock(
+  '@/components/markdown/markdoc-components/start-workflow-button/start-workflow-button',
+  () => {
+    return function MockStartWorkflowButton(props: Record<string, unknown>) {
+      mockStartButtonProps.push(props);
+      return (
+        <button data-testid="start-workflow-button">
+          {props.label as string}
+        </button>
+      );
     };
   }
 );
 
 describe('Markdown with Markdoc', () => {
+  beforeEach(() => {
+    mockSignalButtonProps.length = 0;
+    mockStartButtonProps.length = 0;
+  });
+
   it('renders basic markdown', () => {
     const content = '# Hello World\n\nThis is a test.';
     render(<Markdown markdown={content} />);
@@ -122,5 +147,74 @@ console.log('Hello');
 
     expect(screen.getByText('Bold text')).toBeInTheDocument();
     expect(screen.getByText('italic text')).toBeInTheDocument();
+  });
+
+  describe('page context inheritance', () => {
+    it('signal button without explicit attrs receives page context via Markdown props', () => {
+      const content = '{% signal signalName="test" label="Go" /%}';
+      render(
+        <Markdown
+          markdown={content}
+          domain="my-domain"
+          cluster="cluster0"
+          workflowId="wf-123"
+          runId="run-456"
+        />
+      );
+
+      expect(screen.getByTestId('signal-button')).toBeInTheDocument();
+      expect(mockSignalButtonProps).toHaveLength(1);
+      expect(mockSignalButtonProps[0]).toMatchObject({
+        signalName: 'test',
+        label: 'Go',
+      });
+      // The signal button should NOT receive domain/cluster/workflowId/runId
+      // as direct markdoc props (they weren't in the tag) -- the button component
+      // itself reads them from context at render time.
+    });
+
+    it('signal button with explicit attrs passes them as props (overrides context)', () => {
+      const content =
+        '{% signal signalName="s" label="L" domain="other" cluster="c1" workflowId="w1" runId="r1" /%}';
+      render(
+        <Markdown
+          markdown={content}
+          domain="page-domain"
+          cluster="page-cluster"
+          workflowId="page-wf"
+          runId="page-run"
+        />
+      );
+
+      expect(mockSignalButtonProps).toHaveLength(1);
+      expect(mockSignalButtonProps[0]).toMatchObject({
+        domain: 'other',
+        cluster: 'c1',
+        workflowId: 'w1',
+        runId: 'r1',
+      });
+    });
+
+    it('start workflow button without domain/cluster receives page context', () => {
+      const content =
+        '{% start workflowType="MyWorkflow" label="Start" taskList="tl" /%}';
+      render(
+        <Markdown
+          markdown={content}
+          domain="my-domain"
+          cluster="cluster0"
+          workflowId="wf-123"
+          runId="run-456"
+        />
+      );
+
+      expect(screen.getByTestId('start-workflow-button')).toBeInTheDocument();
+      expect(mockStartButtonProps).toHaveLength(1);
+      expect(mockStartButtonProps[0]).toMatchObject({
+        workflowType: 'MyWorkflow',
+        label: 'Start',
+        taskList: 'tl',
+      });
+    });
   });
 });

--- a/src/components/markdown/markdoc-components/signal-button/signal-button.tsx
+++ b/src/components/markdown/markdoc-components/signal-button/signal-button.tsx
@@ -6,6 +6,8 @@ import { useSnackbar } from 'baseui/snackbar';
 import losslessJsonStringify from '@/utils/lossless-json-stringify';
 import request from '@/utils/request';
 
+import { useMarkdownPageParams } from '../../markdown-page-context';
+
 import { overrides } from './signal-button.styles';
 import { type SignalButtonProps } from './signal-button.types';
 
@@ -13,11 +15,17 @@ export default function SignalButton({
   signalName,
   label,
   input,
-  workflowId,
-  runId,
-  domain,
-  cluster,
+  workflowId: workflowIdProp,
+  runId: runIdProp,
+  domain: domainProp,
+  cluster: clusterProp,
 }: SignalButtonProps) {
+  const pageParams = useMarkdownPageParams();
+  const domain = domainProp ?? pageParams.domain;
+  const cluster = clusterProp ?? pageParams.cluster;
+  const workflowId = workflowIdProp ?? pageParams.workflowId;
+  const runId = runIdProp ?? pageParams.runId;
+
   const { enqueue } = useSnackbar();
 
   const { mutate, isPending } = useMutation({

--- a/src/components/markdown/markdoc-components/start-workflow-button/start-workflow-button.markdoc.ts
+++ b/src/components/markdown/markdoc-components/start-workflow-button/start-workflow-button.markdoc.ts
@@ -11,11 +11,11 @@ export const startWorkflowButtonMarkdocSchema = {
     },
     domain: {
       type: String,
-      required: true,
+      required: false,
     },
     cluster: {
       type: String,
-      required: true,
+      required: false,
     },
     taskList: {
       type: String,

--- a/src/components/markdown/markdoc-components/start-workflow-button/start-workflow-button.tsx
+++ b/src/components/markdown/markdoc-components/start-workflow-button/start-workflow-button.tsx
@@ -6,6 +6,8 @@ import { useRouter } from 'next/navigation';
 
 import request from '@/utils/request';
 
+import { useMarkdownPageParams } from '../../markdown-page-context';
+
 import { overrides } from './start-workflow-button.styles';
 import { type StartWorkflowButtonProps } from './start-workflow-button.types';
 
@@ -17,14 +19,18 @@ type StartWorkflowResult = {
 export default function StartWorkflowButton({
   workflowType,
   label,
-  domain,
-  cluster,
+  domain: domainProp,
+  cluster: clusterProp,
   taskList,
   wfId,
   input,
   timeoutSeconds = 60,
   sdkLanguage = 'GO',
 }: StartWorkflowButtonProps) {
+  const pageParams = useMarkdownPageParams();
+  const domain = domainProp ?? pageParams.domain;
+  const cluster = clusterProp ?? pageParams.cluster;
+
   const { enqueue } = useSnackbar();
   const router = useRouter();
 

--- a/src/components/markdown/markdoc-components/start-workflow-button/start-workflow-button.types.ts
+++ b/src/components/markdown/markdoc-components/start-workflow-button/start-workflow-button.types.ts
@@ -1,8 +1,8 @@
 export type StartWorkflowButtonProps = {
   workflowType: string;
   label: string;
-  domain: string;
-  cluster: string;
+  domain?: string;
+  cluster?: string;
   taskList: string;
   wfId?: string;
   input?: Record<string, any>;

--- a/src/components/markdown/markdown-page-context.tsx
+++ b/src/components/markdown/markdown-page-context.tsx
@@ -1,0 +1,17 @@
+'use client';
+import { createContext, useContext } from 'react';
+
+export type MarkdownPageParams = {
+  domain?: string;
+  cluster?: string;
+  workflowId?: string;
+  runId?: string;
+};
+
+const MarkdownPageContext = createContext<MarkdownPageParams>({});
+
+export const MarkdownPageContextProvider = MarkdownPageContext.Provider;
+
+export function useMarkdownPageParams(): MarkdownPageParams {
+  return useContext(MarkdownPageContext);
+}

--- a/src/components/markdown/markdown.tsx
+++ b/src/components/markdown/markdown.tsx
@@ -4,11 +4,22 @@ import React, { useMemo } from 'react';
 import { parse, renderers, transform } from '@markdoc/markdoc';
 
 import { markdocComponents } from './markdoc-components';
+import { MarkdownPageContextProvider } from './markdown-page-context';
 import { markdocConfig } from './markdoc-schema';
 import { styled } from './markdown.styles';
 import { type Props } from './markdown.types';
 
-export default function Markdown({ markdown }: Props) {
+export default function Markdown({
+  markdown,
+  domain,
+  cluster,
+  workflowId,
+  runId,
+}: Props) {
+  const pageParams = useMemo(
+    () => ({ domain, cluster, workflowId, runId }),
+    [domain, cluster, workflowId, runId]
+  );
   let normalizedContent = markdown || '';
 
   // Remove base indentation from the first non-empty line
@@ -51,10 +62,12 @@ export default function Markdown({ markdown }: Props) {
 
   // Render to React with our custom components
   return (
-    <styled.ViewContainer>
-      {renderers.react(renderableTree, React, {
-        components: markdocComponents,
-      })}
-    </styled.ViewContainer>
+    <MarkdownPageContextProvider value={pageParams}>
+      <styled.ViewContainer>
+        {renderers.react(renderableTree, React, {
+          components: markdocComponents,
+        })}
+      </styled.ViewContainer>
+    </MarkdownPageContextProvider>
   );
 }

--- a/src/components/markdown/markdown.types.tsx
+++ b/src/components/markdown/markdown.types.tsx
@@ -1,3 +1,7 @@
 export type Props = {
   markdown: string;
+  domain?: string;
+  cluster?: string;
+  workflowId?: string;
+  runId?: string;
 };

--- a/src/views/docs/markdown/markdown-guide.ts
+++ b/src/views/docs/markdown/markdown-guide.ts
@@ -1,29 +1,88 @@
 const content = `# Cadence Markdown Guide
 
-This guide provides examples of how to use markdown to interact with Cadence workflows. 
-You can use markdown format in your workflow queries to return actionable content. 
+This guide provides examples of how to use markdown to interact with Cadence workflows.
+You can use markdown format in your workflow queries to return actionable content.
 You can find an example in [cadence-samples repository](https://github.com/cadence-workflow/cadence-samples/tree/master/new_samples) under the query sample.
 Learn more about Cadence markdown in [Cadence Docs](https://cadenceworkflow.io).
 
-It can also be used as a test page to see if the markdown rendering is working correctly. 
-If you see buttons for workflow start and signal, then the markdown rendering is working correctly. 
+It can also be used as a test page to see if the markdown rendering is working correctly.
+If you see buttons for workflow start and signal, then the markdown rendering is working correctly.
 
-Cadence markdown support is implemented using [Markdoc](https://markdoc.io/). 
+Cadence markdown support is implemented using [Markdoc](https://markdoc.io/).
 Markdoc is a markdown parser and renderer that is used to safely render the markdown content.
+
+> **Note:** This docs page has no workflow context, so buttons that rely on inherited page params will appear disabled. On an actual workflow query page, \`domain\`, \`cluster\`, \`workflowId\`, and \`runId\` are inherited automatically and the buttons will be active.
+
+
+## Signal Workflow
+
+Send a signal to a running workflow using the \`signal\` tag.
+
+When rendered on a workflow page (e.g. in a query response), \`domain\`, \`cluster\`, \`workflowId\`, and \`runId\` are inherited from the page automatically. You only need to specify \`signalName\` and \`label\`.
+
+### Example: Minimal (inherits context from page)
+
+\`\`\`
+{% signal signalName="approve" label="Approve" /%}
+\`\`\`
+
+{% signal signalName="approve" label="Approve" /%}
+
+### Example: Explicit target (overrides page context)
+
+Use explicit attributes when you need to signal a different workflow than the one being viewed.
+
+\`\`\`
+{% signal
+  signalName="approve"
+  label="Approve"
+  input={status: "approved", user: "john"}
+  domain="my-domain"
+  cluster="my-cluster"
+  workflowId="workflow-123"
+  runId="run-456"
+/%}
+\`\`\`
+
+{% signal
+  signalName="approve"
+  label="Signal Workflow"
+  input={status: "approved", user: "john"}
+  domain="cadence-samples"
+  cluster="cadence-samples"
+  workflowId="sample-workflow"
+  runId="sample-run"
+/%}
+
+### Signal Attributes
+
+- \`signalName\` (string, **required**) -- name of the signal to send
+- \`label\` (string, **required**) -- button text
+- \`input\` (object, optional) -- signal payload
+- \`domain\` (string, optional) -- inherited from page context if omitted
+- \`cluster\` (string, optional) -- inherited from page context if omitted
+- \`workflowId\` (string, optional) -- inherited from page context if omitted
+- \`runId\` (string, optional) -- inherited from page context if omitted
+
+The \`input\` field supports different value types:
+
+- For booleans, use \`input=true\` or \`input=false\`
+- For json objects, use \`input={"key": "value"}\`
+- For strings, use \`input="string"\`
 
 
 ## Start Workflow
 
 Start a new workflow execution using the \`start\` tag.
 
-### Example: Basic Start
+When rendered on a workflow page, \`domain\` and \`cluster\` are inherited from the page automatically.
+
+### Example: Minimal (inherits context from page)
 
 \`\`\`
 {% start
   workflowType="MyWorkflow"
   label="Start Workflow"
-  domain="my-domain"
-  cluster="my-cluster"
   taskList="my-task-list"
 /%}
 \`\`\`
@@ -31,12 +90,10 @@ Start a new workflow execution using the \`start\` tag.
 {% start
   workflowType="cadence_samples.SampleWorkflow"
   label="Start Workflow"
-  domain="cadence-samples"
-  cluster="cadence-samples"
   taskList="cadence-samples-worker"
 /%}
 
-### Example: Start with Options
+### Example: Explicit target with all options
 
 \`\`\`
 {% start
@@ -64,40 +121,18 @@ Start a new workflow execution using the \`start\` tag.
   sdkLanguage="GO"
 /%}
 
+### Start Attributes
 
-## Signal Workflow
+- \`workflowType\` (string, **required**) -- workflow type name
+- \`label\` (string, **required**) -- button text
+- \`taskList\` (string, **required**) -- task list for the workflow
+- \`domain\` (string, optional) -- inherited from page context if omitted
+- \`cluster\` (string, optional) -- inherited from page context if omitted
+- \`wfId\` (string, optional) -- custom workflow ID
+- \`input\` (object, optional) -- workflow input payload
+- \`timeoutSeconds\` (number, optional, default: 60) -- execution timeout
+- \`sdkLanguage\` (string, optional, default: "GO") -- worker SDK language
 
-Send a signal to a running workflow using the \`signal\` tag.
-
-### Example:
-
-\`\`\`
-{% signal 
-  signalName="approve"
-  label="Approve"
-  input={status: "approved", user: "john"}
-  domain="my-domain"
-  cluster="my-cluster"
-  workflowId="workflow-123"
-  runId="run-456"
-/%}
-\`\`\`
-
-Note that input field is optional and can be omitted. For different value types, you can use the following syntax: 
-
-- For booleans, use \`input=true\` or \`input=false\`
-- For json objects, use \`input={"key": "value"}\`
-- For strings, use \`input="string"\`
-
-{% signal 
-  signalName="approve"
-  label="Signal Workflow"
-  input={status: "approved", user: "john"}
-  domain="cadence-samples"
-  cluster="cadence-samples"
-  workflowId="sample-workflow"
-  runId="sample-run"
-/%}
 
 ## Images
 

--- a/src/views/docs/markdown/markdown-guide.ts
+++ b/src/views/docs/markdown/markdown-guide.ts
@@ -6,12 +6,10 @@ You can find an example in [cadence-samples repository](https://github.com/caden
 Learn more about Cadence markdown in [Cadence Docs](https://cadenceworkflow.io).
 
 It can also be used as a test page to see if the markdown rendering is working correctly.
-If you see buttons for workflow start and signal, then the markdown rendering is working correctly.
+If you see live buttons for the explicit examples below, then the markdown rendering is working correctly.
 
 Cadence markdown support is implemented using [Markdoc](https://markdoc.io/).
 Markdoc is a markdown parser and renderer that is used to safely render the markdown content.
-
-> **Note:** This docs page has no workflow context, so buttons that rely on inherited page params will appear disabled. On an actual workflow query page, \`domain\`, \`cluster\`, \`workflowId\`, and \`runId\` are inherited automatically and the buttons will be active.
 
 
 ## Signal Workflow
@@ -23,10 +21,8 @@ When rendered on a workflow page (e.g. in a query response), \`domain\`, \`clust
 ### Example: Minimal (inherits context from page)
 
 \`\`\`
-{% signal signalName="approve" label="Approve" /%}
+{% signal signalName="approve" label="Signal Workflow" /%}
 \`\`\`
-
-{% signal signalName="approve" label="Approve" /%}
 
 ### Example: Explicit target (overrides page context)
 
@@ -35,12 +31,12 @@ Use explicit attributes when you need to signal a different workflow than the on
 \`\`\`
 {% signal
   signalName="approve"
-  label="Approve"
+  label="Signal Workflow"
   input={status: "approved", user: "john"}
-  domain="my-domain"
-  cluster="my-cluster"
-  workflowId="workflow-123"
-  runId="run-456"
+  domain="cadence-samples"
+  cluster="cadence-samples"
+  workflowId="sample-workflow"
+  runId="sample-run"
 /%}
 \`\`\`
 
@@ -87,31 +83,25 @@ When rendered on a workflow page, \`domain\` and \`cluster\` are inherited from 
 /%}
 \`\`\`
 
-{% start
-  workflowType="cadence_samples.SampleWorkflow"
-  label="Start Workflow"
-  taskList="cadence-samples-worker"
-/%}
-
 ### Example: Explicit target with all options
 
 \`\`\`
 {% start
-  workflowType="MyWorkflow"
-  label="Start with Config"
-  domain="my-domain"
-  cluster="my-cluster"
-  taskList="my-task-list"
-  wfId="custom-workflow-id"
-  input={key: "value"}
-  timeoutSeconds=300
+  workflowType="cadence_samples.ConfiguredWorkflow"
+  label="Start Workflow""
+  domain="cadence-samples"
+  cluster="cadence-samples"
+  taskList="cadence-samples-worker"
+  wfId="configured-wf-123"
+  input={priority: "high", region: "us-west"}
+  timeoutSeconds=120
   sdkLanguage="GO"
 /%}
 \`\`\`
 
 {% start
   workflowType="cadence_samples.ConfiguredWorkflow"
-  label="Start with Config"
+  label="Start Workflow"
   domain="cadence-samples"
   cluster="cadence-samples"
   taskList="cadence-samples-worker"

--- a/src/views/workflow-queries/workflow-queries-result/workflow-queries-result.tsx
+++ b/src/views/workflow-queries/workflow-queries-result/workflow-queries-result.tsx
@@ -35,7 +35,13 @@ export default function WorkflowQueriesResult(props: Props) {
         )}
       {queryResultContent.contentType === 'markdown' &&
         queryResultContent.content !== undefined && (
-          <Markdown markdown={queryResultContent.content} />
+          <Markdown
+            markdown={queryResultContent.content}
+            domain={props.domain}
+            cluster={props.cluster}
+            workflowId={props.workflowId}
+            runId={props.runId}
+          />
         )}
       {queryResultContent.contentType === 'blocks' &&
         queryResultContent.content !== undefined && (


### PR DESCRIPTION

## What changed

- Added a `MarkdownPageContext` React context that carries `domain`, `cluster`, `workflowId`, and `runId` from the page into the Markdown renderer.
- The `Markdown` component now accepts optional page param props and wraps its output in a `MarkdownPageContextProvider`.
- `SignalButton` and `StartWorkflowButton` markdoc components fall back to page context when their tag attributes are omitted. Explicit attributes still take priority.
- `WorkflowQueriesResult` now pass page params through to `<Markdown>`.
- The markdoc schemas for `{% start %}` updated `domain` and `cluster` from `required: true` to `required: false`.
- Updated `/docs` markdown guide: restructured with minimal-first examples, added attribute reference tables for both tags, and ensured code fence examples match their live rendered counterparts.
- Added a "Markdown in Queries" section to `README.md` pointing to the `/docs` reference page.

**Files changed (12):**
`markdown-page-context.tsx` (new), `markdown.tsx`, `markdown.types.tsx`, `signal-button.tsx`, `start-workflow-button.tsx`, `start-workflow-button.types.ts`, `start-workflow-button.markdoc.ts`, `blocks.tsx`, `workflow-queries-result.tsx`, `markdoc.test.tsx`, `markdown-guide.ts`, `README.md`

## Why

Workflow queries can return markdown with `{% signal %}` and `{% start %}` buttons, but previously all params (`domain`, `cluster`, `workflowId`, `runId`) had to be explicitly specified in every tag — even though the page already knows them from the URL. This forced workflow authors to cache and template these values into their query responses (see `cadence-samples/new_samples/query/markdown_query.go`).

With this change, a signal button simplifies from:

```
{% signal signalName="complete" label="Complete" domain="my-domain" cluster="cluster0" workflowId="wf-123" runId="run-456" input=true /%}
```
to:

```
{% signal signalName="complete" label="Complete" input=true /%}
```

# How to test
1. Run `npx jest --watchman=false --no-coverage src/components/markdown/__tests__/markdoc.test.tsx` — all 12 tests should pass (3 new context inheritance tests).
2. Start the dev server (`npm run dev`) and visit `http://localhost:8088/docs` — verify the guide renders correctly with live buttons only on explicit examples and no disabled buttons.
3. If you have a running Cadence backend with a workflow that returns markdown query results, navigate to a workflow's Queries tab and verify signal/start buttons work without explicit `domain`/`cluster`/`workflowId`/`runId` in the markdown.
## Risks
- **Low:** No API or route changes. The context defaults to an empty object `{}`, so existing markdoc tags with explicit attributes are unaffected — the `??` fallback only activates when a prop is `undefined`.
- **Low:** The `StartWorkflowButton` markdoc schema changed `domain`/`cluster` from `required: true` to `required: false`. Markdoc validates at parse time, so existing tags that already specify these attributes are unaffected. Tags that omit them will now parse successfully instead of erroring.
- **None:** Backward-compatible. All existing markdown content that specifies explicit params continues to work identically.


Fixes #1141