### PR TITLE
feat: Add Workflow Execution link to External Signal workflow event summary

### DIFF
--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-signal-external-workflow-execution-group-from-events.test.ts
@@ -149,6 +149,7 @@ describe('getSignalExternalWorkflowExecutionGroupFromEvents', () => {
       (metadata) => metadata.label === 'Initiated'
     );
     expect(initiatedEventMetadata?.summaryFields).toEqual([
+      'workflowExecution',
       'signalName',
       'input',
     ]);

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-signal-external-workflow-execution-group-from-events.ts
@@ -56,6 +56,7 @@ export default function getSignalExternalWorkflowExecutionGroupFromEvents(
   const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<SignalExternalWorkflowExecutionHistoryGroup> =
     {
       signalExternalWorkflowExecutionInitiatedEventAttributes: [
+        'workflowExecution',
         'signalName',
         'input',
       ],


### PR DESCRIPTION
## Summary
Add Workflow Execution link to External Signal workflow event's single-line summary

## Test plan
Updated unit tests + ran locally.

<img width="1593" height="369" alt="Screenshot 2026-04-27 at 16 26 54" src="https://github.com/user-attachments/assets/4eadaacf-30b9-41ef-9a21-d3fef8d3625e" />
