### PR TITLE
feat: plumbing for batch-action workflow query panel

### DIFF
--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
@@ -15,7 +15,13 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
   });
 
   it('renders the "New batch action" title', () => {
-    render(<DomainBatchActionsNewActionDetail onDiscard={jest.fn()} />);
+    render(
+      <DomainBatchActionsNewActionDetail
+        domain="test-domain"
+        cluster="test-cluster"
+        onDiscard={jest.fn()}
+      />
+    );
 
     expect(
       screen.getByRole('heading', { name: 'New batch action' })
@@ -23,7 +29,13 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
   });
 
   it('renders the discard button', () => {
-    render(<DomainBatchActionsNewActionDetail onDiscard={jest.fn()} />);
+    render(
+      <DomainBatchActionsNewActionDetail
+        domain="test-domain"
+        cluster="test-cluster"
+        onDiscard={jest.fn()}
+      />
+    );
 
     expect(screen.getByText('Discard batch action')).toBeInTheDocument();
   });
@@ -32,7 +44,13 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
     const onDiscard = jest.fn();
     const user = userEvent.setup();
 
-    render(<DomainBatchActionsNewActionDetail onDiscard={onDiscard} />);
+    render(
+      <DomainBatchActionsNewActionDetail
+        domain="test-domain"
+        cluster="test-cluster"
+        onDiscard={onDiscard}
+      />
+    );
 
     await user.click(screen.getByText('Discard batch action'));
 

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.types.ts
@@ -1,3 +1,5 @@
 export type Props = {
+  domain: string;
+  cluster: string;
   onDiscard: () => void;
 };

--- a/src/views/domain-batch-actions/domain-batch-actions.styles.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.styles.ts
@@ -4,7 +4,6 @@ export const styled = {
   Container: createStyled('div', () => ({
     display: 'flex',
     flexDirection: 'row',
-    height: '100%',
   })),
   Sidebar: createStyled('aside', () => ({
     width: '20%',
@@ -16,6 +15,5 @@ export const styled = {
     display: 'flex',
     flexDirection: 'column',
     padding: $theme.sizing.scale600,
-    overflow: 'auto',
   })),
 };

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -9,7 +9,7 @@ import DomainBatchActionsSidebar from './domain-batch-actions-sidebar/domain-bat
 import { MOCK_BATCH_ACTIONS } from './domain-batch-actions.constants';
 import { styled } from './domain-batch-actions.styles';
 
-export default function DomainBatchActions(_props: DomainPageTabContentProps) {
+export default function DomainBatchActions(props: DomainPageTabContentProps) {
   // TODO: replace with useSuspenseQuery once the batch-actions list endpoint exists
   const batchActions = MOCK_BATCH_ACTIONS;
 
@@ -56,7 +56,11 @@ export default function DomainBatchActions(_props: DomainPageTabContentProps) {
       </styled.Sidebar>
       <styled.DetailPanel>
         {isDraftSelected && (
-          <DomainBatchActionsNewActionDetail onDiscard={handleDiscard} />
+          <DomainBatchActionsNewActionDetail
+            domain={props.domain}
+            cluster={props.cluster}
+            onDiscard={handleDiscard}
+          />
         )}
         {!isDraftSelected && selectedAction && (
           <DomainBatchActionDetail batchAction={selectedAction} />

--- a/src/views/domain-page/__fixtures__/domain-page-query-params.ts
+++ b/src/views/domain-page/__fixtures__/domain-page-query-params.ts
@@ -10,6 +10,8 @@ export const mockDomainPageQueryParamsValues = {
   sortColumn: 'startTime',
   sortOrder: 'DESC',
   query: '',
+  batchInputType: 'query',
+  batchQuery: '',
   workflowId: '',
   workflowType: '',
   statusBasic: undefined,

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -23,6 +23,10 @@ const domainPageQueryParamsConfig: [
   PageQueryParam<'sortOrder', SortOrder>,
   // Query input
   PageQueryParam<'query', string>,
+  // Batch actions query input (uses separate URL params so the workflows tab
+  // and the batch action draft do not overwrite each other's state).
+  PageQueryParam<'batchInputType', WorkflowsHeaderInputType>,
+  PageQueryParam<'batchQuery', string>,
   // Basic Visibility inputs
   PageQueryParam<'workflowId', string>,
   PageQueryParam<'workflowType', string>,
@@ -86,6 +90,17 @@ const domainPageQueryParamsConfig: [
   },
   {
     key: 'query',
+    defaultValue: '',
+  },
+  {
+    key: 'batchInputType',
+    queryParamKey: 'batch-input',
+    defaultValue: 'query',
+    parseValue: (value: string) => (value === 'search' ? 'search' : 'query'),
+  },
+  {
+    key: 'batchQuery',
+    queryParamKey: 'batch-query',
     defaultValue: '',
   },
   {

--- a/src/views/shared/workflows-header/workflows-header.styles.ts
+++ b/src/views/shared/workflows-header/workflows-header.styles.ts
@@ -6,10 +6,13 @@ import {
 import { type StyleObject } from 'styletron-react';
 
 export const styled = {
-  HeaderContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    marginTop: $theme.sizing.scale950,
-    marginBottom: $theme.sizing.scale900,
-  })),
+  HeaderContainer: createStyled<'div', { $noSpacing?: boolean }>(
+    'div',
+    ({ $theme, $noSpacing }) => ({
+      marginTop: $noSpacing ? 0 : $theme.sizing.scale950,
+      marginBottom: $noSpacing ? 0 : $theme.sizing.scale900,
+    })
+  ),
   InputContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
     display: 'flex',
     flexDirection: 'column',

--- a/src/views/shared/workflows-header/workflows-header.tsx
+++ b/src/views/shared/workflows-header/workflows-header.tsx
@@ -37,6 +37,7 @@ export default function WorkflowsHeader<
   isQueryRunning,
   expandFiltersByDefault,
   showQueryInputOnly,
+  noSpacing,
   columnsPickerProps,
 }: Props<P, I, S, Q>) {
   const [areFiltersShown, setAreFiltersShown] = useState(
@@ -55,7 +56,7 @@ export default function WorkflowsHeader<
   const query = queryParams[queryStringQueryParamKey];
 
   return (
-    <styled.HeaderContainer>
+    <styled.HeaderContainer $noSpacing={noSpacing}>
       <styled.InputContainer>
         <SegmentedControl
           activeKey={inputType}

--- a/src/views/shared/workflows-header/workflows-header.types.ts
+++ b/src/views/shared/workflows-header/workflows-header.types.ts
@@ -29,5 +29,6 @@ export type Props<
   isQueryRunning: boolean;
   expandFiltersByDefault?: boolean;
   showQueryInputOnly?: boolean;
+  noSpacing?: boolean;
   columnsPickerProps?: ColumnsPickerProps;
 };


### PR DESCRIPTION
## Summary
- Adds `noSpacing` prop to shared `WorkflowsHeader`.
- Adds `batchInputType` / `batchQuery` URL params (under `batch-input` / `batch-query`) so the batch-actions tab and workflows tab don't overwrite each other.
- Drops the height/overflow constraints from `DomainBatchActions` layout so the page uses the body scrollbar (the project convention).
- Threads `domain` / `cluster` from the orchestrator down to `DomainBatchActionsNewActionDetail`.

No user-visible behaviour change. Groundwork for #1266 (the panel rewrite) and #1267 (dropdown wiring).

Replaces parts of #1264, which will be closed once this stack lands.

## Test plan
- [x] CI: typecheck / lint / test pass.