### PR TITLE
feat: Add seconds end enhancer to time inputs

### DIFF
--- a/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.tsx
+++ b/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.tsx
@@ -5,6 +5,7 @@ import { FormControl } from 'baseui/form-control';
 import { Input } from 'baseui/input';
 import { RadioGroup, Radio } from 'baseui/radio';
 import { Spinner, SIZE as SPINNER_SIZE } from 'baseui/spinner';
+import { LabelXSmall } from 'baseui/typography';
 import { Controller, useWatch } from 'react-hook-form';
 import { MdWarning } from 'react-icons/md';
 
@@ -170,6 +171,7 @@ export default function WorkflowActionStartForm({
               )}
               placeholder="Enter timeout in seconds"
               size="compact"
+              endEnhancer={<LabelXSmall>Seconds</LabelXSmall>}
             />
           )}
         />

--- a/src/views/workflow-actions/workflow-action-start-retry-policy/workflow-action-start-retry-policy.tsx
+++ b/src/views/workflow-actions/workflow-action-start-retry-policy/workflow-action-start-retry-policy.tsx
@@ -4,6 +4,7 @@ import { Checkbox } from 'baseui/checkbox';
 import { FormControl } from 'baseui/form-control';
 import { Input } from 'baseui/input';
 import { RadioGroup, Radio } from 'baseui/radio';
+import { LabelXSmall } from 'baseui/typography';
 import { Controller, useWatch } from 'react-hook-form';
 
 import useStyletronClasses from '@/hooks/use-styletron-classes';
@@ -92,6 +93,7 @@ export default function WorkflowActionStartRetryPolicy({
                   )}
                   size="compact"
                   placeholder="Enter initial interval in seconds"
+                  endEnhancer={<LabelXSmall>Seconds</LabelXSmall>}
                 />
               )}
             />
@@ -147,6 +149,7 @@ export default function WorkflowActionStartRetryPolicy({
                   )}
                   size="compact"
                   placeholder="Enter maximum interval in seconds"
+                  endEnhancer={<LabelXSmall>Seconds</LabelXSmall>}
                 />
               )}
             />
@@ -204,6 +207,7 @@ export default function WorkflowActionStartRetryPolicy({
                     )}
                     size="compact"
                     placeholder="Enter expiration interval in seconds"
+                    endEnhancer={<LabelXSmall>Seconds</LabelXSmall>}
                   />
                 )}
               />


### PR DESCRIPTION
### Summary
It is not clear that time inputs accepts seconds. Added `Seconds` end enhancer to time input to avoid confusion.

### Testing
<img width="591" height="653" alt="Screenshot 2026-05-01 at 15 24 15" src="https://github.com/user-attachments/assets/9d78d046-eb8c-400c-81e6-c6387ba621fd" />
<img width="611" height="508" alt="Screenshot 2026-05-01 at 15 24 08" src="https://github.com/user-attachments/assets/7c8f47f8-22f8-4662-94e1-21cf69fc9315" />

