### PR TITLE
feat: add schedules-enabled dynamic config

### DIFF
--- a/src/config/dynamic/dynamic.config.ts
+++ b/src/config/dynamic/dynamic.config.ts
@@ -26,6 +26,8 @@ import { type ExtendedDomainInfoEnabledConfig } from './resolvers/extended-domai
 import failoverHistoryEnabled from './resolvers/failover-history-enabled';
 import historyPageV2Enabled from './resolvers/history-page-v2-enabled';
 import { type HistoryPageV2EnabledConfigValue } from './resolvers/history-page-v2-enabled.types';
+import schedulesEnabled from './resolvers/schedules-enabled';
+import { type SchedulesEnabledResolverParams } from './resolvers/schedules-enabled.types';
 import workflowActionsEnabled from './resolvers/workflow-actions-enabled';
 import {
   type WorkflowActionsEnabledResolverParams,
@@ -107,6 +109,12 @@ const dynamicConfigs: {
     'request',
     true
   >;
+  SCHEDULES_ENABLED: ConfigAsyncResolverDefinition<
+    SchedulesEnabledResolverParams,
+    boolean,
+    'request',
+    true
+  >;
   WORKFLOWS_LIST_ENABLED: ConfigAsyncResolverDefinition<
     undefined,
     boolean,
@@ -178,6 +186,11 @@ const dynamicConfigs: {
   },
   HISTORY_PAGE_V2_ENABLED: {
     resolver: historyPageV2Enabled,
+    evaluateOn: 'request',
+    isPublic: true,
+  },
+  SCHEDULES_ENABLED: {
+    resolver: schedulesEnabled,
     evaluateOn: 'request',
     isPublic: true,
   },

--- a/src/config/dynamic/resolvers/schedules-enabled.ts
+++ b/src/config/dynamic/resolvers/schedules-enabled.ts
@@ -1,0 +1,16 @@
+import { type SchedulesEnabledResolverParams } from './schedules-enabled.types';
+
+/**
+ * Returns whether the Schedules feature is enabled.
+ *
+ * To enable, set the CADENCE_SCHEDULES_ENABLED env variable to `true`.
+ *
+ * For further customization, override the implementation of this resolver.
+ *
+ * @returns {Promise<boolean>} Whether the Schedules feature is enabled.
+ */
+export default async function schedulesEnabled(
+  _: SchedulesEnabledResolverParams
+): Promise<boolean> {
+  return process.env.CADENCE_SCHEDULES_ENABLED === 'true';
+}

--- a/src/config/dynamic/resolvers/schedules-enabled.types.ts
+++ b/src/config/dynamic/resolvers/schedules-enabled.types.ts
@@ -1,0 +1,4 @@
+export type SchedulesEnabledResolverParams = {
+  domain: string;
+  cluster: string;
+};

--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -94,6 +94,13 @@ const resolverSchemas: ResolverSchemas = {
     args: z.undefined(),
     returnType: z.enum(HISTORY_PAGE_V2_ENABLED_VALUES_CONFIG),
   },
+  SCHEDULES_ENABLED: {
+    args: z.object({
+      cluster: z.string(),
+      domain: z.string(),
+    }),
+    returnType: z.boolean(),
+  },
   WORKFLOWS_LIST_ENABLED: {
     args: z.undefined(),
     returnType: z.boolean(),

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -50,6 +50,7 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
   BATCH_ACTIONS_ENABLED: false,
   FAILOVER_HISTORY_ENABLED: false,
   HISTORY_PAGE_V2_ENABLED: 'DISABLED',
+  SCHEDULES_ENABLED: false,
   WORKFLOWS_LIST_ENABLED: false,
 };
 export default mockResolvedConfigValues;


### PR DESCRIPTION
## Summary

Adds a new public, per-request dynamic config key `SCHEDULES_ENABLED` so deployments can toggle Schedules-related behavior via `CADENCE_SCHEDULES_ENABLED`. Unset or any value other than `true` leaves the flag off. Schedules support may roll out gradually; this matches existing patterns (`CRON_LIST_ENABLED`, `BATCH_ACTIONS_ENABLED`) and keeps a stable `{ cluster, domain }` resolver contract for forks. No Schedules UI is wired to the flag yet—that can land in a follow-up.

**Rollout:** Low risk; additive config only, default disabled.

**Configuration**


| Variable                         | Effect                    |
| -------------------------------- | ------------------------- |
| `CADENCE_SCHEDULES_ENABLED=true` | Resolver returns `true`.  |
| Unset or any other value         | Resolver returns `false`. |


## Testing

- `npm run typecheck`

## Feature plans

- Schedules List
    - #1270
- Schedules Create Form
- Schedules Details
- Schedules Actions
- Schedules Backfills