### PR TITLE
feat: Integrate batch action params into new action detail panel

### DIFF
--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -84,19 +84,6 @@ jest.mock(
   })
 );
 
-jest.mock(
-  '../domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail',
-  () => ({
-    __esModule: true,
-    default: ({ onDiscard }: NewActionDetailProps) => (
-      <div>
-        <h2>New batch action</h2>
-        <button onClick={onDiscard}>Discard batch action</button>
-      </div>
-    ),
-  })
-);
-
 describe(DomainBatchActions.name, () => {
   beforeEach(() => {
     mockUsePageQueryParams.mockReturnValue([

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
@@ -23,6 +23,11 @@ jest.mock('query-string', () => ({
   ),
 }));
 
+jest.mock(
+  '../../domain-batch-actions-new-action-params/domain-batch-actions-new-action-params',
+  () => jest.fn(() => <div data-testid="mock-params" />)
+);
+
 const mockSetQueryParams = jest.fn();
 const mockUsePageQueryParams = jest.fn();
 jest.mock('@/hooks/use-page-query-params/use-page-query-params', () => ({
@@ -70,6 +75,12 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
     await user.click(await screen.findByText('Discard batch action'));
 
     expect(onDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the params input row', async () => {
+    setup({});
+
+    expect(await screen.findByTestId('mock-params')).toBeInTheDocument();
   });
 
   it('renders the columns selected for the workflows tab', async () => {

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { MdDeleteOutline } from 'react-icons/md';
 
@@ -20,6 +20,7 @@ import WorkflowsList from '@/views/shared/workflows-list/workflows-list';
 import domainBatchActionsNewActionFloatingBarConfig from '../config/domain-batch-actions-new-action-floating-bar.config';
 import DomainBatchActionsNewActionFloatingBar from '../domain-batch-actions-new-action-floating-bar/domain-batch-actions-new-action-floating-bar';
 import DomainBatchActionsNewActionInfoBanner from '../domain-batch-actions-new-action-info-banner/domain-batch-actions-new-action-info-banner';
+import DomainBatchActionsNewActionParams from '../domain-batch-actions-new-action-params/domain-batch-actions-new-action-params';
 
 import {
   overrides,
@@ -33,6 +34,9 @@ export default function DomainBatchActionsNewActionDetail({
   onDiscard,
 }: Props) {
   const [queryParams] = usePageQueryParams(domainPageQueryParamsConfig);
+
+  const [description, setDescription] = useState('');
+  const [rps, setRps] = useState(100);
 
   // Reuse the workflows tab's column selection (persisted per-domain in
   // localStorage) so the user sees the same search attributes they picked
@@ -84,6 +88,12 @@ export default function DomainBatchActionsNewActionDetail({
         </Button>
       </styled.Header>
       <DomainBatchActionsNewActionInfoBanner />
+      <DomainBatchActionsNewActionParams
+        description={description}
+        rps={rps}
+        onDescriptionChange={setDescription}
+        onRpsChange={setRps}
+      />
       <WorkflowsHeader
         pageQueryParamsConfig={domainPageQueryParamsConfig}
         pageFiltersConfig={domainWorkflowsFiltersConfig}


### PR DESCRIPTION
## Summary
- Wire `DomainBatchActionsNewActionParams` into `DomainBatchActionsNewActionDetail` with local `useState` for description and RPS
- Params row renders between the info banner and the workflow query header

## Tests added
- Detail panel test: verifies the params component renders (mocked)

## Stack
This PR is stacked on #1271. Will be rebased onto master once #1271 lands.


<img width="1680" height="766" alt="image" src="https://github.com/user-attachments/assets/e8c16251-4361-4f34-9ef0-aebae0c1a7a1" />
