### PR TITLE
feat: Add list schedules API route handler

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/schedules/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/schedules/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { listSchedules } from '@/route-handlers/list-schedules/list-schedules';
+import type { RouteParams } from '@/route-handlers/list-schedules/list-schedules.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function GET(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    listSchedules,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/config/grpc/grpc-services-config.ts
+++ b/src/config/grpc/grpc-services-config.ts
@@ -7,6 +7,10 @@ const GRPC_SERVICES_CONFIGS = {
     schemaPath: 'uber/cadence/api/v1/service_domain.proto',
     servicePath: 'uber.cadence.api.v1.DomainAPI',
   },
+  scheduleServiceConfig: {
+    schemaPath: 'uber/cadence/api/v1/service_schedule.proto',
+    servicePath: 'uber.cadence.api.v1.ScheduleAPI',
+  },
   visibilityServiceConfig: {
     schemaPath: 'uber/cadence/api/v1/service_visibility.proto',
     servicePath: 'uber.cadence.api.v1.VisibilityAPI',

--- a/src/route-handlers/list-schedules/__tests__/list-schedules.node.ts
+++ b/src/route-handlers/list-schedules/__tests__/list-schedules.node.ts
@@ -1,0 +1,191 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+import queryString from 'query-string';
+
+import type { ListSchedulesResponse as ListSchedulesResponseProto } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesResponse';
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import { listSchedules } from '../list-schedules';
+import { type Context, type RequestParams } from '../list-schedules.types';
+
+jest.mock('@/utils/logger');
+
+const mockSchedules: ListSchedulesResponseProto['schedules'] = [
+  {
+    scheduleId: 'mock-schedule-id-1',
+    workflowType: { name: 'mock-workflow-type-1' },
+    state: { paused: false, pauseInfo: null },
+    cronExpression: '0 * * * *',
+  },
+  {
+    scheduleId: 'mock-schedule-id-2',
+    workflowType: { name: 'mock-workflow-type-2' },
+    state: { paused: true, pauseInfo: null },
+    cronExpression: '*/5 * * * *',
+  },
+];
+
+describe(listSchedules.name, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls listSchedules and returns valid response', async () => {
+    const { res, mockListSchedules } = await setup({
+      queryParams: { pageSize: '10' },
+    });
+
+    expect(mockListSchedules).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      pageSize: 10,
+      nextPageToken: undefined,
+    });
+
+    expect(res.status).toEqual(200);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({
+      schedules: mockSchedules,
+      nextPageToken: 'mock-next-page-token',
+    });
+  });
+
+  it('forwards nextPage query param as nextPageToken', async () => {
+    const { res, mockListSchedules } = await setup({
+      queryParams: { pageSize: '25', nextPage: 'token-123' },
+    });
+
+    expect(mockListSchedules).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      pageSize: 25,
+      nextPageToken: 'token-123',
+    });
+    expect(res.status).toEqual(200);
+  });
+
+  it('returns validation error when pageSize is missing', async () => {
+    const { res, mockListSchedules } = await setup({
+      queryParams: {},
+    });
+
+    expect(mockListSchedules).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Invalid argument(s) for listing schedules',
+        validationErrors: expect.arrayContaining([
+          expect.objectContaining({ path: ['pageSize'] }),
+        ]),
+      })
+    );
+  });
+
+  it('returns validation error when pageSize is not a positive integer', async () => {
+    const { res, mockListSchedules } = await setup({
+      queryParams: { pageSize: '0' },
+    });
+
+    expect(mockListSchedules).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Invalid argument(s) for listing schedules',
+        validationErrors: expect.arrayContaining([
+          expect.objectContaining({
+            message: 'Page size must be a positive integer',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('returns error when listSchedules throws a GRPCError', async () => {
+    const { res, mockListSchedules } = await setup({
+      queryParams: { pageSize: '10' },
+      error: new GRPCError('Schedule service unavailable', {
+        grpcStatusCode: status.NOT_FOUND,
+      }),
+    });
+
+    expect(mockListSchedules).toHaveBeenCalled();
+    expect(res.status).toEqual(404);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Schedule service unavailable',
+      })
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: { domain: 'mock-domain', cluster: 'mock-cluster' },
+        queryParams: expect.any(Object),
+        error: expect.any(GRPCError),
+      }),
+      'Error fetching schedules: Schedule service unavailable'
+    );
+  });
+
+  it('returns error when listSchedules throws a generic error', async () => {
+    const { res, mockListSchedules } = await setup({
+      queryParams: { pageSize: '10' },
+      error: new Error('Network error'),
+    });
+
+    expect(mockListSchedules).toHaveBeenCalled();
+    expect(res.status).toEqual(500);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Error fetching schedules',
+      })
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: { domain: 'mock-domain', cluster: 'mock-cluster' },
+        queryParams: expect.any(Object),
+        error: expect.any(Error),
+      }),
+      'Error fetching schedules'
+    );
+  });
+});
+
+async function setup({
+  queryParams,
+  error,
+}: {
+  queryParams: Record<string, string | string[] | undefined>;
+  error?: Error;
+}) {
+  const mockListSchedules = jest
+    .spyOn(mockGrpcClusterMethods, 'listSchedules')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw error;
+      }
+      return {
+        schedules: mockSchedules,
+        nextPageToken: 'mock-next-page-token',
+      };
+    });
+
+  const res = await listSchedules(
+    new NextRequest(`http://localhost?${queryString.stringify(queryParams)}`),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+      },
+    } as RequestParams,
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockListSchedules };
+}

--- a/src/route-handlers/list-schedules/__tests__/list-schedules.node.ts
+++ b/src/route-handlers/list-schedules/__tests__/list-schedules.node.ts
@@ -64,22 +64,17 @@ describe(listSchedules.name, () => {
     expect(res.status).toEqual(200);
   });
 
-  it('returns validation error when pageSize is missing', async () => {
+  it('defaults pageSize to 25 when not provided', async () => {
     const { res, mockListSchedules } = await setup({
       queryParams: {},
     });
 
-    expect(mockListSchedules).not.toHaveBeenCalled();
-    expect(res.status).toEqual(400);
-    const responseJson = await res.json();
-    expect(responseJson).toEqual(
-      expect.objectContaining({
-        message: 'Invalid argument(s) for listing schedules',
-        validationErrors: expect.arrayContaining([
-          expect.objectContaining({ path: ['pageSize'] }),
-        ]),
-      })
-    );
+    expect(mockListSchedules).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      pageSize: 25,
+      nextPageToken: undefined,
+    });
+    expect(res.status).toEqual(200);
   });
 
   it('returns validation error when pageSize is not a positive integer', async () => {

--- a/src/route-handlers/list-schedules/list-schedules.ts
+++ b/src/route-handlers/list-schedules/list-schedules.ts
@@ -1,0 +1,65 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import queryString from 'query-string';
+
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import type {
+  Context,
+  ListSchedulesResponse,
+  RequestParams,
+  RouteParams,
+} from './list-schedules.types';
+import listSchedulesQueryParamsSchema from './schemas/list-schedules-query-params-schema';
+
+export async function listSchedules(
+  request: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const params = requestParams.params as RouteParams;
+
+  const { data: queryParams, error } = listSchedulesQueryParamsSchema.safeParse(
+    queryString.parse(request.nextUrl.searchParams.toString())
+  );
+
+  if (error) {
+    return NextResponse.json(
+      {
+        message: 'Invalid argument(s) for listing schedules',
+        validationErrors: error.errors,
+      },
+      {
+        status: 400,
+      }
+    );
+  }
+
+  try {
+    const response: ListSchedulesResponse =
+      await ctx.grpcClusterMethods.listSchedules({
+        domain: params.domain,
+        pageSize: queryParams.pageSize,
+        nextPageToken: queryParams.nextPage,
+      });
+
+    return NextResponse.json(response);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: params, queryParams, error: e },
+      'Error fetching schedules' +
+        (e instanceof GRPCError ? ': ' + e.message : '')
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError ? e.message : 'Error fetching schedules',
+        cause: e,
+      },
+      {
+        status: getHTTPStatusCode(e),
+      }
+    );
+  }
+}

--- a/src/route-handlers/list-schedules/list-schedules.types.ts
+++ b/src/route-handlers/list-schedules/list-schedules.types.ts
@@ -1,0 +1,26 @@
+import { type z } from 'zod';
+
+import { type ListSchedulesResponse as ListSchedulesResponseProto } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesResponse';
+import { type ScheduleListEntry as ScheduleListEntryProto } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleListEntry';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+import type listSchedulesQueryParamsSchema from './schemas/list-schedules-query-params-schema';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type ListSchedulesRequestQueryParams = z.input<
+  typeof listSchedulesQueryParamsSchema
+>;
+
+export type ScheduleListEntry = ScheduleListEntryProto;
+
+export type ListSchedulesResponse = ListSchedulesResponseProto;
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/list-schedules/schemas/list-schedules-query-params-schema.ts
+++ b/src/route-handlers/list-schedules/schemas/list-schedules-query-params-schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+const listSchedulesQueryParamsSchema = z.object({
+  pageSize: z
+    .string()
+    .transform((val) => parseInt(val, 10))
+    .pipe(
+      z.number().positive({ message: 'Page size must be a positive integer' })
+    ),
+  nextPage: z.string().optional(),
+});
+
+export default listSchedulesQueryParamsSchema;

--- a/src/route-handlers/list-schedules/schemas/list-schedules-query-params-schema.ts
+++ b/src/route-handlers/list-schedules/schemas/list-schedules-query-params-schema.ts
@@ -3,6 +3,8 @@ import { z } from 'zod';
 const listSchedulesQueryParamsSchema = z.object({
   pageSize: z
     .string()
+    .optional()
+    .default('25')
     .transform((val) => parseInt(val, 10))
     .pipe(
       z.number().positive({ message: 'Page size must be a positive integer' })

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -22,6 +22,8 @@ import { type ListFailoverHistoryRequest__Input } from '@/__generated__/proto-ts
 import { type ListFailoverHistoryResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListFailoverHistoryResponse';
 import { type ListOpenWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListOpenWorkflowExecutionsRequest';
 import { type ListOpenWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListOpenWorkflowExecutionsResponse';
+import { type ListSchedulesRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesRequest';
+import { type ListSchedulesResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesResponse';
 import { type ListTaskListPartitionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsRequest';
 import { type ListTaskListPartitionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsResponse';
 import { type ListWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListWorkflowExecutionsRequest';
@@ -53,7 +55,11 @@ import GRPCService, {
   type GRPCRequestConfig,
 } from './grpc-service';
 type ClusterService = Record<
-  'adminService' | 'domainService' | 'visibilityService' | 'workflowService',
+  | 'adminService'
+  | 'domainService'
+  | 'scheduleService'
+  | 'visibilityService'
+  | 'workflowService',
   GRPCService
 >;
 type ClustersServices = Record<string, ClusterService>;
@@ -91,6 +97,9 @@ export type GRPCClusterMethods = {
   listDomains: (
     payload: ListDomainsRequest__Input
   ) => Promise<ListDomainsResponse>;
+  listSchedules: (
+    payload: ListSchedulesRequest__Input
+  ) => Promise<ListSchedulesResponse>;
   listTaskListPartitions: (
     payload: ListTaskListPartitionsRequest__Input
   ) => Promise<ListTaskListPartitionsResponse>;
@@ -156,6 +165,11 @@ const getClusterServices = async (c: ClusterConfig) => {
     requestConfig,
     ...grpcServiceConfigurations.domainServiceConfig,
   });
+  const scheduleService = new GRPCService({
+    peer: c.grpc.peer,
+    requestConfig,
+    ...grpcServiceConfigurations.scheduleServiceConfig,
+  });
   const visibilityService = new GRPCService({
     peer: c.grpc.peer,
     requestConfig,
@@ -170,6 +184,7 @@ const getClusterServices = async (c: ClusterConfig) => {
   const services: ClusterService = {
     adminService,
     domainService,
+    scheduleService,
     visibilityService,
     workflowService,
   };
@@ -193,8 +208,13 @@ const getClusterServicesMethods = async (
   metadata?: GRPCMetadata
 ): Promise<GRPCClusterMethods> => {
   const clusterServices = await getAllClustersServices();
-  const { visibilityService, adminService, domainService, workflowService } =
-    clusterServices[c];
+  const {
+    visibilityService,
+    adminService,
+    domainService,
+    scheduleService,
+    workflowService,
+  } = clusterServices[c];
 
   return {
     archivedWorkflows: visibilityService.request<
@@ -269,6 +289,13 @@ const getClusterServicesMethods = async (
       ListDomainsResponse
     >({
       method: 'ListDomains',
+      metadata: metadata,
+    }),
+    listSchedules: scheduleService.request<
+      ListSchedulesRequest__Input,
+      ListSchedulesResponse
+    >({
+      method: 'ListSchedules',
       metadata: metadata,
     }),
     listTaskListPartitions: workflowService.request<

--- a/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
@@ -14,6 +14,7 @@ export const mockGrpcClusterMethods: GRPCClusterMethods = {
   getSearchAttributes: jest.fn(),
   listDomains: jest.fn(),
   listFailoverHistory: jest.fn(),
+  listSchedules: jest.fn(),
   listTaskListPartitions: jest.fn(),
   listWorkflows: jest.fn(),
   openWorkflows: jest.fn(),


### PR DESCRIPTION
## Summary

Adds a `GET /api/domains/[domain]/[cluster]/schedules` endpoint that lists schedules for a domain by calling the Cadence `ScheduleAPI.ListSchedules` gRPC method. This is the server-side plumbing required for the Schedules tab to start fetching real data.

## Changes

- Registered the schedule gRPC service in `grpc-services-config.ts` (`uber.cadence.api.v1.ScheduleAPI`, `service_schedule.proto`) and instantiated `scheduleService` in the cluster service map in `grpc-client.ts`.
- Added `listSchedules` to `GRPCClusterMethods`, wiring it to `scheduleService.request<ListSchedulesRequest__Input, ListSchedulesResponse>({ method: 'ListSchedules' })`, and registered the matching `jest.fn()` in the cluster methods mock.
- Created the `list-schedules` route handler under `src/route-handlers/list-schedules/`:
  - `list-schedules.ts` — validates query params, calls `ctx.grpcClusterMethods.listSchedules`, and returns the proto response. On failure it logs via `logger.error<RouteHandlerErrorPayload>` and maps `GRPCError` to the right HTTP status using `getHTTPStatusCode`.
  - `list-schedules.types.ts` — `RouteParams`, `RequestParams`, `ScheduleListEntry`, `ListSchedulesResponse` (alias of the generated proto type), and `Context = DefaultMiddlewaresContext`.
  - `schemas/list-schedules-query-params-schema.ts` — Zod schema for `pageSize` (positive integer, parsed from string) and optional `nextPage`.
- Added the App Router entry `src/app/api/domains/[domain]/[cluster]/schedules/route.ts`, which wraps `listSchedules` with `routeHandlerWithMiddlewares` and `routeHandlersDefaultMiddlewares`.
- Added node-side unit tests covering the happy path, pagination forwarding (`nextPage` → `nextPageToken`), missing/invalid `pageSize` validation errors, and both `GRPCError` and generic error handling, following the `listFailoverHistory` test pattern.

## Testing
Tested using the API
<img width="1586" height="648" alt="Screenshot 2026-05-07 at 16 22 25" src="https://github.com/user-attachments/assets/2f76f8bb-a68e-41bc-9d24-f452d57f7964" />


## Feature plans

- Schedules List
    - #1270
    - #1275 
    - #1276
    - #1283
    - #1284
- Schedules Details
- Schedules Create Form
- Schedules Edit Form
- Schedules In Workflow Summary
