### PR TITLE
feat: Add CountWorkflowExecutions API and useCountWorkflows hook

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/workflows/count/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/count/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { countWorkflows } from '@/route-handlers/count-workflows/count-workflows';
+import type { RouteParams } from '@/route-handlers/count-workflows/count-workflows.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function GET(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    countWorkflows,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/route-handlers/count-workflows/__tests__/count-workflows.node.ts
+++ b/src/route-handlers/count-workflows/__tests__/count-workflows.node.ts
@@ -1,0 +1,180 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+import queryString from 'query-string';
+
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+import * as getVisibilityQueryModule from '@/utils/visibility/get-visibility-query';
+
+import { countWorkflows } from '../count-workflows';
+import type { Context } from '../count-workflows.types';
+
+jest.mock('@/utils/logger');
+jest.mock('@/utils/visibility/get-visibility-query');
+
+describe(countWorkflows.name, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls countWorkflows with query inputType and returns count', async () => {
+    const { res, mockCountWorkflows } = await setup({
+      queryParams: {
+        listType: 'default',
+        inputType: 'query',
+        query: 'WorkflowType="foo"',
+      },
+    });
+
+    expect(mockCountWorkflows).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      query: 'WorkflowType="foo"',
+    });
+
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({ count: 42 });
+  });
+
+  it('calls countWorkflows with search inputType using query builder', async () => {
+    const { res, mockCountWorkflows, mockGetListWorkflowExecutionsQuery } =
+      await setup({
+        queryParams: {
+          listType: 'default',
+          inputType: 'search',
+        },
+      });
+
+    expect(mockGetListWorkflowExecutionsQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        search: undefined,
+      })
+    );
+    expect(mockCountWorkflows).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      query: 'mock list workflow executions query',
+    });
+
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({ count: 42 });
+  });
+
+  it('returns validation error for invalid query params', async () => {
+    const { res, mockCountWorkflows } = await setup({
+      queryParams: {
+        listType: 'invalid-type',
+        inputType: 'query',
+      },
+    });
+
+    expect(mockCountWorkflows).not.toHaveBeenCalled();
+
+    expect(res.status).toEqual(400);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Invalid argument(s) for workflow count',
+      })
+    );
+  });
+
+  it('returns error if countWorkflows throws GRPCError', async () => {
+    const { res, mockCountWorkflows } = await setup({
+      queryParams: {
+        listType: 'default',
+        inputType: 'query',
+        query: 'WorkflowType="foo"',
+      },
+      error: new GRPCError('Domain not found', {
+        grpcStatusCode: status.NOT_FOUND,
+      }),
+    });
+
+    expect(mockCountWorkflows).toHaveBeenCalled();
+
+    expect(res.status).toEqual(404);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Domain not found',
+      })
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: { domain: 'mock-domain', cluster: 'mock-cluster' },
+        error: expect.any(GRPCError),
+      }),
+      'Error counting workflows: Domain not found'
+    );
+  });
+
+  it('returns error if countWorkflows throws generic error', async () => {
+    const { res, mockCountWorkflows } = await setup({
+      queryParams: {
+        listType: 'default',
+        inputType: 'query',
+        query: 'WorkflowType="foo"',
+      },
+      error: new Error('Network error'),
+    });
+
+    expect(mockCountWorkflows).toHaveBeenCalled();
+
+    expect(res.status).toEqual(500);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Error counting workflows',
+      })
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: { domain: 'mock-domain', cluster: 'mock-cluster' },
+        error: expect.any(Error),
+      }),
+      'Error counting workflows'
+    );
+  });
+});
+
+async function setup({
+  queryParams,
+  error,
+}: {
+  queryParams: Record<string, string | string[] | undefined>;
+  error?: Error;
+}) {
+  const mockGetListWorkflowExecutionsQuery = jest
+    .spyOn(getVisibilityQueryModule, 'default')
+    .mockReturnValue('mock list workflow executions query');
+
+  const mockCountWorkflows = jest
+    .spyOn(mockGrpcClusterMethods, 'countWorkflows')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw error;
+      }
+      return { count: '42' };
+    });
+
+  const res = await countWorkflows(
+    new NextRequest(`http://localhost?${queryString.stringify(queryParams)}`),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+      },
+    },
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return {
+    res,
+    mockCountWorkflows,
+    mockGetListWorkflowExecutionsQuery,
+  };
+}

--- a/src/route-handlers/count-workflows/count-workflows.ts
+++ b/src/route-handlers/count-workflows/count-workflows.ts
@@ -1,0 +1,81 @@
+import { type NextRequest, NextResponse } from 'next/server';
+import queryString from 'query-string';
+
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+import getVisibilityQuery from '@/utils/visibility/get-visibility-query';
+
+import type {
+  Context,
+  CountWorkflowsResponse,
+  RequestParams,
+  RouteParams,
+} from './count-workflows.types';
+import countWorkflowsQueryParamSchema from './schemas/count-workflows-query-params-schema';
+
+export async function countWorkflows(
+  request: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const params = requestParams.params as RouteParams;
+
+  const { data: queryParams, error } = countWorkflowsQueryParamSchema.safeParse(
+    queryString.parse(request.nextUrl.searchParams.toString())
+  );
+  if (error) {
+    return NextResponse.json(
+      {
+        message: 'Invalid argument(s) for workflow count',
+        validationErrors: error.errors,
+      },
+      {
+        status: 400,
+      }
+    );
+  }
+
+  const query =
+    queryParams.inputType === 'query'
+      ? queryParams.query
+      : getVisibilityQuery({
+          search: queryParams.search,
+          workflowStatuses: queryParams.statuses,
+          sortColumn: queryParams.sortColumn,
+          sortOrder: queryParams.sortOrder,
+          timeColumn: queryParams.timeColumn,
+          timeRangeStart: queryParams.timeRangeStart,
+          timeRangeEnd: queryParams.timeRangeEnd,
+          includeOrderBy: false,
+        });
+
+  try {
+    const res = await ctx.grpcClusterMethods.countWorkflows({
+      domain: params.domain,
+      query,
+    });
+
+    const response: CountWorkflowsResponse = {
+      count: parseInt(res.count, 10),
+    };
+
+    return NextResponse.json(response);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: params, queryParams, error: e },
+      'Error counting workflows' +
+        (e instanceof GRPCError ? ': ' + e.message : '')
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError ? e.message : 'Error counting workflows',
+        cause: e,
+      },
+      {
+        status: getHTTPStatusCode(e),
+      }
+    );
+  }
+}

--- a/src/route-handlers/count-workflows/count-workflows.types.ts
+++ b/src/route-handlers/count-workflows/count-workflows.types.ts
@@ -1,0 +1,16 @@
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type CountWorkflowsResponse = {
+  count: number;
+};
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/count-workflows/schemas/count-workflows-query-params-schema.ts
+++ b/src/route-handlers/count-workflows/schemas/count-workflows-query-params-schema.ts
@@ -1,0 +1,5 @@
+import { getRefinedVisibilityQuerySchema } from '@/route-handlers/list-workflows/schemas/list-workflows-query-params-schema';
+
+const countWorkflowsQueryParamSchema = getRefinedVisibilityQuerySchema();
+
+export default countWorkflowsQueryParamSchema;

--- a/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
+++ b/src/route-handlers/list-workflows/schemas/list-workflows-query-params-schema.ts
@@ -39,8 +39,16 @@ export const visibilityQuerySchema = z.object({
   sortOrder: z.enum(SORT_ORDERS, { message: 'Invalid sort order' }).optional(),
 });
 
-const listWorkflowsQueryParamSchema = visibilityQuerySchema
-  .merge(
+export const getRefinedVisibilityQuerySchema = <
+  T extends typeof visibilityQuerySchema,
+>(
+  schema: T = visibilityQuerySchema as T
+): z.ZodEffects<T> => {
+  return schema.superRefine(validateArchivedQueryParams) as z.ZodEffects<T>;
+};
+
+const listWorkflowsQueryParamSchema = getRefinedVisibilityQuerySchema(
+  visibilityQuerySchema.merge(
     z.object({
       pageSize: z
         .string()
@@ -53,6 +61,6 @@ const listWorkflowsQueryParamSchema = visibilityQuerySchema
       nextPage: z.string().optional(),
     })
   )
-  .superRefine(validateArchivedQueryParams);
+);
 
 export default listWorkflowsQueryParamSchema;

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -1,6 +1,8 @@
 import { type DescribeClusterRequest__Input } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterRequest';
 import { type DescribeClusterResponse } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeClusterResponse';
 import { type DescribeWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeWorkflowExecutionRequest';
+import { type CountWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/CountWorkflowExecutionsRequest';
+import { type CountWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/CountWorkflowExecutionsResponse';
 import { type DescribeDomainRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainRequest';
 import { type DescribeDomainResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainResponse';
 import { type DescribeTaskListRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeTaskListRequest';
@@ -70,6 +72,9 @@ export type GRPCClusterMethods = {
   closedWorkflows: (
     payload: ListClosedWorkflowExecutionsRequest__Input
   ) => Promise<ListClosedWorkflowExecutionsResponse>;
+  countWorkflows: (
+    payload: CountWorkflowExecutionsRequest__Input
+  ) => Promise<CountWorkflowExecutionsResponse>;
   describeCluster: (
     payload: DescribeClusterRequest__Input
   ) => Promise<DescribeClusterResponse>;
@@ -229,6 +234,13 @@ const getClusterServicesMethods = async (
       ListClosedWorkflowExecutionsResponse
     >({
       method: 'ListClosedWorkflowExecutions',
+      metadata: metadata,
+    }),
+    countWorkflows: visibilityService.request<
+      CountWorkflowExecutionsRequest__Input,
+      CountWorkflowExecutionsResponse
+    >({
+      method: 'CountWorkflowExecutions',
       metadata: metadata,
     }),
     describeCluster: adminService.request<

--- a/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
@@ -3,6 +3,7 @@ import { type GRPCClusterMethods } from '@/utils/grpc/grpc-client';
 export const mockGrpcClusterMethods: GRPCClusterMethods = {
   archivedWorkflows: jest.fn(),
   closedWorkflows: jest.fn(),
+  countWorkflows: jest.fn(),
   describeCluster: jest.fn(),
   describeDomain: jest.fn(),
   updateDomain: jest.fn(),

--- a/src/utils/visibility/__tests__/get-visibility-query.test.ts
+++ b/src/utils/visibility/__tests__/get-visibility-query.test.ts
@@ -26,4 +26,23 @@ describe('getVisibilityQuery', () => {
     const query = getVisibilityQuery({ timeColumn: 'StartTime' });
     expect(query).toEqual('ORDER BY StartTime DESC');
   });
+
+  it('should omit ORDER BY when includeOrderBy is false', () => {
+    const query = getVisibilityQuery({
+      search: 'mocksearchterm',
+      timeColumn: 'StartTime',
+      includeOrderBy: false,
+    });
+    expect(query).toEqual(
+      '(WorkflowType = "mocksearchterm" OR WorkflowID = "mocksearchterm" OR RunID = "mocksearchterm")'
+    );
+  });
+
+  it('should return empty string when includeOrderBy is false and no filters', () => {
+    const query = getVisibilityQuery({
+      timeColumn: 'StartTime',
+      includeOrderBy: false,
+    });
+    expect(query).toEqual('');
+  });
 });

--- a/src/utils/visibility/get-visibility-query.ts
+++ b/src/utils/visibility/get-visibility-query.ts
@@ -10,6 +10,7 @@ export default function getVisibilityQuery({
   timeColumn,
   timeRangeStart,
   timeRangeEnd,
+  includeOrderBy = true,
 }: {
   search?: string;
   workflowStatuses?: Array<WorkflowStatus>;
@@ -18,6 +19,7 @@ export default function getVisibilityQuery({
   timeColumn: 'StartTime' | 'CloseTime';
   timeRangeStart?: string;
   timeRangeEnd?: string;
+  includeOrderBy?: boolean;
 }) {
   const searchQueries: Array<string> = [];
   if (search) {
@@ -51,8 +53,11 @@ export default function getVisibilityQuery({
     searchQueries.push(`${timeColumn} <= "${timeRangeEnd}"`);
   }
 
-  return (
-    (searchQueries.length > 0 ? `${searchQueries.join(' AND ')} ` : '') +
-    `ORDER BY ${sortColumn ?? 'StartTime'} ${sortOrder ?? 'DESC'}`
-  );
+  const filterClause =
+    searchQueries.length > 0 ? searchQueries.join(' AND ') : '';
+  const orderClause = includeOrderBy
+    ? `ORDER BY ${sortColumn ?? 'StartTime'} ${sortOrder ?? 'DESC'}`
+    : '';
+
+  return [filterClause, orderClause].filter(Boolean).join(' ');
 }

--- a/src/views/shared/hooks/use-count-workflows.ts
+++ b/src/views/shared/hooks/use-count-workflows.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import queryString from 'query-string';
+
+import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
+
+import {
+  type CountWorkflowsResponse,
+  type UseCountWorkflowsParams,
+} from './use-count-workflows.types';
+
+export default function useCountWorkflows({
+  domain,
+  cluster,
+  query,
+}: UseCountWorkflowsParams) {
+  const queryResult = useQuery<CountWorkflowsResponse, RequestError>({
+    queryKey: ['countWorkflows', { domain, cluster, query }],
+    queryFn: async () =>
+      request(
+        queryString.stringifyUrl({
+          url: `/api/domains/${domain}/${cluster}/workflows/count`,
+          query: {
+            inputType: 'query',
+            listType: 'default',
+            query,
+          },
+        })
+      ).then((res) => res.json()),
+  });
+
+  return {
+    count: queryResult.data?.count,
+    ...queryResult,
+  };
+}

--- a/src/views/shared/hooks/use-count-workflows.types.ts
+++ b/src/views/shared/hooks/use-count-workflows.types.ts
@@ -1,0 +1,9 @@
+import { type CountWorkflowsResponse } from '@/route-handlers/count-workflows/count-workflows.types';
+
+export type { CountWorkflowsResponse };
+
+export type UseCountWorkflowsParams = {
+  domain: string;
+  cluster: string;
+  query?: string;
+};


### PR DESCRIPTION
## Summary

The batch actions floating bar needs to show the total number of workflows matching a query, but the list API only returns one page at a time. Cadence's visibility service has a `CountWorkflowExecutions` gRPC method that returns the total count for a query without fetching the actual workflows. This PR adds the full server-to-client pipeline for calling it.

### What's new

- **gRPC client method** (`src/utils/grpc/grpc-client.ts`)
  Added `countWorkflows` to `GRPCClusterMethods`. It calls the `CountWorkflowExecutions` method on the visibility service, which takes a domain and a query string and returns a count.

- **Route handler** (`src/route-handlers/count-workflows/`)
  A new `GET /api/domains/[domain]/[cluster]/workflows/count` endpoint. It follows the same pattern as `list-workflows`: parses query params with a Zod schema (reusing the shared visibility query schema from #1285), resolves the query string, calls the gRPC method, and returns `{ count: number }`. Error handling matches the existing pattern (GRPCError → appropriate HTTP status, generic error → 500).

- **Count schema** (`count-workflows/schemas/count-workflows-query-params-schema.ts`)
  Simply applies `visibilityQuerySchema.superRefine(validateArchivedQueryParams)` — no extra fields needed since count doesn't use pagination. This is why #1285 moved `listType` into the shared schema.

- **Client hook** (`src/views/shared/hooks/use-count-workflows.ts`)
  A `useCountWorkflows` hook that calls the count endpoint using TanStack Query's `useQuery`. It fires whenever `query` is defined (including empty string, which means "all workflows") and returns the count.

- **Types** — `CountWorkflowsResponse` is defined once in the route handler types. The hook types file re-exports it to avoid duplication.

## Tests
- `count-workflows.node.ts` — 5 tests: query mode, search mode, validation error, gRPC error, generic error

> Part 2 of 3 — stack: #1285 shared schema → **#1286 count API** → #1287 wire to floating bar