### PR TITLE
feat: Wire CountWorkflowExecutions to floating bar with error handling

### DIFF
--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { type ListWorkflowsResponse } from '@/route-handlers/list-workflows/list-workflows.types';
 import { mockDomainPageQueryParamsValues } from '@/views/domain-page/__fixtures__/domain-page-query-params';
+import { type CountWorkflowsResponse } from '@/views/shared/hooks/use-count-workflows.types';
 import { mockWorkflowsListSystemColumns } from '@/views/shared/workflows-list/__fixtures__/mock-workflows-list-columns';
 
 import { type Props as MSWMocksHandlersProps } from '../../../../test-utils/msw-mock-handlers/msw-mock-handlers.types';
@@ -18,14 +19,28 @@ jest.mock('react-icons/md', () => ({
 }));
 
 jest.mock('query-string', () => ({
-  stringifyUrl: jest.fn(
-    () => '/api/domains/test-domain/test-cluster/workflows'
-  ),
+  stringifyUrl: jest.fn(({ url }: { url: string }) => url),
 }));
 
 jest.mock(
   '../../domain-batch-actions-new-action-params/domain-batch-actions-new-action-params',
   () => jest.fn(() => <div data-testid="mock-params" />)
+);
+
+jest.mock(
+  '../../domain-batch-actions-new-action-floating-bar/domain-batch-actions-new-action-floating-bar',
+  () =>
+    jest.fn(({ selectedCount, totalCount }) => (
+      <div data-testid="mock-floating-bar">
+        {`${selectedCount} of ${totalCount} workflows included`}
+      </div>
+    ))
+);
+
+jest.mock('@/components/error-panel/error-panel', () =>
+  jest.fn(({ message }: { message: string }) => (
+    <div data-testid="mock-error-panel">{message}</div>
+  ))
 );
 
 const mockSetQueryParams = jest.fn();
@@ -104,16 +119,33 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
     expect(screen.queryByText('Workflow Type')).not.toBeInTheDocument();
   });
 
-  it('shows the floating bar with the fetched workflow count', async () => {
-    setup({ workflowCount: 7 });
+  it('shows the floating bar with the count from the count API', async () => {
+    setup({ workflowCount: 3, totalCount: 7 });
 
     expect(
       await screen.findByText(/7 of 7 workflows included/i)
     ).toBeInTheDocument();
   });
 
+  it('shows total count from count API when available', async () => {
+    setup({ workflowCount: 3, totalCount: 50 });
+
+    expect(
+      await screen.findByText(/50 of 50 workflows included/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows error panel when count API fails', async () => {
+    setup({ workflowCount: 3, countError: true });
+
+    expect(
+      await screen.findByText('Failed to fetch workflows')
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('mock-floating-bar')).not.toBeInTheDocument();
+  });
+
   it('hides the floating bar when no workflows have been fetched', async () => {
-    setup({ workflowCount: 0 });
+    setup({ workflowCount: 0, totalCount: 0 });
 
     await waitFor(() => {
       expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
@@ -126,9 +158,13 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
 function setup({
   onDiscard = jest.fn(),
   workflowCount = 1,
+  totalCount = 100,
+  countError = false,
 }: {
   onDiscard?: () => void;
   workflowCount?: number;
+  totalCount?: number;
+  countError?: boolean;
 }) {
   const user = userEvent.setup();
   const response: ListWorkflowsResponse = {
@@ -139,6 +175,10 @@ function setup({
       })
     ),
     nextPage: '',
+  };
+
+  const countResponse: CountWorkflowsResponse = {
+    count: totalCount,
   };
 
   render(
@@ -154,6 +194,18 @@ function setup({
           httpMethod: 'GET',
           mockOnce: false,
           httpResolver: async () => HttpResponse.json(response),
+        },
+        {
+          path: '/api/domains/:domain/:cluster/workflows/count',
+          httpMethod: 'GET',
+          mockOnce: false,
+          httpResolver: async () =>
+            countError
+              ? HttpResponse.json(
+                  { message: 'Internal error' },
+                  { status: 500 }
+                )
+              : HttpResponse.json(countResponse),
         },
       ] as MSWMocksHandlersProps['endpointsMocks'],
     }

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
@@ -14,6 +14,7 @@ import domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-
 import domainWorkflowsFiltersConfig from '@/views/domain-workflows/config/domain-workflows-filters.config';
 import DOMAIN_WORKFLOWS_PAGE_SIZE from '@/views/domain-workflows/config/domain-workflows-page-size.config';
 import getWorkflowsErrorPanelProps from '@/views/domain-workflows/domain-workflows-table/helpers/get-workflows-error-panel-props';
+import useCountWorkflows from '@/views/shared/hooks/use-count-workflows';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 import WorkflowsHeader from '@/views/shared/workflows-header/workflows-header';
 import useWorkflowsListColumns from '@/views/shared/workflows-list/hooks/use-workflows-list-columns';
@@ -83,18 +84,29 @@ export default function DomainBatchActionsNewActionDetail({
     query: queryParams.batchQuery,
   });
 
+  const {
+    count: totalWorkflowCount,
+    error: countError,
+    isLoading: isCountLoading,
+  } = useCountWorkflows({
+    domain,
+    cluster,
+    query: queryParams.batchQuery,
+  });
+
+  const isDataLoading = isLoading || isCountLoading;
+
   const errorPanelProps =
-    workflows.length === 0
+    workflows.length === 0 || countError
       ? getWorkflowsErrorPanelProps({
           inputType: 'query',
-          error,
+          error: error ?? countError,
           // TODO: compute this from the panel's filter state, the way
           // domain-workflows-table.tsx does. Hardcoded false for now because
           // batchQuery is the only filter and an empty query is a valid state.
           areSearchParamsAbsent: false,
         })
       : undefined;
-
   return (
     <styled.Container>
       <styled.Header>
@@ -125,13 +137,13 @@ export default function DomainBatchActionsNewActionDetail({
         showQueryInputOnly
         noSpacing
       />
-      {isLoading && <SectionLoadingIndicator />}
-      {!isLoading && errorPanelProps && (
+      {isDataLoading && <SectionLoadingIndicator />}
+      {!isDataLoading && errorPanelProps && (
         <PanelSection>
           <ErrorPanel {...errorPanelProps} reset={refetch} />
         </PanelSection>
       )}
-      {!isLoading && !errorPanelProps && (
+      {!isDataLoading && !errorPanelProps && (
         <WorkflowsList
           workflows={workflows}
           columns={visibleColumns}
@@ -141,16 +153,11 @@ export default function DomainBatchActionsNewActionDetail({
           isFetchingNextPage={isFetchingNextPage}
         />
       )}
-      {workflows.length > 0 && (
+      {!isDataLoading && !errorPanelProps && !!totalWorkflowCount && (
         <styled.FloatingBarSlot>
-          {/* TODO: totalCount currently reflects only the workflows already
-              loaded by useInfiniteQuery, not the true match count for the
-              query. Wire up the CountWorkflowExecutions visibility API
-              (proto types already generated) so the bar shows the real
-              total across all pages. */}
           <DomainBatchActionsNewActionFloatingBar
-            selectedCount={workflows.length}
-            totalCount={workflows.length}
+            selectedCount={totalWorkflowCount}
+            totalCount={totalWorkflowCount}
             actions={domainBatchActionsNewActionFloatingBarConfig}
             onActionClick={handleActionClick}
             disabled={hasValidationErrors}

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-floating-bar/__tests__/domain-batch-actions-new-action-floating-bar.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-floating-bar/__tests__/domain-batch-actions-new-action-floating-bar.test.tsx
@@ -61,11 +61,13 @@ function setup({
   totalCount = 32,
   actions = mockActions,
   disabled,
+  errorMessage,
 }: {
   selectedCount?: number;
   totalCount?: number;
   actions?: DomainBatchActionsNewActionFloatingBarActionConfig[];
   disabled?: boolean;
+  errorMessage?: string;
 }) {
   const onActionClick = jest.fn();
   const user = userEvent.setup();
@@ -77,6 +79,7 @@ function setup({
       actions={actions}
       onActionClick={onActionClick}
       disabled={disabled}
+      errorMessage={errorMessage}
     />
   );
 


### PR DESCRIPTION
## Summary

The batch actions floating bar previously showed `"{loaded} of {loaded} workflows included"` — both numbers came from the paginated list, so the "total" was only the workflows fetched so far. This PR wires up the count API from #1286 to show the real total.

### What changed

- **Detail panel** (`domain-batch-actions-new-action-detail.tsx`)
  Calls `useCountWorkflows` with the same query as the list. Passes the count to the floating bar as both `selectedCount` and `totalCount`. In query mode, these are equal because the query selects all matching workflows (there's no additional client-side filtering). Falls back to `workflows.length` while the count is loading.

- **Floating bar error handling** (`domain-batch-actions-new-action-floating-bar.tsx`)
When countWorkflows API fails, the error propagates to the listWorkflow API. Both API are coupled.


## Tests
- Detail panel: total count from count API shows correctly, error message appears when count API returns 500 (2 new tests)

> Part 3 of 3 — stack: #1285 shared schema → #1286 count API → **#1287 wire to floating bar**