### PR TITLE
feat: integrate search and status filtering into schedules page

### DIFF
--- a/src/views/domain-schedules/__tests__/domain-schedules.test.tsx
+++ b/src/views/domain-schedules/__tests__/domain-schedules.test.tsx
@@ -7,6 +7,7 @@ import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 import { type Props as LoaderProps } from '@/components/table/table-infinite-scroll-loader/table-infinite-scroll-loader.types';
 import { getMockScheduleListEntry } from '@/route-handlers/list-schedules/__fixtures__/mock-schedule-list-entries';
 import { type ListSchedulesResponse } from '@/route-handlers/list-schedules/list-schedules.types';
+import { mockDomainPageQueryParamsValues } from '@/views/domain-page/__fixtures__/domain-page-query-params';
 
 import type { Props as MSWMocksHandlersProps } from '../../../test-utils/msw-mock-handlers/msw-mock-handlers.types';
 import DomainSchedules from '../domain-schedules';
@@ -32,6 +33,14 @@ jest.mock(
     ))
 );
 
+jest.mock('../domain-schedules-header/domain-schedules-header', () =>
+  jest.fn(({ count }: { count: number | undefined }) => (
+    <div data-testid="mock-header">
+      Schedules header (count={count === undefined ? 'loading' : count})
+    </div>
+  ))
+);
+
 jest.mock('../config/schedules-table.config', () => [
   {
     name: 'Schedule Id',
@@ -41,33 +50,39 @@ jest.mock('../config/schedules-table.config', () => [
   },
 ]);
 
+const mockUsePageQueryParams = jest.fn();
+jest.mock('@/hooks/use-page-query-params/use-page-query-params', () => ({
+  __esModule: true,
+  default: (...args: Array<unknown>) => mockUsePageQueryParams(...args),
+}));
+
 describe(DomainSchedules.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUsePageQueryParams.mockReturnValue([
+      mockDomainPageQueryParamsValues,
+      jest.fn(),
+    ]);
   });
 
-  it('renders loading indicator while initial fetch is pending', () => {
+  it('renders loading indicator and a header in loading state while initial fetch is pending', () => {
     setup({ isLoading: true });
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Schedules' })).toBeDefined();
+    expect(screen.getByText(/count=loading/)).toBeInTheDocument();
   });
 
   it('renders the empty state when no schedules are returned', async () => {
     setup({ errorCase: 'no-schedules' });
 
     expect(await screen.findByText('No schedules found')).toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: 'Schedules (0)' })
-    ).toBeInTheDocument();
+    expect(screen.getByText(/count=0/)).toBeInTheDocument();
   });
 
   it('renders the title with the count and the table when schedules load', async () => {
     setup();
 
-    expect(
-      await screen.findByRole('heading', { name: /Schedules \(\d+\)/ })
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/count=2/)).toBeInTheDocument();
     expect(screen.getByText('Schedule Id')).toBeInTheDocument();
     expect(screen.getByText('mock-schedule-id-0-0')).toBeInTheDocument();
   });
@@ -75,16 +90,12 @@ describe(DomainSchedules.name, () => {
   it('updates the count after fetching the next page', async () => {
     const { user } = setup();
 
-    expect(
-      await screen.findByRole('heading', { name: 'Schedules (2)' })
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/count=2/)).toBeInTheDocument();
 
     await user.click(screen.getByTestId('mock-loader'));
 
     await waitFor(() => {
-      expect(
-        screen.getByRole('heading', { name: 'Schedules (4)' })
-      ).toBeInTheDocument();
+      expect(screen.getByText(/count=4/)).toBeInTheDocument();
     });
   });
 
@@ -99,22 +110,65 @@ describe(DomainSchedules.name, () => {
   it('still renders the table when a follow-up page fails', async () => {
     const { user } = setup({ errorCase: 'subsequent-fetch-error' });
 
-    expect(
-      await screen.findByRole('heading', { name: 'Schedules (2)' })
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/count=2/)).toBeInTheDocument();
 
     await user.click(screen.getByTestId('mock-loader'));
 
     expect(await screen.findByText('Mock end: Error')).toBeInTheDocument();
+  });
+
+  it('filters schedules by the search term and reflects the filtered count in the title', async () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        schedulesSearch: 'mock-schedule-id-0-1',
+      },
+      jest.fn(),
+    ]);
+
+    setup();
+
+    expect(await screen.findByText(/count=1/)).toBeInTheDocument();
+    expect(screen.getAllByText(/^mock-schedule-id-/)).toHaveLength(1);
+  });
+
+  it('filters schedules by the status query param', async () => {
+    mockUsePageQueryParams.mockReturnValue([
+      { ...mockDomainPageQueryParamsValues, schedulesStatus: 'PAUSED' },
+      jest.fn(),
+    ]);
+
+    setup({ pausedScheduleIndex: 1 });
+
+    expect(await screen.findByText(/count=1/)).toBeInTheDocument();
+    expect(screen.getAllByText(/^mock-schedule-id-/)).toHaveLength(1);
+  });
+
+  it('renders the no-match state when filters return no results but schedules exist', async () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        schedulesSearch: 'something-that-never-matches',
+      },
+      jest.fn(),
+    ]);
+
+    setup();
+
+    expect(
+      await screen.findByText('No schedules match your filters')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/count=0/)).toBeInTheDocument();
   });
 });
 
 function setup(opts?: {
   errorCase?: 'initial-fetch-error' | 'subsequent-fetch-error' | 'no-schedules';
   isLoading?: boolean;
+  pausedScheduleIndex?: number;
 }) {
-  const { errorCase, isLoading } = opts ?? {};
-  const pages = generateSchedulePages(2);
+  const { errorCase, isLoading, pausedScheduleIndex } = opts ?? {};
+  const pages = generateSchedulePages(2, pausedScheduleIndex);
   let currentEventIndex = 0;
   const user = userEvent.setup();
 
@@ -169,7 +223,10 @@ function setup(opts?: {
   return { user };
 }
 
-function generateSchedulePages(count: number): Array<ListSchedulesResponse> {
+function generateSchedulePages(
+  count: number,
+  pausedScheduleIndex?: number
+): Array<ListSchedulesResponse> {
   const pages = Array.from(
     { length: count },
     (_, pageIndex): ListSchedulesResponse => ({
@@ -177,6 +234,10 @@ function generateSchedulePages(count: number): Array<ListSchedulesResponse> {
         getMockScheduleListEntry({
           scheduleId: `mock-schedule-id-${pageIndex}-${index}`,
           workflowType: { name: `mock-workflow-name-${pageIndex}-${index}` },
+          state: {
+            paused: index === pausedScheduleIndex,
+            pauseInfo: null,
+          },
         })
       ),
       nextPageToken: `${pageIndex + 1}`,

--- a/src/views/domain-schedules/domain-schedules-header/__tests__/domain-schedules-header.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-header/__tests__/domain-schedules-header.test.tsx
@@ -11,11 +11,6 @@ jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
   jest.fn(() => [mockDomainPageQueryParamsValues, mockSetQueryParams])
 );
 
-jest.mock('@/components/page-filters/page-filters', () => ({
-  __esModule: true,
-  default: jest.fn(() => <div data-testid="mock-page-filters" />),
-}));
-
 describe(DomainSchedulesHeader.name, () => {
   it('renders the title without count when count is undefined', () => {
     render(<DomainSchedulesHeader count={undefined} />);
@@ -41,9 +36,11 @@ describe(DomainSchedulesHeader.name, () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the page filters slot', () => {
+  it('renders the page filters search input', () => {
     render(<DomainSchedulesHeader count={0} />);
 
-    expect(screen.getByTestId('mock-page-filters')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Find schedule by ID or workflow type')
+    ).toBeInTheDocument();
   });
 });

--- a/src/views/domain-schedules/domain-schedules.styles.ts
+++ b/src/views/domain-schedules/domain-schedules.styles.ts
@@ -12,23 +12,4 @@ export const styled = {
       marginBottom: $theme.sizing.scale900,
     })
   ),
-  Toolbar: createStyled(
-    'div',
-    ({ $theme }: { $theme: Theme }): StyleObject => ({
-      display: 'flex',
-      flexWrap: 'wrap',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      gap: $theme.sizing.scale600,
-    })
-  ),
-  ToolbarTitle: createStyled(
-    'h2',
-    ({ $theme }: { $theme: Theme }): StyleObject => ({
-      ...$theme.typography.HeadingXSmall,
-      color: $theme.colors.contentPrimary,
-      marginTop: 0,
-      marginBottom: 0,
-    })
-  ),
 };

--- a/src/views/domain-schedules/domain-schedules.tsx
+++ b/src/views/domain-schedules/domain-schedules.tsx
@@ -8,12 +8,16 @@ import ErrorPanel from '@/components/error-panel/error-panel';
 import PanelSection from '@/components/panel-section/panel-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import Table from '@/components/table/table';
+import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
+import domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-query-params.config';
 import useListSchedules from '@/views/shared/hooks/use-list-schedules/use-list-schedules';
 
 import schedulesTableConfig from './config/schedules-table.config';
+import DomainSchedulesHeader from './domain-schedules-header/domain-schedules-header';
 import { SCHEDULES_PAGE_SIZE } from './domain-schedules.constants';
 import { styled } from './domain-schedules.styles';
 import { type Props } from './domain-schedules.types';
+import filterSchedules from './helpers/filter-schedules';
 
 export default function DomainSchedules({ domain, cluster }: Props) {
   const {
@@ -30,12 +34,28 @@ export default function DomainSchedules({ domain, cluster }: Props) {
     pageSize: SCHEDULES_PAGE_SIZE,
   });
 
+  const [queryParams] = usePageQueryParams(domainPageQueryParamsConfig, {
+    pageRerender: false,
+  });
+
   const schedules = useMemo(
     () => data?.pages.flatMap((page) => page.schedules ?? []) ?? [],
     [data]
   );
 
-  const title = isLoading ? 'Schedules' : `Schedules (${schedules.length})`;
+  const filteredSchedules = useMemo(
+    () =>
+      filterSchedules({
+        schedules,
+        search: queryParams.schedulesSearch,
+        status: queryParams.schedulesStatus,
+      }),
+    [schedules, queryParams.schedulesSearch, queryParams.schedulesStatus]
+  );
+
+  const hasActiveFilters = Boolean(
+    queryParams.schedulesSearch || queryParams.schedulesStatus
+  );
 
   let content;
   if (isLoading) {
@@ -71,10 +91,20 @@ export default function DomainSchedules({ domain, cluster }: Props) {
         />
       </PanelSection>
     );
+  } else if (filteredSchedules.length === 0 && hasActiveFilters) {
+    content = (
+      <PanelSection>
+        <ErrorPanel
+          message="No schedules match your filters"
+          description="Try changing the search term or clearing the filters."
+          omitLogging={true}
+        />
+      </PanelSection>
+    );
   } else {
     content = (
       <Table
-        data={schedules}
+        data={filteredSchedules}
         shouldShowResults
         endMessageProps={{
           kind: 'infinite-scroll',
@@ -91,9 +121,9 @@ export default function DomainSchedules({ domain, cluster }: Props) {
 
   return (
     <styled.Root>
-      <styled.Toolbar>
-        <styled.ToolbarTitle>{title}</styled.ToolbarTitle>
-      </styled.Toolbar>
+      <DomainSchedulesHeader
+        count={isLoading ? undefined : filteredSchedules.length}
+      />
       {content}
     </styled.Root>
   );

--- a/src/views/domain-schedules/helpers/__tests__/filter-schedules.test.ts
+++ b/src/views/domain-schedules/helpers/__tests__/filter-schedules.test.ts
@@ -1,0 +1,91 @@
+import { getMockScheduleListEntry } from '@/route-handlers/list-schedules/__fixtures__/mock-schedule-list-entries';
+
+import filterSchedules from '../filter-schedules';
+
+const runningOrder = getMockScheduleListEntry({
+  scheduleId: 'order-running',
+  workflowType: { name: 'OrderWorkflow' },
+  state: { paused: false, pauseInfo: null },
+});
+
+const pausedPayment = getMockScheduleListEntry({
+  scheduleId: 'payment-paused',
+  workflowType: { name: 'PaymentWorkflow' },
+  state: { paused: true, pauseInfo: null },
+});
+
+const runningPayment = getMockScheduleListEntry({
+  scheduleId: 'payment-running',
+  workflowType: { name: 'PaymentWorkflow' },
+  state: { paused: false, pauseInfo: null },
+});
+
+const schedules = [runningOrder, pausedPayment, runningPayment];
+
+describe('filterSchedules', () => {
+  it('returns all schedules when there are no filters', () => {
+    expect(filterSchedules({ schedules })).toEqual(schedules);
+  });
+
+  it('filters by schedule id (case insensitive, partial match)', () => {
+    expect(filterSchedules({ schedules, search: 'ORDER' })).toEqual([
+      runningOrder,
+    ]);
+  });
+
+  it('filters by workflow type name (case insensitive, partial match)', () => {
+    expect(filterSchedules({ schedules, search: 'payment' })).toEqual([
+      pausedPayment,
+      runningPayment,
+    ]);
+  });
+
+  it('ignores empty/whitespace-only search', () => {
+    expect(filterSchedules({ schedules, search: '   ' })).toEqual(schedules);
+  });
+
+  it('filters by paused status', () => {
+    expect(filterSchedules({ schedules, status: 'PAUSED' })).toEqual([
+      pausedPayment,
+    ]);
+  });
+
+  it('filters by running status', () => {
+    expect(filterSchedules({ schedules, status: 'RUNNING' })).toEqual([
+      runningOrder,
+      runningPayment,
+    ]);
+  });
+
+  it('combines search and status filters', () => {
+    expect(
+      filterSchedules({
+        schedules,
+        search: 'payment',
+        status: 'RUNNING',
+      })
+    ).toEqual([runningPayment]);
+  });
+
+  it('returns an empty array when nothing matches', () => {
+    expect(filterSchedules({ schedules, search: 'no-match' })).toEqual([]);
+  });
+
+  it('handles schedules with missing workflow type or state', () => {
+    const partial = getMockScheduleListEntry({
+      scheduleId: 'partial-schedule',
+      workflowType: null,
+      state: null,
+    });
+
+    expect(
+      filterSchedules({ schedules: [partial], search: 'partial' })
+    ).toEqual([partial]);
+    expect(
+      filterSchedules({ schedules: [partial], status: 'RUNNING' })
+    ).toEqual([partial]);
+    expect(filterSchedules({ schedules: [partial], status: 'PAUSED' })).toEqual(
+      []
+    );
+  });
+});

--- a/src/views/domain-schedules/helpers/filter-schedules.ts
+++ b/src/views/domain-schedules/helpers/filter-schedules.ts
@@ -1,0 +1,35 @@
+import { type ScheduleListEntry } from '@/route-handlers/list-schedules/list-schedules.types';
+
+import { type DomainSchedulesStatus } from '../domain-schedules.types';
+
+export default function filterSchedules({
+  schedules,
+  search,
+  status,
+}: {
+  schedules: Array<ScheduleListEntry>;
+  search?: string;
+  status?: DomainSchedulesStatus;
+}): Array<ScheduleListEntry> {
+  let filtered = schedules;
+
+  if (status === 'PAUSED') {
+    filtered = filtered.filter((s) => Boolean(s.state?.paused));
+  } else if (status === 'RUNNING') {
+    filtered = filtered.filter((s) => !s.state?.paused);
+  }
+
+  const trimmedSearch = search?.trim().toLowerCase();
+  if (trimmedSearch) {
+    filtered = filtered.filter((s) => {
+      const scheduleId = s.scheduleId?.toLowerCase() ?? '';
+      const workflowTypeName = s.workflowType?.name?.toLowerCase() ?? '';
+      return (
+        scheduleId.includes(trimmedSearch) ||
+        workflowTypeName.includes(trimmedSearch)
+      );
+    });
+  }
+
+  return filtered;
+}


### PR DESCRIPTION
## Summary

Integrates client-side search and status filtering into the domain schedules page. Previously the schedules list had no filtering capability — users had to scroll through all entries to find a specific schedule. This change wires the existing `DomainSchedulesHeader` filters (search input and status dropdown) into the schedules list by reading `schedulesSearch` and `schedulesStatus` query params and applying a `filterSchedules` helper client-side.

## Changes

- **`domain-schedules.tsx`** — Reads `schedulesSearch` and `schedulesStatus` query params via `usePageQueryParams`, applies `filterSchedules` to the loaded schedules, passes the filtered count to `DomainSchedulesHeader`, and shows an empty-state `ErrorPanel` when active filters produce no results. Replaced the inline toolbar/title markup with `DomainSchedulesHeader`.
- **`helpers/filter-schedules.ts`** — New helper that filters a `ScheduleListEntry[]` by status (`PAUSED` / `RUNNING`) and by a case-insensitive search term matched against `scheduleId` and `workflowType.name`.
- **`helpers/is-domain-schedules-status.ts`** — Type guard (`isDomainSchedulesStatus`) for the `DomainSchedulesStatus` union, used by the query-params config.
- **`domain-schedules.styles.ts`** — Removed `Toolbar` and `ToolbarTitle` styled components that were only used by the inline title, now superseded by `DomainSchedulesHeader`.
- Tests updated/added for `DomainSchedules`, `filterSchedules`, and `isDomainSchedulesStatus`.

No new dependencies added. No breaking changes to props or APIs. The filtering is purely client-side over the already-fetched pages; no changes to gRPC calls or route handlers.

## Testing

https://github.com/user-attachments/assets/caaa796d-23ce-4f3f-b6d6-77a7118795e9


## Feature plans

- Schedules List
    - #1270
    - #1275 
    - #1276
    - #1283
    - #1290
    - #1291
    - #1292
    - #1294
    - #1295
- Schedules Create Form
- Schedules Details
- Schedules Actions
- Schedules Backfills

