### PR TITLE
feat: Add useStartBatchAction hook and batcher payload builder

### DIFF
--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -7,7 +7,7 @@ export const BATCH_ACTION_RPS_DEFAULT = 100;
 export const BATCH_ACTION_BATCHER_DOMAIN = 'cadence-batcher';
 export const BATCH_ACTION_WORKFLOW_TYPE = 'cadence-sys-batch-workflow-v2';
 export const BATCH_ACTION_TASK_LIST = 'cadence-sys-batcher-tasklist';
-export const BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS = 24 * 60 * 60;
+export const BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS = 20 * 365 * 24 * 60 * 60;
 
 // TODO: Replace with real API data
 export const MOCK_BATCH_ACTIONS: BatchAction[] = [

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -4,6 +4,11 @@ export const DRAFT_ACTION_ID = 'draft';
 
 export const BATCH_ACTION_RPS_DEFAULT = 100;
 
+export const BATCH_ACTION_BATCHER_DOMAIN = 'cadence-batcher';
+export const BATCH_ACTION_WORKFLOW_TYPE = 'cadence-sys-batch-workflow-v2';
+export const BATCH_ACTION_TASK_LIST = 'cadence-sys-batcher-tasklist';
+export const BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS = 24 * 60 * 60;
+
 // TODO: Replace with real API data
 export const MOCK_BATCH_ACTIONS: BatchAction[] = [
   {

--- a/src/views/domain-batch-actions/helpers/__tests__/build-batch-action-payload.test.ts
+++ b/src/views/domain-batch-actions/helpers/__tests__/build-batch-action-payload.test.ts
@@ -1,0 +1,49 @@
+import buildBatchActionPayload from '../build-batch-action-payload';
+
+describe('buildBatchActionPayload', () => {
+  it('builds a payload with the basic fields and no SignalParams for non-signal actions', () => {
+    expect(
+      buildBatchActionPayload({
+        domain: 'cadence-samples',
+        query: 'WorkflowType="foo"',
+        reason: 'cleanup',
+        rps: 50,
+        batchType: 'terminate',
+      })
+    ).toEqual({
+      DomainName: 'cadence-samples',
+      Query: 'WorkflowType="foo"',
+      Reason: 'cleanup',
+      BatchType: 'terminate',
+      RPS: 50,
+    });
+  });
+
+  it('includes SignalParams when batchType is signal', () => {
+    const payload = buildBatchActionPayload({
+      domain: 'cadence-samples',
+      query: 'WorkflowType="foo"',
+      reason: 'send signal',
+      rps: 10,
+      batchType: 'signal',
+      signalParams: { signalName: 'mySignal', signalInput: '{"k":"v"}' },
+    });
+
+    expect(payload.SignalParams).toEqual({
+      SignalName: 'mySignal',
+      Input: '{"k":"v"}',
+    });
+  });
+
+  it('omits SignalParams when batchType is signal but signalParams is missing', () => {
+    const payload = buildBatchActionPayload({
+      domain: 'cadence-samples',
+      query: 'WorkflowType="foo"',
+      reason: 'send signal',
+      rps: 10,
+      batchType: 'signal',
+    });
+
+    expect(payload.SignalParams).toBeUndefined();
+  });
+});

--- a/src/views/domain-batch-actions/helpers/__tests__/build-batch-action-payload.test.ts
+++ b/src/views/domain-batch-actions/helpers/__tests__/build-batch-action-payload.test.ts
@@ -1,7 +1,7 @@
 import buildBatchActionPayload from '../build-batch-action-payload';
 
 describe('buildBatchActionPayload', () => {
-  it('builds a payload with the basic fields and no SignalParams for non-signal actions', () => {
+  it('build a payload with the basic fields and no SignalParams for non-signal actions', () => {
     expect(
       buildBatchActionPayload({
         domain: 'cadence-samples',

--- a/src/views/domain-batch-actions/helpers/build-batch-action-payload.ts
+++ b/src/views/domain-batch-actions/helpers/build-batch-action-payload.ts
@@ -1,0 +1,28 @@
+import {
+  type BatchActionPayload,
+  type BuildBatchActionPayloadParams,
+} from '../hooks/use-start-batch-action.types';
+
+export default function buildBatchActionPayload({
+  domain,
+  query,
+  reason,
+  rps,
+  batchType,
+  signalParams,
+}: BuildBatchActionPayloadParams): BatchActionPayload {
+  return {
+    DomainName: domain,
+    Query: query,
+    Reason: reason,
+    BatchType: batchType,
+    RPS: rps,
+    ...(batchType === 'signal' &&
+      signalParams && {
+        SignalParams: {
+          SignalName: signalParams.signalName,
+          Input: signalParams.signalInput ?? '',
+        },
+      }),
+  };
+}

--- a/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
@@ -1,0 +1,99 @@
+import { HttpResponse } from 'msw';
+
+import { renderHook, waitFor } from '@/test-utils/rtl';
+
+import useStartBatchAction from '../use-start-batch-action';
+import { type BuildBatchActionPayloadParams } from '../use-start-batch-action.types';
+
+describe(useStartBatchAction.name, () => {
+  it('posts to the cadence-batcher start route with the wrapped BatchParams payload', async () => {
+    const { result, getLatestRequest } = setup();
+
+    result.current.mutate({
+      domain: 'cadence-samples',
+      query: 'WorkflowType="foo"',
+      reason: 'cleanup',
+      rps: 50,
+      batchType: 'terminate',
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const req = getLatestRequest();
+    expect(req.url).toBe(
+      '/api/domains/cadence-batcher/cluster0/workflows/start'
+    );
+    expect(req.body).toEqual({
+      workflowType: { name: 'cadence-sys-batch-workflow-v2' },
+      taskList: { name: 'cadence-sys-batcher-tasklist' },
+      // Single-element top-level array so the GO branch of processWorkflowInput
+      // emits exactly the BatchParams JSON object.
+      input: [
+        {
+          DomainName: 'cadence-samples',
+          Query: 'WorkflowType="foo"',
+          Reason: 'cleanup',
+          BatchType: 'terminate',
+          RPS: 50,
+        },
+      ],
+      workerSDKLanguage: 'GO',
+      executionStartToCloseTimeoutSeconds: 24 * 60 * 60,
+    });
+    expect(result.current.data).toEqual({
+      workflowId: 'wf-1',
+      runId: 'run-1',
+    });
+  });
+
+  it('surfaces errors from the start route', async () => {
+    const { result } = setup({ error: true });
+
+    result.current.mutate({
+      domain: 'cadence-samples',
+      query: 'WorkflowType="foo"',
+      reason: 'cleanup',
+      rps: 50,
+      batchType: 'terminate',
+    } satisfies BuildBatchActionPayloadParams);
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error?.message).toBe('Failed to start');
+  });
+});
+
+function setup({ error = false }: { error?: boolean } = {}) {
+  let latestRequest: { url: string; body: unknown } = { url: '', body: null };
+
+  const utils = renderHook(() => useStartBatchAction({ cluster: 'cluster0' }), {
+    endpointsMocks: [
+      {
+        path: '/api/domains/:domain/:cluster/workflows/start',
+        httpMethod: 'POST',
+        mockOnce: false,
+        httpResolver: async ({ request }) => {
+          const text = await request.text();
+          latestRequest = {
+            url: new URL(request.url).pathname,
+            body: text ? JSON.parse(text) : null,
+          };
+
+          if (error) {
+            return HttpResponse.json(
+              { message: 'Failed to start' },
+              { status: 500 }
+            );
+          }
+
+          return HttpResponse.json({ workflowId: 'wf-1', runId: 'run-1' });
+        },
+      },
+    ],
+  });
+
+  return { ...utils, getLatestRequest: () => latestRequest };
+}

--- a/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
@@ -40,7 +40,7 @@ describe(useStartBatchAction.name, () => {
         },
       ],
       workerSDKLanguage: 'GO',
-      executionStartToCloseTimeoutSeconds: 24 * 60 * 60,
+      executionStartToCloseTimeoutSeconds: 20 * 365 * 24 * 60 * 60,
     });
     expect(result.current.data).toEqual({
       workflowId: 'wf-1',

--- a/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
+++ b/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
+
+import {
+  BATCH_ACTION_BATCHER_DOMAIN,
+  BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS,
+  BATCH_ACTION_TASK_LIST,
+  BATCH_ACTION_WORKFLOW_TYPE,
+} from '../domain-batch-actions.constants';
+import buildBatchActionPayload from '../helpers/build-batch-action-payload';
+
+import {
+  type BuildBatchActionPayloadParams,
+  type StartBatchActionResponse,
+  type UseStartBatchActionParams,
+} from './use-start-batch-action.types';
+
+export default function useStartBatchAction({
+  cluster,
+}: UseStartBatchActionParams) {
+  return useMutation<
+    StartBatchActionResponse,
+    RequestError,
+    BuildBatchActionPayloadParams
+  >({
+    mutationFn: (input) => {
+      const batchParams = buildBatchActionPayload(input);
+      return request(
+        `/api/domains/${encodeURIComponent(BATCH_ACTION_BATCHER_DOMAIN)}/${encodeURIComponent(cluster)}/workflows/start`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            workflowType: { name: BATCH_ACTION_WORKFLOW_TYPE },
+            taskList: { name: BATCH_ACTION_TASK_LIST },
+            // The batcher workflow signature is `(ctx, params BatchParams)` — a
+            // single struct. We pass it as a one-element top-level array so
+            // processWorkflowInput's GO branch (input.map(JSON.stringify).join(' '))
+            // emits exactly '{...batchParams}'.
+            input: [batchParams],
+            workerSDKLanguage: 'GO',
+            executionStartToCloseTimeoutSeconds:
+              BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS,
+          }),
+        }
+      ).then((res): Promise<StartBatchActionResponse> => res.json());
+    },
+  });
+}

--- a/src/views/domain-batch-actions/hooks/use-start-batch-action.types.ts
+++ b/src/views/domain-batch-actions/hooks/use-start-batch-action.types.ts
@@ -1,0 +1,33 @@
+import { type SignalWorkflowFormData } from '@/views/workflow-actions/workflow-action-signal-form/workflow-action-signal-form.types';
+
+import { type BatchActionConfirmableType } from '../domain-batch-actions.types';
+
+export type UseStartBatchActionParams = {
+  cluster: string;
+};
+
+export type BuildBatchActionPayloadParams = {
+  domain: string;
+  query: string;
+  reason: string;
+  rps: number;
+  batchType: BatchActionConfirmableType;
+  signalParams?: SignalWorkflowFormData;
+};
+
+export type BatchActionPayload = {
+  DomainName: string;
+  Query: string;
+  Reason: string;
+  BatchType: BatchActionConfirmableType;
+  RPS: number;
+  SignalParams?: {
+    SignalName: string;
+    Input: string;
+  };
+};
+
+export type StartBatchActionResponse = {
+  workflowId: string;
+  runId: string;
+};

--- a/src/views/shared/hooks/use-count-workflows.ts
+++ b/src/views/shared/hooks/use-count-workflows.ts
@@ -21,7 +21,7 @@ export default function useCountWorkflows({
     queryFn: async () =>
       request(
         queryString.stringifyUrl({
-          url: `/api/domains/${domain}/${cluster}/workflows/count`,
+          url: `/api/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows/count`,
           query: {
             inputType: 'query',
             listType: 'default',


### PR DESCRIPTION
Stacked on top of #1289.

## Summary
- New constants for the Cadence batcher: domain (`cadence-batcher`), workflow type (`cadence-sys-batch-workflow-v2`), task list, execution timeout
- `buildBatchActionPayload` pure helper that assembles the `BatchParams` object (DomainName, Query, Reason, BatchType, RPS, optional SignalParams when batchType is signal)
- `useStartBatchAction` TanStack Query mutation that posts to the existing `/api/domains/[domain]/[cluster]/workflows/start` route — single-element `input` array + `workerSDKLanguage: 'GO'` so `processWorkflowInput` emits the JSON-encoded `BatchParams` the Go batcher expects

No UI behaviour changes. Foundation for the wiring PR that follows.

## Test plan
- Unit tests for `buildBatchActionPayload` and `useStartBatchAction`