### PR TITLE
feat: Add createSchedule cluster method

### DIFF
--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -3,6 +3,8 @@ import { type DescribeClusterResponse } from '@/__generated__/proto-ts/uber/cade
 import { type DescribeWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/admin/v1/DescribeWorkflowExecutionRequest';
 import { type CountWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/CountWorkflowExecutionsRequest';
 import { type CountWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/CountWorkflowExecutionsResponse';
+import { type CreateScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/CreateScheduleRequest';
+import { type CreateScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/CreateScheduleResponse';
 import { type DescribeDomainRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainRequest';
 import { type DescribeDomainResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainResponse';
 import { type DescribeTaskListRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeTaskListRequest';
@@ -75,6 +77,9 @@ export type GRPCClusterMethods = {
   countWorkflows: (
     payload: CountWorkflowExecutionsRequest__Input
   ) => Promise<CountWorkflowExecutionsResponse>;
+  createSchedule: (
+    payload: CreateScheduleRequest__Input
+  ) => Promise<CreateScheduleResponse>;
   describeCluster: (
     payload: DescribeClusterRequest__Input
   ) => Promise<DescribeClusterResponse>;
@@ -241,6 +246,13 @@ const getClusterServicesMethods = async (
       CountWorkflowExecutionsResponse
     >({
       method: 'CountWorkflowExecutions',
+      metadata: metadata,
+    }),
+    createSchedule: scheduleService.request<
+      CreateScheduleRequest__Input,
+      CreateScheduleResponse
+    >({
+      method: 'CreateSchedule',
       metadata: metadata,
     }),
     describeCluster: adminService.request<

--- a/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
@@ -4,6 +4,7 @@ export const mockGrpcClusterMethods: GRPCClusterMethods = {
   archivedWorkflows: jest.fn(),
   closedWorkflows: jest.fn(),
   countWorkflows: jest.fn(),
+  createSchedule: jest.fn(),
   describeCluster: jest.fn(),
   describeDomain: jest.fn(),
   updateDomain: jest.fn(),


### PR DESCRIPTION
## Summary

Wiring Cadence Schedule API `CreateSchedule` RPC into `GRPCClusterMethods` so the follow-up PR can use to expose create `POST /api/domains/{domain}/{cluster}/schedules`.

## Changes

- Add `createSchedule` to `GRPCClusterMethods` and implement it via `scheduleService` (`CreateSchedule` method).
- Extend `mockGrpcClusterMethods` with a `createSchedule` jest mock.

## Testing

- `npm run typecheck`
- `npm run lint` 


## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- Schedules Create Form
   - #1302
- Schedules Details
- Schedules Actions
- Schedules Backfills

