### PR TITLE
feat(schedules): add useCreateSchedule mutation hook with invalidation

### DIFF
--- a/src/route-handlers/create-schedule/__fixtures__/create-schedule-request-body.ts
+++ b/src/route-handlers/create-schedule/__fixtures__/create-schedule-request-body.ts
@@ -1,0 +1,14 @@
+import { type CreateScheduleRequestBody } from '../create-schedule.types';
+
+export const mockCreateScheduleRequestBody: CreateScheduleRequestBody = {
+  scheduleId: 'my-schedule',
+  cronExpression: '0 9 * * *',
+  startWorkflow: {
+    workflowType: { name: 'DemoWorkflow' },
+    taskList: { name: 'demo-task-list' },
+    workerSDKLanguage: 'GO',
+    workflowIdPrefix: 'scheduled-demo-',
+    executionStartToCloseTimeoutSeconds: 3600,
+    taskStartToCloseTimeoutSeconds: 30,
+  },
+};

--- a/src/route-handlers/create-schedule/__tests__/create-schedule.node.ts
+++ b/src/route-handlers/create-schedule/__tests__/create-schedule.node.ts
@@ -7,32 +7,19 @@ import { GRPCError } from '@/utils/grpc/grpc-error';
 import logger from '@/utils/logger';
 import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
 
+import { mockCreateScheduleRequestBody } from '../__fixtures__/create-schedule-request-body';
 import { createSchedule } from '../create-schedule';
 import { type Context, type RequestParams } from '../create-schedule.types';
 
 jest.mock('@/utils/logger');
 
-const validScheduleCreateFields = {
-  cronExpression: '0 9 * * *',
-  startWorkflow: {
-    workflowType: { name: 'DemoWorkflow' },
-    taskList: { name: 'demo-task-list' },
-    workerSDKLanguage: 'GO' as const,
-    workflowIdPrefix: 'scheduled-demo-',
-    executionStartToCloseTimeoutSeconds: 3600,
-    taskStartToCloseTimeoutSeconds: 30,
-  },
-};
-
 function getValidRequestBody() {
-  return {
-    scheduleId: 'my-schedule',
-    ...validScheduleCreateFields,
-  };
+  return { ...mockCreateScheduleRequestBody };
 }
 
 function getValidRequestBodyWithoutScheduleId() {
-  return { ...validScheduleCreateFields };
+  const { scheduleId: _, ...rest } = mockCreateScheduleRequestBody;
+  return rest;
 }
 
 describe(createSchedule.name, () => {

--- a/src/views/shared/hooks/use-create-schedule/__tests__/use-create-schedule.test.tsx
+++ b/src/views/shared/hooks/use-create-schedule/__tests__/use-create-schedule.test.tsx
@@ -1,91 +1,45 @@
+import { QueryClient } from '@tanstack/react-query';
 import { act } from '@testing-library/react';
-
-import { useQueryClient } from '@tanstack/react-query';
 import { HttpResponse } from 'msw';
 
 import { renderHook, waitFor } from '@/test-utils/rtl';
 
-import useCreateSchedule from '../use-create-schedule';
-import { type UseCreateScheduleVariables } from '../use-create-schedule.types';
+import { mockCreateScheduleRequestBody } from '@/route-handlers/create-schedule/__fixtures__/create-schedule-request-body';
 
-jest.mock('@tanstack/react-query', () => ({
-  ...jest.requireActual('@tanstack/react-query'),
-  useQueryClient: jest.fn(),
-}));
+import useCreateSchedule from '../use-create-schedule';
 
 const MOCK_DOMAIN = 'test-domain';
 const MOCK_CLUSTER = 'test-cluster';
 
-const VALID_CREATE_SCHEDULE_BODY: UseCreateScheduleVariables = {
-  scheduleId: 'my-schedule',
-  spec: {
-    cronExpression: '0 9 * * *',
-  },
-  action: {
-    startWorkflow: {
-      workflowType: { name: 'DemoWorkflow' },
-      taskList: { name: 'demo-task-list' },
-      workerSDKLanguage: 'GO',
-      workflowIdPrefix: 'scheduled-demo-',
-      executionStartToCloseTimeoutSeconds: 3600,
-    },
-  },
-};
-
 describe(useCreateSchedule.name, () => {
-  let mockInvalidateQueries: jest.Mock;
+  it('sends a POST request to the correct schedules endpoint with the mutation variables', async () => {
+    const { result, getLatestRequest } = setup({});
 
-  beforeEach(() => {
-    mockInvalidateQueries = jest.fn();
-    (useQueryClient as jest.Mock).mockReturnValue({
-      invalidateQueries: mockInvalidateQueries,
-    });
-  });
-
-  it('exposes isPending as false initially', () => {
-    const { result } = setup({});
-
-    expect(result.current.isPending).toBe(false);
-  });
-
-  it('sets isPending to true while mutation is in-flight', async () => {
-    let resolveRequest: (() => void) | undefined;
-    const blockingPromise = new Promise<void>((resolve) => {
-      resolveRequest = resolve;
+    await act(async () => {
+      await result.current.mutateAsync(mockCreateScheduleRequestBody);
     });
 
-    const { result } = setup({
-      httpResolver: async () => {
-        await blockingPromise;
-        return HttpResponse.json({});
-      },
-    });
-
-    act(() => {
-      result.current.mutate(VALID_CREATE_SCHEDULE_BODY);
-    });
-
-    await waitFor(() => {
-      expect(result.current.isPending).toBe(true);
-    });
-
-    act(() => {
-      resolveRequest?.();
-    });
-
-    await waitFor(() => {
-      expect(result.current.isPending).toBe(false);
-    });
+    const req = getLatestRequest();
+    expect(req.url).toBe(
+      `/api/domains/${MOCK_DOMAIN}/${MOCK_CLUSTER}/schedules`
+    );
+    expect(req.method).toBe('POST');
+    expect(req.body).toEqual(mockCreateScheduleRequestBody);
   });
 
   it('invalidates listSchedules queries on success', async () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
     const { result } = setup({});
 
     await act(async () => {
-      await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+      await result.current.mutateAsync(mockCreateScheduleRequestBody);
     });
 
-    expect(mockInvalidateQueries).toHaveBeenCalledWith(
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         queryKey: [
           'listSchedules',
@@ -95,106 +49,12 @@ describe(useCreateSchedule.name, () => {
     );
   });
 
-  it('sets isSuccess to true after successful mutation', async () => {
-    const { result } = setup({});
-
-    await act(async () => {
-      await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
-    });
-
-    expect(result.current.isSuccess).toBe(true);
-  });
-
-  it('surfaces error from API on 400 failure', async () => {
-    const { result } = setup({
-      httpResolver: async () =>
-        HttpResponse.json(
-          {
-            message: 'Invalid values provided for schedule create',
-            validationErrors: [
-              { code: 'too_small', path: ['scheduleId'], message: 'Too small' },
-            ],
-          },
-          { status: 400 }
-        ),
-    });
-
-    await act(async () => {
-      try {
-        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
-      } catch {
-        // expected to throw
-      }
-    });
-
-    await waitFor(() => {
-      expect(result.current.error).not.toBeNull();
-    });
-
-    expect(result.current.error?.status).toBe(400);
-    expect(result.current.error?.message).toBe(
-      'Invalid values provided for schedule create'
-    );
-    expect(result.current.error?.validationErrors).toHaveLength(1);
-  });
-
-  it('surfaces error from API on 409 conflict', async () => {
-    const { result } = setup({
-      httpResolver: async () =>
-        HttpResponse.json(
-          { message: 'Schedule already exists' },
-          { status: 409 }
-        ),
-    });
-
-    await act(async () => {
-      try {
-        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
-      } catch {
-        // expected to throw
-      }
-    });
-
-    await waitFor(() => {
-      expect(result.current.error).not.toBeNull();
-    });
-
-    expect(result.current.error?.status).toBe(409);
-    expect(result.current.error?.message).toBe('Schedule already exists');
-  });
-
-  it('resets mutation state after calling reset()', async () => {
-    const { result } = setup({
-      httpResolver: async () =>
-        HttpResponse.json(
-          { message: 'Schedule already exists' },
-          { status: 409 }
-        ),
-    });
-
-    await act(async () => {
-      try {
-        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
-      } catch {
-        // expected to throw
-      }
-    });
-
-    await waitFor(() => {
-      expect(result.current.error).not.toBeNull();
-    });
-
-    await act(async () => {
-      result.current.reset();
-    });
-
-    await waitFor(() => {
-      expect(result.current.error).toBeNull();
-    });
-    expect(result.current.isSuccess).toBe(false);
-  });
-
   it('does not invalidate queries on failure', async () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
     const { result } = setup({
       httpResolver: async () =>
         HttpResponse.json(
@@ -205,7 +65,7 @@ describe(useCreateSchedule.name, () => {
 
     await act(async () => {
       try {
-        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+        await result.current.mutateAsync(mockCreateScheduleRequestBody);
       } catch {
         // expected to throw
       }
@@ -215,16 +75,26 @@ describe(useCreateSchedule.name, () => {
       expect(result.current.error).not.toBeNull();
     });
 
-    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
   });
 });
 
 function setup({
   httpResolver,
 }: {
-  httpResolver?: () => ReturnType<typeof HttpResponse.json> | Promise<ReturnType<typeof HttpResponse.json>>;
+  httpResolver?: (args: {
+    request: Request;
+  }) =>
+    | ReturnType<typeof HttpResponse.json>
+    | Promise<ReturnType<typeof HttpResponse.json>>;
 } = {}) {
-  const { result } = renderHook(
+  let latestRequest: { url: string; method: string; body: unknown } = {
+    url: '',
+    method: '',
+    body: null,
+  };
+
+  const utils = renderHook(
     () => useCreateSchedule({ domain: MOCK_DOMAIN, cluster: MOCK_CLUSTER }),
     {
       endpointsMocks: [
@@ -232,11 +102,21 @@ function setup({
           path: `/api/domains/${MOCK_DOMAIN}/${MOCK_CLUSTER}/schedules`,
           httpMethod: 'POST',
           mockOnce: false,
-          httpResolver: httpResolver ?? (async () => HttpResponse.json({})),
+          httpResolver:
+            httpResolver ??
+            (async ({ request }) => {
+              const url = new URL(request.url);
+              latestRequest = {
+                url: url.pathname,
+                method: request.method,
+                body: await request.json(),
+              };
+              return HttpResponse.json({});
+            }),
         },
       ],
     }
   );
 
-  return { result };
+  return { ...utils, getLatestRequest: () => latestRequest };
 }

--- a/src/views/shared/hooks/use-create-schedule/__tests__/use-create-schedule.test.tsx
+++ b/src/views/shared/hooks/use-create-schedule/__tests__/use-create-schedule.test.tsx
@@ -1,0 +1,242 @@
+import { act } from '@testing-library/react';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { HttpResponse } from 'msw';
+
+import { renderHook, waitFor } from '@/test-utils/rtl';
+
+import useCreateSchedule from '../use-create-schedule';
+import { type UseCreateScheduleVariables } from '../use-create-schedule.types';
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQueryClient: jest.fn(),
+}));
+
+const MOCK_DOMAIN = 'test-domain';
+const MOCK_CLUSTER = 'test-cluster';
+
+const VALID_CREATE_SCHEDULE_BODY: UseCreateScheduleVariables = {
+  scheduleId: 'my-schedule',
+  spec: {
+    cronExpression: '0 9 * * *',
+  },
+  action: {
+    startWorkflow: {
+      workflowType: { name: 'DemoWorkflow' },
+      taskList: { name: 'demo-task-list' },
+      workerSDKLanguage: 'GO',
+      workflowIdPrefix: 'scheduled-demo-',
+      executionStartToCloseTimeoutSeconds: 3600,
+    },
+  },
+};
+
+describe(useCreateSchedule.name, () => {
+  let mockInvalidateQueries: jest.Mock;
+
+  beforeEach(() => {
+    mockInvalidateQueries = jest.fn();
+    (useQueryClient as jest.Mock).mockReturnValue({
+      invalidateQueries: mockInvalidateQueries,
+    });
+  });
+
+  it('exposes isPending as false initially', () => {
+    const { result } = setup({});
+
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('sets isPending to true while mutation is in-flight', async () => {
+    let resolveRequest: (() => void) | undefined;
+    const blockingPromise = new Promise<void>((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    const { result } = setup({
+      httpResolver: async () => {
+        await blockingPromise;
+        return HttpResponse.json({});
+      },
+    });
+
+    act(() => {
+      result.current.mutate(VALID_CREATE_SCHEDULE_BODY);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(true);
+    });
+
+    act(() => {
+      resolveRequest?.();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+  });
+
+  it('invalidates listSchedules queries on success', async () => {
+    const { result } = setup({});
+
+    await act(async () => {
+      await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+    });
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: [
+          'listSchedules',
+          { domain: MOCK_DOMAIN, cluster: MOCK_CLUSTER },
+        ],
+      })
+    );
+  });
+
+  it('sets isSuccess to true after successful mutation', async () => {
+    const { result } = setup({});
+
+    await act(async () => {
+      await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+    });
+
+    expect(result.current.isSuccess).toBe(true);
+  });
+
+  it('surfaces error from API on 400 failure', async () => {
+    const { result } = setup({
+      httpResolver: async () =>
+        HttpResponse.json(
+          {
+            message: 'Invalid values provided for schedule create',
+            validationErrors: [
+              { code: 'too_small', path: ['scheduleId'], message: 'Too small' },
+            ],
+          },
+          { status: 400 }
+        ),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+      } catch {
+        // expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.error?.status).toBe(400);
+    expect(result.current.error?.message).toBe(
+      'Invalid values provided for schedule create'
+    );
+    expect(result.current.error?.validationErrors).toHaveLength(1);
+  });
+
+  it('surfaces error from API on 409 conflict', async () => {
+    const { result } = setup({
+      httpResolver: async () =>
+        HttpResponse.json(
+          { message: 'Schedule already exists' },
+          { status: 409 }
+        ),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+      } catch {
+        // expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.error?.status).toBe(409);
+    expect(result.current.error?.message).toBe('Schedule already exists');
+  });
+
+  it('resets mutation state after calling reset()', async () => {
+    const { result } = setup({
+      httpResolver: async () =>
+        HttpResponse.json(
+          { message: 'Schedule already exists' },
+          { status: 409 }
+        ),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+      } catch {
+        // expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    await act(async () => {
+      result.current.reset();
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeNull();
+    });
+    expect(result.current.isSuccess).toBe(false);
+  });
+
+  it('does not invalidate queries on failure', async () => {
+    const { result } = setup({
+      httpResolver: async () =>
+        HttpResponse.json(
+          { message: 'Schedule already exists' },
+          { status: 409 }
+        ),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(VALID_CREATE_SCHEDULE_BODY);
+      } catch {
+        // expected to throw
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+  });
+});
+
+function setup({
+  httpResolver,
+}: {
+  httpResolver?: () => ReturnType<typeof HttpResponse.json> | Promise<ReturnType<typeof HttpResponse.json>>;
+} = {}) {
+  const { result } = renderHook(
+    () => useCreateSchedule({ domain: MOCK_DOMAIN, cluster: MOCK_CLUSTER }),
+    {
+      endpointsMocks: [
+        {
+          path: `/api/domains/${MOCK_DOMAIN}/${MOCK_CLUSTER}/schedules`,
+          httpMethod: 'POST',
+          mockOnce: false,
+          httpResolver: httpResolver ?? (async () => HttpResponse.json({})),
+        },
+      ],
+    }
+  );
+
+  return { result };
+}

--- a/src/views/shared/hooks/use-create-schedule/__tests__/use-create-schedule.test.tsx
+++ b/src/views/shared/hooks/use-create-schedule/__tests__/use-create-schedule.test.tsx
@@ -5,6 +5,7 @@ import { HttpResponse } from 'msw';
 import { renderHook, waitFor } from '@/test-utils/rtl';
 
 import { mockCreateScheduleRequestBody } from '@/route-handlers/create-schedule/__fixtures__/create-schedule-request-body';
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
 
 import useCreateSchedule from '../use-create-schedule';
 
@@ -25,6 +26,21 @@ describe(useCreateSchedule.name, () => {
     );
     expect(req.method).toBe('POST');
     expect(req.body).toEqual(mockCreateScheduleRequestBody);
+  });
+
+  it('returns the response from the endpoint', async () => {
+    const { result } = setup({});
+
+    let response;
+    await act(async () => {
+      response = await result.current.mutateAsync(
+        mockCreateScheduleRequestBody
+      );
+    });
+
+    expect(response).toEqual({
+      scheduleId: mockCreateScheduleRequestBody.scheduleId,
+    });
   });
 
   it('invalidates listSchedules queries on success', async () => {
@@ -106,12 +122,13 @@ function setup({
             httpResolver ??
             (async ({ request }) => {
               const url = new URL(request.url);
+              const body = (await request.json()) as CreateScheduleRequestBody;
               latestRequest = {
                 url: url.pathname,
                 method: request.method,
-                body: await request.json(),
+                body,
               };
-              return HttpResponse.json({});
+              return HttpResponse.json({ scheduleId: body.scheduleId });
             }),
         },
       ],

--- a/src/views/shared/hooks/use-create-schedule/use-create-schedule.ts
+++ b/src/views/shared/hooks/use-create-schedule/use-create-schedule.ts
@@ -29,9 +29,6 @@ export default function useCreateSchedule({
         {
           method: 'POST',
           body: JSON.stringify(variables),
-          headers: {
-            'Content-Type': 'application/json',
-          },
         }
       ).then((res) => res.json()),
     onSuccess: () => {

--- a/src/views/shared/hooks/use-create-schedule/use-create-schedule.ts
+++ b/src/views/shared/hooks/use-create-schedule/use-create-schedule.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { type CreateScheduleResponseBody } from '@/route-handlers/create-schedule/create-schedule.types';
 import request from '@/utils/request';
 import { type RequestError } from '@/utils/request/request-error';
 
@@ -17,27 +18,26 @@ export default function useCreateSchedule({
 }: UseCreateScheduleParams): UseCreateScheduleResult {
   const queryClient = useQueryClient();
 
-  const { mutate, mutateAsync, isPending, error, isSuccess, reset } =
-    useMutation<Record<string, never>, RequestError, UseCreateScheduleVariables>(
-      {
-        mutationFn: (variables) =>
-          request(
-            `/api/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/schedules`,
-            {
-              method: 'POST',
-              body: JSON.stringify(variables),
-              headers: {
-                'Content-Type': 'application/json',
-              },
-            }
-          ).then((res) => res.json()),
-        onSuccess: () => {
-          queryClient.invalidateQueries({
-            queryKey: ['listSchedules', { domain, cluster }],
-          });
-        },
-      }
-    );
-
-  return { mutate, mutateAsync, isPending, error, isSuccess, reset };
+  return useMutation<
+    CreateScheduleResponseBody,
+    RequestError,
+    UseCreateScheduleVariables
+  >({
+    mutationFn: (variables) =>
+      request(
+        `/api/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/schedules`,
+        {
+          method: 'POST',
+          body: JSON.stringify(variables),
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        }
+      ).then((res) => res.json()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['listSchedules', { domain, cluster }],
+      });
+    },
+  });
 }

--- a/src/views/shared/hooks/use-create-schedule/use-create-schedule.ts
+++ b/src/views/shared/hooks/use-create-schedule/use-create-schedule.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
+
+import {
+  type UseCreateScheduleParams,
+  type UseCreateScheduleResult,
+  type UseCreateScheduleVariables,
+} from './use-create-schedule.types';
+
+export default function useCreateSchedule({
+  domain,
+  cluster,
+}: UseCreateScheduleParams): UseCreateScheduleResult {
+  const queryClient = useQueryClient();
+
+  const { mutate, mutateAsync, isPending, error, isSuccess, reset } =
+    useMutation<Record<string, never>, RequestError, UseCreateScheduleVariables>(
+      {
+        mutationFn: (variables) =>
+          request(
+            `/api/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/schedules`,
+            {
+              method: 'POST',
+              body: JSON.stringify(variables),
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            }
+          ).then((res) => res.json()),
+        onSuccess: () => {
+          queryClient.invalidateQueries({
+            queryKey: ['listSchedules', { domain, cluster }],
+          });
+        },
+      }
+    );
+
+  return { mutate, mutateAsync, isPending, error, isSuccess, reset };
+}

--- a/src/views/shared/hooks/use-create-schedule/use-create-schedule.types.ts
+++ b/src/views/shared/hooks/use-create-schedule/use-create-schedule.types.ts
@@ -1,4 +1,9 @@
-import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+import { type UseMutationResult } from '@tanstack/react-query';
+
+import {
+  type CreateScheduleRequestBody,
+  type CreateScheduleResponseBody,
+} from '@/route-handlers/create-schedule/create-schedule.types';
 import { type RequestError } from '@/utils/request/request-error';
 
 export type UseCreateScheduleParams = {
@@ -8,13 +13,8 @@ export type UseCreateScheduleParams = {
 
 export type UseCreateScheduleVariables = CreateScheduleRequestBody;
 
-export type UseCreateScheduleResult = {
-  mutate: (variables: UseCreateScheduleVariables) => void;
-  mutateAsync: (
-    variables: UseCreateScheduleVariables
-  ) => Promise<Record<string, never>>;
-  isPending: boolean;
-  error: RequestError | null;
-  isSuccess: boolean;
-  reset: () => void;
-};
+export type UseCreateScheduleResult = UseMutationResult<
+  CreateScheduleResponseBody,
+  RequestError,
+  UseCreateScheduleVariables
+>;

--- a/src/views/shared/hooks/use-create-schedule/use-create-schedule.types.ts
+++ b/src/views/shared/hooks/use-create-schedule/use-create-schedule.types.ts
@@ -1,0 +1,20 @@
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+import { type RequestError } from '@/utils/request/request-error';
+
+export type UseCreateScheduleParams = {
+  domain: string;
+  cluster: string;
+};
+
+export type UseCreateScheduleVariables = CreateScheduleRequestBody;
+
+export type UseCreateScheduleResult = {
+  mutate: (variables: UseCreateScheduleVariables) => void;
+  mutateAsync: (
+    variables: UseCreateScheduleVariables
+  ) => Promise<Record<string, never>>;
+  isPending: boolean;
+  error: RequestError | null;
+  isSuccess: boolean;
+  reset: () => void;
+};


### PR DESCRIPTION
## Summary

Adds `useCreateSchedule` — that uses TanStack Query `useMutation` hook that POSTs to `/api/domains/{domain}/{cluster}/schedules` and invalidates the schedules list query on success.


## Testing

- typecheck & test cases


## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- Schedules Create Form
   - #1302
   - #1303 
   - #1305
- Schedules Details
- Schedules Actions
- Schedules Backfills
