### PR TITLE
fix: remove double-encoding of URL params in diagnostics event ID links

### DIFF
--- a/src/views/workflow-diagnostics/config/workflow-diagnostics-metadata-parsers.config.ts
+++ b/src/views/workflow-diagnostics/config/workflow-diagnostics-metadata-parsers.config.ts
@@ -20,7 +20,7 @@ const workflowDiagnosticsMetadataParsersConfig: Array<WorkflowDiagnosticsMetadat
           Link,
           {
             href: queryString.stringifyUrl({
-              url: `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows/${encodeURIComponent(workflowId)}/${encodeURIComponent(runId)}/history`,
+              url: `/domains/${domain}/${cluster}/workflows/${workflowId}/${runId}/history`,
               query: {
                 he: value,
               },


### PR DESCRIPTION
## Summary
- Removed `encodeURIComponent()` calls from the diagnostics metadata parsers config when building workflow history links for Event IDs
- The route params (`domain`, `cluster`, `workflowId`, `runId`) already arrive URL-encoded from the page route, so wrapping them in `encodeURIComponent()` caused double-encoding (e.g. `%5B` → `%255B`), producing broken links when workflow IDs contain special characters like `[`, `]`, or spaces

## Example
**Before (broken):** `/domains/freight-search-dca/prod11-dca/workflows/%255Bproduction%255D%2520Validation%2520Test/run-id/history?he=5`

**After (correct):** `/domains/freight-search-dca/prod11-dca/workflows/%5Bproduction%5D%20Validation%20Test/run-id/history?he=5`
