### PR TITLE
feat: Make batch UI deep-linkable via URL query param

### DIFF
--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -10,6 +10,7 @@ import DomainBatchActions from '../domain-batch-actions';
 import { type Props as NewActionDetailProps } from '../domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.types';
 import { type Props as SidebarProps } from '../domain-batch-actions-sidebar/domain-batch-actions-sidebar.types';
 
+const mockSetQueryParams = jest.fn();
 const mockUsePageQueryParams = jest.fn();
 jest.mock('@/hooks/use-page-query-params/use-page-query-params', () => ({
   __esModule: true,
@@ -17,6 +18,7 @@ jest.mock('@/hooks/use-page-query-params/use-page-query-params', () => ({
 }));
 
 jest.mock('../domain-batch-actions.constants', () => ({
+  DRAFT_ACTION_ID: 'draft',
   MOCK_BATCH_ACTIONS: [
     {
       id: '5',
@@ -86,9 +88,10 @@ jest.mock(
 
 describe(DomainBatchActions.name, () => {
   beforeEach(() => {
+    mockSetQueryParams.mockClear();
     mockUsePageQueryParams.mockReturnValue([
       { ...mockDomainPageQueryParamsValues, batchQuery: '' },
-      jest.fn(),
+      mockSetQueryParams,
     ]);
   });
 
@@ -105,50 +108,48 @@ describe(DomainBatchActions.name, () => {
     expect(screen.getByText('Abort batch action')).toBeInTheDocument();
   });
 
-  it('updates detail panel when a different action is selected', async () => {
+  it('updates URL param when a different action is selected', async () => {
     const user = userEvent.setup();
 
     render(<DomainBatchActions domain="test-domain" cluster="test-cluster" />);
 
     await user.click(screen.getByText('mock-select-4'));
 
-    expect(
-      screen.getByRole('heading', { name: /Batch action #4/ })
-    ).toBeInTheDocument();
-    expect(screen.queryByText('Abort batch action')).not.toBeInTheDocument();
+    expect(mockSetQueryParams).toHaveBeenCalledWith({ batchActionId: '4' });
   });
 
-  it('opens the draft detail panel when "New batch action" is clicked', async () => {
+  it('sets batchActionId to draft when "New batch action" is clicked', async () => {
     const user = userEvent.setup();
 
     render(<DomainBatchActions domain="test-domain" cluster="test-cluster" />);
 
     await user.click(screen.getByText('mock-new-batch-action'));
 
-    expect(
-      screen.getByRole('heading', { name: 'New batch action' })
-    ).toBeInTheDocument();
-    expect(screen.getByText('Discard batch action')).toBeInTheDocument();
+    expect(mockSetQueryParams).toHaveBeenCalledWith({
+      batchActionId: 'draft',
+    });
   });
 
-  it('returns to the previously selected action detail when discarded', async () => {
+  it('clears batchActionId and batchQuery on discard', async () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        batchActionId: 'draft',
+        batchQuery: 'WorkflowType="foo"',
+      },
+      mockSetQueryParams,
+    ]);
+
     const user = userEvent.setup();
 
     render(<DomainBatchActions domain="test-domain" cluster="test-cluster" />);
-
-    await user.click(screen.getByText('mock-new-batch-action'));
-    expect(
-      screen.getByRole('heading', { name: 'New batch action' })
-    ).toBeInTheDocument();
 
     await user.click(screen.getByText('Discard batch action'));
 
-    expect(
-      screen.queryByRole('heading', { name: 'New batch action' })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByRole('heading', { name: /Batch action #5/ })
-    ).toBeInTheDocument();
+    expect(mockSetQueryParams).toHaveBeenCalledWith({
+      batchActionId: undefined,
+      batchQuery: '',
+    });
   });
 
   it('opens the draft on mount when batchQuery is present in the URL', () => {
@@ -157,7 +158,7 @@ describe(DomainBatchActions.name, () => {
         ...mockDomainPageQueryParamsValues,
         batchQuery: 'WorkflowType="foo"',
       },
-      jest.fn(),
+      mockSetQueryParams,
     ]);
 
     render(<DomainBatchActions domain="test-domain" cluster="test-cluster" />);
@@ -168,5 +169,54 @@ describe(DomainBatchActions.name, () => {
     expect(
       screen.queryByRole('heading', { name: /Batch action #5/ })
     ).not.toBeInTheDocument();
+  });
+
+  it('opens the draft when batchActionId is "draft" (no batchQuery)', () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        batchActionId: 'draft',
+        batchQuery: '',
+      },
+      mockSetQueryParams,
+    ]);
+
+    render(<DomainBatchActions domain="test-domain" cluster="test-cluster" />);
+
+    expect(
+      screen.getByRole('heading', { name: 'New batch action' })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the specified batch action when batchActionId is set', () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        batchActionId: '4',
+        batchQuery: '',
+      },
+      mockSetQueryParams,
+    ]);
+
+    render(<DomainBatchActions domain="test-domain" cluster="test-cluster" />);
+
+    expect(
+      screen.getByRole('heading', { name: /Batch action #4/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: /Batch action #5/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it('sets batchActionId to draft when selecting the draft sidebar item', async () => {
+    const user = userEvent.setup();
+
+    render(<DomainBatchActions domain="test-domain" cluster="test-cluster" />);
+
+    await user.click(screen.getByText('mock-select-draft'));
+
+    expect(mockSetQueryParams).toHaveBeenCalledWith({
+      batchActionId: 'draft',
+    });
   });
 });

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -1,5 +1,7 @@
 import { type BatchAction } from './domain-batch-actions.types';
 
+export const DRAFT_ACTION_ID = 'draft';
+
 export const BATCH_ACTION_RPS_DEFAULT = 100;
 
 // TODO: Replace with real API data

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -8,44 +8,47 @@ import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-
 import DomainBatchActionDetail from './domain-batch-actions-detail/domain-batch-actions-detail';
 import DomainBatchActionsNewActionDetail from './domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail';
 import DomainBatchActionsSidebar from './domain-batch-actions-sidebar/domain-batch-actions-sidebar';
-import { MOCK_BATCH_ACTIONS } from './domain-batch-actions.constants';
+import { DRAFT_ACTION_ID, MOCK_BATCH_ACTIONS } from './domain-batch-actions.constants';
 import { styled } from './domain-batch-actions.styles';
 
 export default function DomainBatchActions(props: DomainPageTabContentProps) {
-  const [queryParams] = usePageQueryParams(domainPageQueryParamsConfig);
+  const [queryParams, setQueryParams] = usePageQueryParams(
+    domainPageQueryParamsConfig
+  );
 
   // TODO: replace with useSuspenseQuery once the batch-actions list endpoint exists
   const batchActions = MOCK_BATCH_ACTIONS;
 
-  // TODO: lift selectedActionId into a query param to support deep linking.
-  const [selectedActionId, setSelectedActionId] = useState<string | null>(
-    batchActions[0]?.id ?? null
+  const isDraftSelected =
+    queryParams.batchActionId === DRAFT_ACTION_ID ||
+    (!queryParams.batchActionId && Boolean(queryParams.batchQuery));
+  const selectedActionId =
+    !isDraftSelected && queryParams.batchActionId
+      ? queryParams.batchActionId
+      : (batchActions[0]?.id ?? null);
+
+  const [isDraftOpen, setIsDraftOpen] = useState(
+    isDraftSelected || Boolean(queryParams.batchQuery)
   );
-  // The "Batch workflow actions" dropdown is the only producer of `batch-query`
-  // in the URL; its presence signals that the user wants the draft open.
-  const isNewActionRequested = Boolean(queryParams.batchQuery);
-  const [isDraftOpen, setIsDraftOpen] = useState(isNewActionRequested);
-  const [isDraftSelected, setIsDraftSelected] = useState(isNewActionRequested);
 
   const selectedAction = batchActions.find((a) => a.id === selectedActionId);
 
   const handleCreateNew = () => {
     setIsDraftOpen(true);
-    setIsDraftSelected(true);
+    setQueryParams({ batchActionId: DRAFT_ACTION_ID });
   };
 
   const handleSelectAction = (id: string) => {
-    setSelectedActionId(id);
-    setIsDraftSelected(false);
+    setQueryParams({ batchActionId: id });
   };
 
   const handleSelectDraft = () => {
-    setIsDraftSelected(true);
+    setQueryParams({ batchActionId: DRAFT_ACTION_ID });
   };
 
   const handleDiscard = () => {
     setIsDraftOpen(false);
-    setIsDraftSelected(false);
+    setQueryParams({ batchActionId: undefined, batchQuery: '' });
   };
 
   return (

--- a/src/views/domain-page/__fixtures__/domain-page-query-params.ts
+++ b/src/views/domain-page/__fixtures__/domain-page-query-params.ts
@@ -12,6 +12,7 @@ export const mockDomainPageQueryParamsValues = {
   query: '',
   batchInputType: 'query',
   batchQuery: '',
+  batchActionId: undefined,
   workflowId: '',
   workflowType: '',
   statusBasic: undefined,

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -27,6 +27,7 @@ const domainPageQueryParamsConfig: [
   // and the batch action draft do not overwrite each other's state).
   PageQueryParam<'batchInputType', WorkflowsHeaderInputType>,
   PageQueryParam<'batchQuery', string>,
+  PageQueryParam<'batchActionId', string | undefined>,
   // Basic Visibility inputs
   PageQueryParam<'workflowId', string>,
   PageQueryParam<'workflowType', string>,
@@ -102,6 +103,10 @@ const domainPageQueryParamsConfig: [
     key: 'batchQuery',
     queryParamKey: 'batch-query',
     defaultValue: '',
+  },
+  {
+    key: 'batchActionId',
+    queryParamKey: 'bid',
   },
   {
     key: 'workflowId',

--- a/src/views/domain-page/domain-page-actions-dropdown/__tests__/domain-page-actions-dropdown.test.tsx
+++ b/src/views/domain-page/domain-page-actions-dropdown/__tests__/domain-page-actions-dropdown.test.tsx
@@ -256,7 +256,9 @@ describe(DomainPageActionsDropdown.name, () => {
       await user.click(screen.getByTestId('popover-trigger'));
       await user.click(screen.getByText('Batch workflow actions'));
 
-      expect(mockRouterPush).toHaveBeenCalledWith('batch-actions?batch-query=');
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        'batch-actions?batch-query=&bid=draft'
+      );
     });
 
     it('seeds batch-query from current query when navigating', async () => {
@@ -276,6 +278,7 @@ describe(DomainPageActionsDropdown.name, () => {
       const url = new URL(pushedTo, 'http://example.com/');
       expect(url.pathname).toBe('/batch-actions');
       expect(url.searchParams.get('batch-query')).toBe('WorkflowType="foo"');
+      expect(url.searchParams.get('bid')).toBe('draft');
     });
 
     it('preserves existing URL search params when navigating', async () => {
@@ -298,6 +301,7 @@ describe(DomainPageActionsDropdown.name, () => {
       expect(url.searchParams.get('input')).toBe('query');
       expect(url.searchParams.get('query')).toBe('foo');
       expect(url.searchParams.get('batch-query')).toBe('');
+      expect(url.searchParams.get('bid')).toBe('draft');
 
       Object.defineProperty(window, 'location', {
         configurable: true,

--- a/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.tsx
+++ b/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.tsx
@@ -75,6 +75,7 @@ export default function DomainPageActionsDropdown({
     if (action.id === batchWorkflowDomainAction.id) {
       const params = new URLSearchParams(window.location.search);
       params.set('batch-query', queryParams.query ?? '');
+      params.set('bid', 'draft');
       router.push(`batch-actions?${params.toString()}`);
     }
   };


### PR DESCRIPTION
## Summary
- Add `batchActionId` (`?bid=`) URL query param to make batch action views shareable
- `?bid=draft` links to the draft page, `?bid=<id>` links to a specific batch action, and `?bid=draft&batch-query=...` opens a pre-filled draft
- Replaces local `useState` for `selectedActionId` and `isDraftSelected` with URL-driven state via the existing `usePageQueryParams` hook
- Backward-compatible: `?batch-query=...` without `bid` still opens the draft


