### PR TITLE
feat: add breadcrumbs to task list page

### DIFF
--- a/src/views/task-list-page/task-list-loader/__tests__/task-list-loader.test.tsx
+++ b/src/views/task-list-page/task-list-loader/__tests__/task-list-loader.test.tsx
@@ -5,9 +5,9 @@ import { HttpResponse } from 'msw';
 import { render, screen, act } from '@/test-utils/rtl';
 
 import { type DescribeTaskListResponse } from '@/route-handlers/describe-task-list/describe-task-list.types';
-import type { Props as TaskListLabelProps } from '@/views/shared/task-list-label/task-list-label.types';
 
 import { mockTaskList } from '../../__fixtures__/mock-task-list';
+import { type Props as TaskListPageHeaderProps } from '../../task-list-page-header/task-list-page-header.types';
 import { type Props as TaskListTableProps } from '../../task-list-workers-table/task-list-workers-table.types';
 import TaskListLoader from '../task-list-loader';
 
@@ -25,8 +25,8 @@ jest.mock('../../task-list-filters/task-list-filters', () =>
   jest.fn(() => <div>Mock task list filters</div>)
 );
 
-jest.mock('@/views/shared/task-list-label/task-list-label', () =>
-  jest.fn(({ taskList }: TaskListLabelProps) => (
+jest.mock('../../task-list-page-header/task-list-page-header', () =>
+  jest.fn(({ taskList }: TaskListPageHeaderProps) => (
     <div>
       {taskList.name}: {taskList.workers.length} workers
     </div>

--- a/src/views/task-list-page/task-list-loader/task-list-loader.styles.ts
+++ b/src/views/task-list-page/task-list-loader/task-list-loader.styles.ts
@@ -4,12 +4,6 @@ export const styled = {
   TaskListContainer: createStyled('div', ({ $theme }) => ({
     display: 'flex',
     flexDirection: 'column',
-    paddingTop: $theme.sizing.scale800,
     rowGap: $theme.sizing.scale600,
-  })),
-  TaskListHeaderContainer: createStyled('div', ({ $theme }) => ({
-    display: 'flex',
-    flexDirection: 'row',
-    columnGap: $theme.sizing.scale400,
   })),
 };

--- a/src/views/task-list-page/task-list-loader/task-list-loader.tsx
+++ b/src/views/task-list-page/task-list-loader/task-list-loader.tsx
@@ -2,15 +2,13 @@
 import React from 'react';
 
 import { useSuspenseQuery } from '@tanstack/react-query';
-import Image from 'next/image';
 
-import cadenceLogoBlack from '@/assets/cadence-logo-black.svg';
 import PageSection from '@/components/page-section/page-section';
 import { type DescribeTaskListResponse } from '@/route-handlers/describe-task-list/describe-task-list.types';
 import request from '@/utils/request';
-import TaskListLabel from '@/views/shared/task-list-label/task-list-label';
 
 import TaskListFilters from '../task-list-filters/task-list-filters';
+import TaskListPageHeader from '../task-list-page-header/task-list-page-header';
 import TaskListWorkersTable from '../task-list-workers-table/task-list-workers-table';
 
 import { TASK_LIST_REFETCH_INTERVAL_MS } from './task-list-loader.constants';
@@ -30,20 +28,18 @@ export default function TaskListLoader(props: Props) {
   });
 
   return (
-    <PageSection>
-      <styled.TaskListContainer>
-        <styled.TaskListHeaderContainer>
-          <Image
-            width={22}
-            height={22}
-            alt="Cadence Icon"
-            src={cadenceLogoBlack}
-          />
-          <TaskListLabel taskList={taskList} isHighlighted={true} />
-        </styled.TaskListHeaderContainer>
-        <TaskListFilters />
-        <TaskListWorkersTable taskList={taskList} />
-      </styled.TaskListContainer>
-    </PageSection>
+    <>
+      <TaskListPageHeader
+        domain={props.domain}
+        cluster={props.cluster}
+        taskList={taskList}
+      />
+      <PageSection>
+        <styled.TaskListContainer>
+          <TaskListFilters />
+          <TaskListWorkersTable taskList={taskList} />
+        </styled.TaskListContainer>
+      </PageSection>
+    </>
   );
 }

--- a/src/views/task-list-page/task-list-page-header-cluster-selector/__tests__/task-list-page-header-cluster-selector.test.tsx
+++ b/src/views/task-list-page/task-list-page-header-cluster-selector/__tests__/task-list-page-header-cluster-selector.test.tsx
@@ -1,0 +1,133 @@
+import React, { Suspense } from 'react';
+
+import { HttpResponse } from 'msw';
+
+import { render, screen, within } from '@/test-utils/rtl';
+
+import ErrorBoundary from '@/components/error-boundary/error-boundary';
+import { mockDomainDescription } from '@/views/domain-page/__fixtures__/domain-description';
+import { type DomainDescription } from '@/views/domain-page/domain-page.types';
+import type { Props as DomainClusterSelectorProps } from '@/views/shared/domain-cluster-selector/domain-cluster-selector.types';
+
+import TaskListPageHeaderClusterSelector from '../task-list-page-header-cluster-selector';
+import { type Props } from '../task-list-page-header-cluster-selector.types';
+
+jest.mock('next/navigation', () => ({
+  ...jest.requireActual('next/navigation'),
+  useParams: () => ({
+    domain: 'mock-domain',
+    cluster: 'cluster_1',
+    taskListName: 'tasklist-1',
+  }),
+}));
+
+const MockDomainClusterSelector = jest.fn(
+  (props: DomainClusterSelectorProps) => (
+    <>
+      <div data-testid="domain-cluster-selector">{props.cluster}</div>
+      <div data-testid="single-cluster-fallback-type">
+        {props.singleClusterFallbackType}
+      </div>
+      <div data-testid="no-spacing">{props.noSpacing ? 'true' : 'false'}</div>
+      <div data-testid="domain-description">
+        {JSON.stringify(props.domainDescription)}
+      </div>
+      <div data-testid="build-path-for-cluster">
+        {typeof props.buildPathForCluster === 'function'
+          ? props.buildPathForCluster('cluster_2')
+          : 'undefined'}
+      </div>
+    </>
+  )
+);
+
+jest.mock(
+  '@/views/shared/domain-cluster-selector/domain-cluster-selector',
+  () => ({
+    __esModule: true,
+    default: (props: DomainClusterSelectorProps) =>
+      MockDomainClusterSelector(props),
+  })
+);
+
+describe(TaskListPageHeaderClusterSelector.name, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders DomainClusterSelector with correct props', async () => {
+    setup({ domain: 'mock-domain', cluster: 'cluster_1' });
+
+    expect(
+      await screen.findByTestId('domain-cluster-selector')
+    ).toBeInTheDocument();
+
+    const singleClusterFallbackTypeDiv = screen.getByTestId(
+      'single-cluster-fallback-type'
+    );
+    expect(
+      within(singleClusterFallbackTypeDiv).getByText('none')
+    ).toBeInTheDocument();
+
+    const noSpacing = screen.getByTestId('no-spacing');
+    expect(within(noSpacing).getByText('true')).toBeInTheDocument();
+
+    const domainDescription = screen.getByTestId('domain-description');
+    expect(
+      within(domainDescription).getByText(JSON.stringify(mockDomainDescription))
+    ).toBeInTheDocument();
+  });
+
+  it('throws an error when domain API returns an error', async () => {
+    setup({ domain: 'mock-domain', cluster: 'cluster_1', isError: true });
+
+    expect(await screen.findByText('Error loading domain')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('domain-cluster-selector')
+    ).not.toBeInTheDocument();
+  });
+
+  it('passes buildPathForCluster that swaps cluster on the task list route', async () => {
+    setup({ domain: 'mock-domain', cluster: 'cluster_1' });
+
+    await screen.findByTestId('domain-cluster-selector');
+    const buildPathForClusterDiv = screen.getByTestId('build-path-for-cluster');
+    expect(buildPathForClusterDiv).toHaveTextContent(
+      '/domains/mock-domain/cluster_2/task-lists/tasklist-1'
+    );
+  });
+});
+
+function setup({
+  domain,
+  cluster,
+  domainDescription = mockDomainDescription,
+  isError,
+}: Props & {
+  domainDescription?: DomainDescription;
+  isError?: boolean;
+}) {
+  render(
+    <ErrorBoundary
+      fallbackRender={() => <div>Error loading domain</div>}
+      omitLogging
+    >
+      <Suspense fallback={null}>
+        <TaskListPageHeaderClusterSelector domain={domain} cluster={cluster} />
+      </Suspense>
+    </ErrorBoundary>,
+    {
+      endpointsMocks: [
+        {
+          path: '/api/domains/:domain/:cluster',
+          httpMethod: 'GET',
+          mockOnce: false,
+          httpResolver: () =>
+            isError
+              ? HttpResponse.json({ message: 'Error' }, { status: 500 })
+              : HttpResponse.json(domainDescription),
+        },
+      ],
+    }
+  );
+}

--- a/src/views/task-list-page/task-list-page-header-cluster-selector/helpers/__tests__/build-task-list-page-cluster-path.test.ts
+++ b/src/views/task-list-page/task-list-page-header-cluster-selector/helpers/__tests__/build-task-list-page-cluster-path.test.ts
@@ -1,0 +1,25 @@
+import buildTaskListPageClusterPath from '../build-task-list-page-cluster-path';
+
+describe(buildTaskListPageClusterPath.name, () => {
+  it('builds path for plain values', () => {
+    expect(
+      buildTaskListPageClusterPath({
+        domain: 'my-domain',
+        cluster: 'cluster_1',
+        taskListName: 'tasklist-1',
+      })
+    ).toBe('/domains/my-domain/cluster_1/task-lists/tasklist-1');
+  });
+
+  it('encodes special characters in domain, cluster and taskListName', () => {
+    expect(
+      buildTaskListPageClusterPath({
+        domain: 'domain%20with',
+        cluster: 'cluster_with_special%chars',
+        taskListName: 'task@list/1',
+      })
+    ).toBe(
+      '/domains/domain%2520with/cluster_with_special%25chars/task-lists/task%40list%2F1'
+    );
+  });
+});

--- a/src/views/task-list-page/task-list-page-header-cluster-selector/helpers/build-task-list-page-cluster-path.ts
+++ b/src/views/task-list-page/task-list-page-header-cluster-selector/helpers/build-task-list-page-cluster-path.ts
@@ -1,0 +1,9 @@
+import { type BuildTaskListPageClusterPathParams } from '../task-list-page-header-cluster-selector.types';
+
+export default function buildTaskListPageClusterPath({
+  domain,
+  cluster,
+  taskListName,
+}: BuildTaskListPageClusterPathParams): string {
+  return `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/task-lists/${encodeURIComponent(taskListName)}`;
+}

--- a/src/views/task-list-page/task-list-page-header-cluster-selector/task-list-page-header-cluster-selector.tsx
+++ b/src/views/task-list-page/task-list-page-header-cluster-selector/task-list-page-header-cluster-selector.tsx
@@ -1,0 +1,43 @@
+'use client';
+import React from 'react';
+
+import { useParams } from 'next/navigation';
+
+import decodeUrlParams from '@/utils/decode-url-params';
+import DomainClusterSelector from '@/views/shared/domain-cluster-selector/domain-cluster-selector';
+import useSuspenseDomainDescription from '@/views/shared/hooks/use-domain-description/use-suspense-domain-description';
+
+import { type RouteParams } from '../task-list-page.types';
+
+import buildTaskListPageClusterPath from './helpers/build-task-list-page-cluster-path';
+import type { Props } from './task-list-page-header-cluster-selector.types';
+
+export default function TaskListPageHeaderClusterSelector({
+  domain,
+  cluster,
+}: Props) {
+  const { data: domainDescription } = useSuspenseDomainDescription({
+    domain,
+    cluster,
+  });
+
+  const encodedParams = useParams<RouteParams>();
+  const decodedParams = decodeUrlParams(encodedParams) as RouteParams;
+
+  const buildPathForCluster = (newCluster: string) =>
+    buildTaskListPageClusterPath({
+      domain,
+      cluster: newCluster,
+      taskListName: decodedParams.taskListName,
+    });
+
+  return (
+    <DomainClusterSelector
+      domainDescription={domainDescription}
+      cluster={cluster}
+      buildPathForCluster={buildPathForCluster}
+      singleClusterFallbackType="none"
+      noSpacing={true}
+    />
+  );
+}

--- a/src/views/task-list-page/task-list-page-header-cluster-selector/task-list-page-header-cluster-selector.types.ts
+++ b/src/views/task-list-page/task-list-page-header-cluster-selector/task-list-page-header-cluster-selector.types.ts
@@ -1,0 +1,10 @@
+export type Props = {
+  domain: string;
+  cluster: string;
+};
+
+export type BuildTaskListPageClusterPathParams = {
+  domain: string;
+  cluster: string;
+  taskListName: string;
+};

--- a/src/views/task-list-page/task-list-page-header/__tests__/task-list-page-header.test.tsx
+++ b/src/views/task-list-page/task-list-page-header/__tests__/task-list-page-header.test.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+import { render } from '@/test-utils/rtl';
+
+import { mockTaskList } from '../../__fixtures__/mock-task-list';
+import TaskListPageHeader from '../task-list-page-header';
+import type { Props } from '../task-list-page-header.types';
+
+jest.mock(
+  '../../task-list-page-header-cluster-selector/task-list-page-header-cluster-selector',
+  () =>
+    function TaskListPageHeaderClusterSelector({
+      cluster,
+    }: {
+      cluster: string;
+    }) {
+      return (
+        <span data-testid="task-list-page-cluster-selector">{cluster}</span>
+      );
+    }
+);
+
+jest.mock(
+  '@/views/shared/task-list-label/task-list-label',
+  () =>
+    function TaskListLabel({ taskList }: { taskList: { name: string } }) {
+      return <div data-testid="task-list-label">{taskList.name}</div>;
+    }
+);
+
+describe('TaskListPageHeader', () => {
+  it('renders breadcrumbs with correct domain content and link', () => {
+    const domain = 'test-domain';
+    const cluster = 'test-cluster';
+    const { getByText } = setup({ domain, cluster });
+
+    const domainBreadcrumb = getByText(domain);
+    expect(domainBreadcrumb).toBeInTheDocument();
+    expect(domainBreadcrumb).toHaveAttribute(
+      'href',
+      `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}`
+    );
+  });
+
+  it('renders cluster selector in breadcrumb', () => {
+    const cluster = 'test-cluster';
+    const { getByTestId } = setup({ cluster });
+
+    expect(getByTestId('task-list-page-cluster-selector')).toHaveTextContent(
+      cluster
+    );
+  });
+
+  it('renders task list label as the last breadcrumb item', () => {
+    const { getByTestId } = setup({});
+
+    const label = getByTestId('task-list-label');
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveTextContent(mockTaskList.name);
+  });
+
+  it('renders Cadence Icon image with correct alt text', () => {
+    const { getByAltText } = setup({});
+    expect(getByAltText('Cadence Icon')).toBeInTheDocument();
+  });
+});
+
+function setup({
+  domain = 'example-domain',
+  cluster = 'example-cluster',
+  taskList = mockTaskList,
+}: Partial<Props>) {
+  return render(
+    <TaskListPageHeader domain={domain} cluster={cluster} taskList={taskList} />
+  );
+}

--- a/src/views/task-list-page/task-list-page-header/task-list-page-header.styles.ts
+++ b/src/views/task-list-page/task-list-page-header/task-list-page-header.styles.ts
@@ -1,0 +1,47 @@
+import type { Theme } from 'baseui';
+import type { BreadcrumbsOverrides } from 'baseui/breadcrumbs';
+import type { StyleObject } from 'styletron-react';
+
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+export const overrides = {
+  breadcrumbs: {
+    Root: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        marginTop: $theme.sizing.scale800,
+        marginBottom: $theme.sizing.scale900,
+      }),
+    },
+    List: {
+      style: (): StyleObject => ({
+        display: 'flex',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }),
+    },
+    ListItem: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        display: 'flex',
+        alignItems: 'center',
+        marginBottom: $theme.sizing.scale200,
+        ...$theme.typography.LabelSmall,
+        lineHeight: $theme.typography.LabelMedium.lineHeight,
+      }),
+    },
+  } satisfies BreadcrumbsOverrides,
+};
+
+const cssStylesObj = {
+  breadcrumbItemContainer: (theme) => ({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.sizing.scale550,
+    flexWrap: 'wrap',
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =
+  cssStylesObj;

--- a/src/views/task-list-page/task-list-page-header/task-list-page-header.tsx
+++ b/src/views/task-list-page/task-list-page-header/task-list-page-header.tsx
@@ -1,0 +1,55 @@
+'use client';
+import React, { Suspense } from 'react';
+
+import { Breadcrumbs } from 'baseui/breadcrumbs';
+import { StyledLink } from 'baseui/link';
+import Image from 'next/image';
+import Link from 'next/link';
+
+import cadenceLogoBlack from '@/assets/cadence-logo-black.svg';
+import PageSection from '@/components/page-section/page-section';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+import TaskListLabel from '@/views/shared/task-list-label/task-list-label';
+
+import TaskListPageHeaderClusterSelector from '../task-list-page-header-cluster-selector/task-list-page-header-cluster-selector';
+
+import { cssStyles, overrides } from './task-list-page-header.styles';
+import type { Props } from './task-list-page-header.types';
+
+export default function TaskListPageHeader({
+  domain,
+  cluster,
+  taskList,
+}: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+  const domainLink = `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}`;
+  return (
+    <PageSection>
+      <Breadcrumbs
+        overrides={overrides.breadcrumbs}
+        showTrailingSeparator={false}
+      >
+        <div className={cls.breadcrumbItemContainer}>
+          <Image
+            width={22}
+            height={22}
+            alt="Cadence Icon"
+            src={cadenceLogoBlack}
+          />
+          <StyledLink $as={Link} href={domainLink}>
+            {domain}
+          </StyledLink>
+          <Suspense fallback={null}>
+            <TaskListPageHeaderClusterSelector
+              domain={domain}
+              cluster={cluster}
+            />
+          </Suspense>
+        </div>
+        <div className={cls.breadcrumbItemContainer}>
+          <TaskListLabel taskList={taskList} isHighlighted />
+        </div>
+      </Breadcrumbs>
+    </PageSection>
+  );
+}

--- a/src/views/task-list-page/task-list-page-header/task-list-page-header.types.ts
+++ b/src/views/task-list-page/task-list-page-header/task-list-page-header.types.ts
@@ -1,0 +1,7 @@
+import { type TaskList } from '@/route-handlers/describe-task-list/describe-task-list.types';
+
+export type Props = {
+  domain: string;
+  cluster: string;
+  taskList: TaskList;
+};


### PR DESCRIPTION
## Summary
- Adds a `<Breadcrumbs>` header to the task list page, mirroring the existing workflow page pattern: Cadence icon → domain link → cluster selector dropdown → task list (current).
- Gives users navigation context back to the domain page and a way to switch cluster without leaving the task list.

## Changes
- New `TaskListPageHeader`— baseui `<Breadcrumbs>` inside a `<PageSection>`. Styles match `workflow-page-header.styles.ts`.
- New `TaskListPageHeaderClusterSelector` — thin wrapper around the shared `DomainClusterSelector`, with a `buildTaskListPageClusterPath` helper that URL-encodes each segment so names containing `%` / `@` / `/` round-trip correctly.
- `task-list-loader` now renders the new header at the top of the page (outside the inner `<PageSection>`, so positioning matches the workflow page) and drops the old inline logo + label row.

<img width="1722" height="489" alt="image" src="https://github.com/user-attachments/assets/d760848d-b8ee-464f-bfb9-64e36442f008" />