### PR TITLE
feat: Add empty-state placeholder to batch actions tab

### DIFF
--- a/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/__tests__/domain-batch-actions-no-actions-placeholder.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/__tests__/domain-batch-actions-no-actions-placeholder.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type Props as ErrorPanelProps } from '@/components/error-panel/error-panel.types';
+
+import DomainBatchActionsNoActionsPlaceholder from '../domain-batch-actions-no-actions-placeholder';
+
+jest.mock('@/components/error-panel/error-panel', () => ({
+  __esModule: true,
+  default: ({ message, description, actions }: ErrorPanelProps) => (
+    <div>
+      <h2>{message}</h2>
+      <p>{description}</p>
+      {actions?.map((action) => (
+        <button
+          key={action.label}
+          onClick={() => {
+            if (action.kind === 'callback') action.onClick();
+          }}
+        >
+          {action.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+describe(DomainBatchActionsNoActionsPlaceholder.name, () => {
+  it('renders the empty-state heading and description', () => {
+    setup({});
+
+    expect(
+      screen.getByRole('heading', { name: 'No batch actions found' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Click the button below to get started/)
+    ).toBeInTheDocument();
+  });
+
+  it('invokes onCreateNew when the action button is clicked', async () => {
+    const { user, onCreateNew } = setup({});
+
+    await user.click(screen.getByRole('button', { name: 'New batch action' }));
+
+    expect(onCreateNew).toHaveBeenCalledTimes(1);
+  });
+});
+
+function setup({ onCreateNew = jest.fn() }: { onCreateNew?: jest.Mock }) {
+  const user = userEvent.setup();
+  render(<DomainBatchActionsNoActionsPlaceholder onCreateNew={onCreateNew} />);
+  return { user, onCreateNew };
+}

--- a/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder.tsx
@@ -1,0 +1,25 @@
+import { MdAdd } from 'react-icons/md';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+
+import { type Props } from './domain-batch-actions-no-actions-placeholder.types';
+
+export default function DomainBatchActionsNoActionsPlaceholder({
+  onCreateNew,
+}: Props) {
+  return (
+    <ErrorPanel
+      message="No batch actions found"
+      description="Click the button below to get started with Batch Workflow actions. Easily process multiple tasks at once and automate your workflows with just a few simple steps."
+      actions={[
+        {
+          kind: 'callback',
+          label: 'New batch action',
+          buttonKind: 'primary',
+          startEnhancer: MdAdd,
+          onClick: onCreateNew,
+        },
+      ]}
+    />
+  );
+}

--- a/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  onCreateNew: () => void;
+};

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -7,6 +7,7 @@ import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-
 
 import DomainBatchActionDetail from './domain-batch-actions-detail/domain-batch-actions-detail';
 import DomainBatchActionsNewActionDetail from './domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail';
+import DomainBatchActionsNoActionsPlaceholder from './domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder';
 import DomainBatchActionsSidebar from './domain-batch-actions-sidebar/domain-batch-actions-sidebar';
 import { MOCK_BATCH_ACTIONS } from './domain-batch-actions.constants';
 import { styled } from './domain-batch-actions.styles';
@@ -47,6 +48,18 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
     setIsDraftOpen(false);
     setIsDraftSelected(false);
   };
+
+  if (batchActions.length === 0 && !isDraftOpen) {
+    return (
+      <styled.Container>
+        <styled.DetailPanel>
+          <DomainBatchActionsNoActionsPlaceholder
+            onCreateNew={handleCreateNew}
+          />
+        </styled.DetailPanel>
+      </styled.Container>
+    );
+  }
 
   return (
     <styled.Container>


### PR DESCRIPTION
## Summary
- Adds a new `DomainBatchActionsNoActionsPlaceholder` component that renders the shared `ErrorPanel` with empty-state copy and a primary "New batch action" CTA.
- Wires it into `DomainBatchActions`: when there are no batch actions in history and no draft is open, the placeholder takes over the panel; clicking the CTA opens the new-action draft (same handler the sidebar uses).
- Mirrors the empty-state pattern already used by the schedules tab.

<img width="754" height="347" alt="image" src="https://github.com/user-attachments/assets/8372860e-5450-4be6-a270-bc6c983ebb5a" />


