### PR TITLE
feat: Add useListBatchActions hook

### DIFF
--- a/src/views/shared/hooks/use-list-batch-actions/__tests__/use-list-batch-actions.test.ts
+++ b/src/views/shared/hooks/use-list-batch-actions/__tests__/use-list-batch-actions.test.ts
@@ -1,0 +1,83 @@
+import { HttpResponse } from 'msw';
+
+import { renderHook, waitFor } from '@/test-utils/rtl';
+
+import { type ListBatchActionsResponse } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+
+import useListBatchActions from '../use-list-batch-actions';
+
+const mockResponse: ListBatchActionsResponse = {
+  batchActions: [
+    { id: 'batch-1', status: 'RUNNING' },
+    { id: 'batch-2', status: 'COMPLETED' },
+  ],
+  nextPageToken: '',
+};
+
+describe(useListBatchActions.name, () => {
+  it('fetches the first page from the batch-actions endpoint and forwards pageSize', async () => {
+    const { result, getLatestRequest } = setup();
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    const req = getLatestRequest();
+    expect(req.url).toBe('/api/domains/cadence-samples/cluster0/batch-actions');
+    expect(req.search).toEqual({ pageSize: '25' });
+
+    expect(result.current.data?.pages[0]).toEqual(mockResponse);
+  });
+
+  it('surfaces errors from the batch-actions endpoint', async () => {
+    const { result } = setup({ error: true });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error?.message).toBe('Failed to fetch batch actions');
+  });
+});
+
+function setup({ error = false }: { error?: boolean } = {}) {
+  let latestRequest: { url: string; search: Record<string, string> } = {
+    url: '',
+    search: {},
+  };
+
+  const utils = renderHook(
+    () =>
+      useListBatchActions({
+        domain: 'cadence-samples',
+        cluster: 'cluster0',
+        pageSize: 25,
+      }),
+    {
+      endpointsMocks: [
+        {
+          path: '/api/domains/:domain/:cluster/batch-actions',
+          httpMethod: 'GET',
+          mockOnce: false,
+          httpResolver: async ({ request }) => {
+            const url = new URL(request.url);
+            latestRequest = {
+              url: url.pathname,
+              search: Object.fromEntries(url.searchParams.entries()),
+            };
+
+            if (error) {
+              return HttpResponse.json(
+                { message: 'Failed to fetch batch actions' },
+                { status: 500 }
+              );
+            }
+
+            return HttpResponse.json(mockResponse);
+          },
+        },
+      ],
+    }
+  );
+
+  return { ...utils, getLatestRequest: () => latestRequest };
+}

--- a/src/views/shared/hooks/use-list-batch-actions/get-list-batch-actions-query-options.ts
+++ b/src/views/shared/hooks/use-list-batch-actions/get-list-batch-actions-query-options.ts
@@ -1,0 +1,40 @@
+import {
+  type InfiniteData,
+  type UseInfiniteQueryOptions,
+} from '@tanstack/react-query';
+import queryString from 'query-string';
+
+import { type ListBatchActionsResponse } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
+
+import { type UseListBatchActionsParams } from './use-list-batch-actions.types';
+
+export default function getListBatchActionsQueryOptions({
+  domain,
+  cluster,
+  pageSize,
+}: UseListBatchActionsParams): UseInfiniteQueryOptions<
+  ListBatchActionsResponse,
+  RequestError,
+  InfiniteData<ListBatchActionsResponse>,
+  ListBatchActionsResponse,
+  [string, UseListBatchActionsParams],
+  string | undefined
+> {
+  return {
+    queryKey: ['listBatchActions', { domain, cluster, pageSize }],
+    queryFn: ({ pageParam }) =>
+      request(
+        queryString.stringifyUrl({
+          url: `/api/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/batch-actions`,
+          query: {
+            pageSize: pageSize.toString(),
+            nextPage: pageParam,
+          },
+        })
+      ).then((res) => res.json()),
+    initialPageParam: undefined,
+    getNextPageParam: (lastPage) => lastPage.nextPageToken || undefined,
+  };
+}

--- a/src/views/shared/hooks/use-list-batch-actions/use-list-batch-actions.ts
+++ b/src/views/shared/hooks/use-list-batch-actions/use-list-batch-actions.ts
@@ -1,0 +1,9 @@
+'use client';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import getListBatchActionsQueryOptions from './get-list-batch-actions-query-options';
+import { type UseListBatchActionsParams } from './use-list-batch-actions.types';
+
+export default function useListBatchActions(params: UseListBatchActionsParams) {
+  return useInfiniteQuery(getListBatchActionsQueryOptions(params));
+}

--- a/src/views/shared/hooks/use-list-batch-actions/use-list-batch-actions.types.ts
+++ b/src/views/shared/hooks/use-list-batch-actions/use-list-batch-actions.types.ts
@@ -1,0 +1,5 @@
+import { type RouteParams as ListBatchActionsRouteParams } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+
+export type UseListBatchActionsParams = ListBatchActionsRouteParams & {
+  pageSize: number;
+};


### PR DESCRIPTION
Stacked on top of #1312.

---

## Summary

- Adds `useListBatchActions` Query hook for the new `list-batch-actions` endpoint.
- Takes `{ domain, cluster, pageSize }`, uses `useInfiniteQuery`, forwards `nextPageToken` via `getNextPageParam`.
- No consumer yet; the sidebar wire-up ships in the next PR.
