### PR TITLE
fix: Format verbose cause enum on workflow initiation failed events

### DIFF
--- a/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts.snapshot
+++ b/src/utils/data-formatters/format-workflow-history-event/__tests__/index.test.ts.snapshot
@@ -413,7 +413,7 @@ exports[`formatWorkflowHistoryEvent should format workflow requestCancelActivity
 
 exports[`formatWorkflowHistoryEvent should format workflow requestCancelExternalWorkflowExecutionFailedEventAttributes to match snapshot 1`] = `
 {
-  "cause": "CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID",
+  "cause": "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION",
   "control": null,
   "decisionTaskCompletedEventId": 24,
   "domain": "cadence-domain",
@@ -450,7 +450,7 @@ exports[`formatWorkflowHistoryEvent should format workflow requestCancelExternal
 
 exports[`formatWorkflowHistoryEvent should format workflow signalExternalWorkflowExecutionFailedEventAttributes to match snapshot 1`] = `
 {
-  "cause": "SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID",
+  "cause": "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION",
   "control": 0,
   "decisionTaskCompletedEventId": 4,
   "domain": "cadence-domain",
@@ -491,7 +491,7 @@ exports[`formatWorkflowHistoryEvent should format workflow signalExternalWorkflo
 
 exports[`formatWorkflowHistoryEvent should format workflow startChildWorkflowExecutionFailedEventAttributes to match snapshot 1`] = `
 {
-  "cause": "CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID",
+  "cause": "WORKFLOW_ALREADY_RUNNING",
   "control": null,
   "decisionTaskCompletedEventId": 4,
   "domain": "cadence-domain",

--- a/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-request-cancel-external-workflow-execution-failed-event.ts
@@ -1,4 +1,5 @@
 import formatBase64Payload from '../format-base64-payload';
+import formatEnum from '../format-enum';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type RequestCancelExternalWorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
@@ -18,7 +19,7 @@ const formatRequestCancelExternalWorkflowExecutionFailedEvent = ({
 
   return {
     ...primaryCommonFields,
-    cause,
+    cause: formatEnum(cause, 'CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE'),
     control: control ? parseInt(formatBase64Payload(control)) : null,
     initiatedEventId: parseInt(initiatedEventId),
     ...eventAttributes,

--- a/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-signal-external-workflow-execution-failed-event.ts
@@ -1,4 +1,5 @@
 import formatBase64Payload from '../format-base64-payload';
+import formatEnum from '../format-enum';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type SignalExternalWorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
@@ -19,7 +20,7 @@ const formatSignalExternalWorkflowExecutionFailedEvent = ({
   return {
     ...primaryCommonFields,
     ...eventAttributes,
-    cause,
+    cause: formatEnum(cause, 'SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE'),
     control: control ? parseInt(formatBase64Payload(control)) : null,
     initiatedEventId: parseInt(initiatedEventId),
     decisionTaskCompletedEventId: parseInt(decisionTaskCompletedEventId),

--- a/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
+++ b/src/utils/data-formatters/format-workflow-history-event/format-start-child-workflow-execution-failed-event.ts
@@ -1,4 +1,5 @@
 import formatBase64Payload from '../format-base64-payload';
+import formatEnum from '../format-enum';
 
 import formatWorkflowCommonEventFields from './format-workflow-common-event-fields';
 import { type StartChildWorkflowExecutionFailedEvent } from './format-workflow-history-event.type';
@@ -18,7 +19,7 @@ const formatStartChildWorkflowExecutionFailedEvent = ({
 
   return {
     ...primaryCommonFields,
-    cause,
+    cause: formatEnum(cause, 'CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE'),
     ...eventAttributes,
     control: control ? parseInt(formatBase64Payload(control)) : null,
     initiatedEventId: parseInt(initiatedEventId),

--- a/src/views/workflow-history-v2/__fixtures__/workflow-history-child-workflow-events.ts
+++ b/src/views/workflow-history-v2/__fixtures__/workflow-history-child-workflow-events.ts
@@ -66,7 +66,7 @@ export const initiateFailureChildWorkflowEvent = {
     },
     control: '',
     decisionTaskCompletedEventId: '4',
-    cause: 'CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID',
+    cause: 'CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_RUNNING',
     initiatedEventId: '',
   },
   attributes: 'startChildWorkflowExecutionFailedEventAttributes',

--- a/src/views/workflow-history-v2/__fixtures__/workflow-history-request-cancel-external-workflow-events.ts
+++ b/src/views/workflow-history-v2/__fixtures__/workflow-history-request-cancel-external-workflow-events.ts
@@ -56,7 +56,8 @@ export const failRequestCancelExternalWorkflowEvent = {
       runId: '',
     },
     control: '',
-    cause: 'CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID',
+    cause:
+      'CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION',
     initiatedEventId: '25',
   },
   attributes: 'requestCancelExternalWorkflowExecutionFailedEventAttributes',

--- a/src/views/workflow-history-v2/__fixtures__/workflow-history-signal-external-workflow-events.ts
+++ b/src/views/workflow-history-v2/__fixtures__/workflow-history-signal-external-workflow-events.ts
@@ -54,7 +54,8 @@ export const failSignalExternalWorkflowEvent = {
   version: '575102',
   taskId: '8090823672',
   signalExternalWorkflowExecutionFailedEventAttributes: {
-    cause: 'SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID',
+    cause:
+      'SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION',
     decisionTaskCompletedEventId: '4',
     initiatedEventId: '30',
     domain: 'cadence-domain',

--- a/src/views/workflow-history/__fixtures__/workflow-history-child-workflow-events.ts
+++ b/src/views/workflow-history/__fixtures__/workflow-history-child-workflow-events.ts
@@ -66,7 +66,7 @@ export const initiateFailureChildWorkflowEvent = {
     },
     control: '',
     decisionTaskCompletedEventId: '4',
-    cause: 'CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID',
+    cause: 'CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_RUNNING',
     initiatedEventId: '',
   },
   attributes: 'startChildWorkflowExecutionFailedEventAttributes',

--- a/src/views/workflow-history/__fixtures__/workflow-history-request-cancel-external-workflow-events.ts
+++ b/src/views/workflow-history/__fixtures__/workflow-history-request-cancel-external-workflow-events.ts
@@ -56,7 +56,8 @@ export const failRequestCancelExternalWorkflowEvent = {
       runId: '',
     },
     control: '',
-    cause: 'CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID',
+    cause:
+      'CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION',
     initiatedEventId: '25',
   },
   attributes: 'requestCancelExternalWorkflowExecutionFailedEventAttributes',

--- a/src/views/workflow-history/__fixtures__/workflow-history-signal-external-workflow-events.ts
+++ b/src/views/workflow-history/__fixtures__/workflow-history-signal-external-workflow-events.ts
@@ -54,7 +54,8 @@ export const failSignalExternalWorkflowEvent = {
   version: '575102',
   taskId: '8090823672',
   signalExternalWorkflowExecutionFailedEventAttributes: {
-    cause: 'SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_INVALID',
+    cause:
+      'SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED_CAUSE_UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION',
     decisionTaskCompletedEventId: '4',
     initiatedEventId: '30',
     domain: 'cadence-domain',


### PR DESCRIPTION
Use `formatEnum` to strip verbose prefixes from cause fields on child workflow, signal external, and cancel external initiation failed events.

<img width="736" height="306" alt="image" src="https://github.com/user-attachments/assets/34ce49a1-0847-4959-8817-23eea67bcc4c" />
<img width="711" height="278" alt="image" src="https://github.com/user-attachments/assets/2ff8097f-0636-4238-b6bf-5ac1d31a169c" />
<img width="723" height="284" alt="image" src="https://github.com/user-attachments/assets/0b9dda72-26b8-488c-8cf2-91d893ed5ad1" />
