### PR TITLE
fix(domains-page): forward auth token to ListDomains on server-side render

### DIFF
--- a/src/views/domains-page/helpers/__tests__/get-domains-for-cluster.node.ts
+++ b/src/views/domains-page/helpers/__tests__/get-domains-for-cluster.node.ts
@@ -1,3 +1,7 @@
+import {
+  getGrpcMetadataFromAuth,
+  resolveAuthContext,
+} from '@/utils/auth/auth-context';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 import { GRPCError } from '@/utils/grpc/grpc-error';
 import logger from '@/utils/logger';
@@ -7,6 +11,7 @@ import { getDomainObj } from '../../__fixtures__/domains';
 import * as filterIrrelevantDomainsModule from '../filter-irrelevant-domains';
 import getDomainsForCluster from '../get-domains-for-cluster';
 
+jest.mock('@/utils/auth/auth-context');
 jest.mock('@/utils/grpc/grpc-client');
 jest.mock('@/utils/logger');
 jest.mock('../filter-irrelevant-domains');
@@ -14,12 +19,24 @@ jest.mock('../filter-irrelevant-domains');
 describe(getDomainsForCluster.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.mocked(resolveAuthContext).mockResolvedValue({
+      authEnabled: true,
+      auth: { isValidToken: true, token: 'mock-token' },
+      groups: [],
+      isAdmin: true,
+    });
+    jest
+      .mocked(getGrpcMetadataFromAuth)
+      .mockReturnValue({ 'cadence-authorization': 'mock-token' });
   });
 
   it('calls listDomains with the correct pageSize and returns filtered domains', async () => {
     const { result, mockListDomains, mockFilterIrrelevantDomains } =
       await setup({ domainsCount: 2 });
 
+    expect(grpcClient.getClusterMethods).toHaveBeenCalledWith('test-cluster', {
+      'cadence-authorization': 'mock-token',
+    });
     expect(mockListDomains).toHaveBeenCalledWith({ pageSize: 1000 });
     expect(mockFilterIrrelevantDomains).toHaveBeenCalledWith(
       'test-cluster',
@@ -110,6 +127,7 @@ async function setup({
       domains: Array.from({ length: domainsCount }, (_, i) =>
         getDomainObj({ id: `domain-${i + 1}`, name: `Domain ${i + 1}` })
       ),
+      nextPageToken: '',
     });
   }
 

--- a/src/views/domains-page/helpers/get-domains-for-cluster.ts
+++ b/src/views/domains-page/helpers/get-domains-for-cluster.ts
@@ -1,5 +1,9 @@
 import 'server-only';
 
+import {
+  getGrpcMetadataFromAuth,
+  resolveAuthContext,
+} from '@/utils/auth/auth-context';
 import * as grpcClient from '@/utils/grpc/grpc-client';
 import { GRPCError } from '@/utils/grpc/grpc-error';
 import logger from '@/utils/logger';
@@ -10,7 +14,11 @@ export default async function getDomainsForCluster(
   clusterName: string,
   pageSize: number
 ) {
-  const clusterMethods = await grpcClient.getClusterMethods(clusterName);
+  const authContext = await resolveAuthContext();
+  const clusterMethods = await grpcClient.getClusterMethods(
+    clusterName,
+    getGrpcMetadataFromAuth(authContext)
+  );
 
   return clusterMethods.listDomains({ pageSize }).then(
     ({ domains }) => {


### PR DESCRIPTION
What changed?

resolve the auth context in `getDomainsForCluster` and pass `getGrpcMetadataFromAuth(authContext)` to `getClusterMethods`, matching what every API route handler already does via the `grpc-metadata` middleware.

Why?

The domains page renders server-side and calls `ListDomains` via `getDomainsForCluster`, but that helper is the only caller of `grpcClient.getClusterMethods` outside the route-handlers middleware and never pulls the auth context, so the user's JWT cookie was not forwarded to the backend.
Until now this was harmless because `ListDomains` was not authorized on the backend. With [cadence#8117](https://github.com/cadence-workflow/cadence/pull/8117) the frontend access-controlled wrapper now filters every returned domain through `Authorize`, and an unauthenticated request is denied for every domain. The UI shows an empty domains list even when the user has a valid token in the cookie.

How did you test it?
- `npm run test:unit:node get-domains-for-cluster.node.ts`
- `npm run lint && npm run typecheck`
- Manual: with `CADENCE_WEB_AUTH_STRATEGY=jwt` and a token that should see domains, the page lists them against a backend with cadence#8117. Without the fix, same setup → empty list.
 