### PR TITLE
refactor: make Domain Page actions menu more customizable + improve styling

### DIFF
--- a/src/views/domain-page/config/domain-page-actions.config.ts
+++ b/src/views/domain-page/config/domain-page-actions.config.ts
@@ -1,22 +1,22 @@
 import { MdOutlinePlayArrow, MdPlaylistPlay } from 'react-icons/md';
 
-import type { DomainPageActionConfig } from '../domain-page-actions-dropdown/domain-page-actions-dropdown.types';
+import DomainPageActionsBatchWorkflow from '../domain-page-actions-batch-workflow/domain-page-actions-batch-workflow';
+import { type DomainPageActionConfig } from '../domain-page-actions-dropdown/domain-page-actions-dropdown.types';
+import DomainPageActionsStartWorkflow from '../domain-page-actions-start-workflow/domain-page-actions-start-workflow';
 
-export const startWorkflowDomainAction: DomainPageActionConfig = {
-  id: 'start-workflow',
-  label: 'Start new workflow',
-  icon: MdOutlinePlayArrow,
-};
-
-export const batchWorkflowDomainAction: DomainPageActionConfig = {
-  id: 'batch-workflow-actions',
-  label: 'Batch workflow actions',
-  icon: MdPlaylistPlay,
-};
-
-const domainPageActionsConfig = [
-  startWorkflowDomainAction,
-  batchWorkflowDomainAction,
-] as const satisfies DomainPageActionConfig[];
+const domainPageActionsConfig: Array<DomainPageActionConfig> = [
+  {
+    id: 'start-workflow',
+    label: 'Start new workflow',
+    icon: MdOutlinePlayArrow,
+    actionButton: DomainPageActionsStartWorkflow,
+  },
+  {
+    id: 'batch-workflow-actions',
+    label: 'Batch workflow actions',
+    icon: MdPlaylistPlay,
+    actionButton: DomainPageActionsBatchWorkflow,
+  },
+];
 
 export default domainPageActionsConfig;

--- a/src/views/domain-page/domain-page-actions-batch-workflow/__tests__/domain-page-actions-batch-workflow.test.tsx
+++ b/src/views/domain-page/domain-page-actions-batch-workflow/__tests__/domain-page-actions-batch-workflow.test.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+
+import { type IconProps } from 'baseui/icon';
+import { HttpResponse } from 'msw';
+
+import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
+
+import { type GetConfigResponse } from '@/route-handlers/get-config/get-config.types';
+
+import { type DomainPageActionButtonProps } from '../../domain-page-actions-dropdown/domain-page-actions-dropdown.types';
+import DomainPageActionsBatchWorkflow from '../domain-page-actions-batch-workflow';
+
+function MockIcon({ size }: IconProps) {
+  return <span data-testid="mock-icon" data-size={size} />;
+}
+
+const mockPush = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+}));
+
+jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
+  jest.fn(() => [{ query: 'WorkflowType = "test"' }])
+);
+
+jest.mock(
+  '../../domain-page-base-action-button/domain-page-base-action-button',
+  () =>
+    jest.fn(
+      ({
+        label,
+        onClick,
+        disabledReason,
+      }: {
+        label: string;
+        onClick: () => void;
+        disabledReason?: string;
+      }) => (
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={Boolean(disabledReason)}
+          aria-label={disabledReason ?? label}
+          data-testid="domain-page-base-action-button"
+        >
+          {label}
+        </button>
+      )
+    )
+);
+
+describe(DomainPageActionsBatchWorkflow.name, () => {
+  const defaultProps: DomainPageActionButtonProps = {
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+    label: 'Batch workflow actions',
+    icon: MockIcon,
+    onCloseMenu: jest.fn(),
+  };
+
+  const originalWindow = window;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    window = Object.create(window);
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalWindow.location,
+        search: '?status=RUNNING',
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    window = originalWindow;
+  });
+
+  it('renders nothing when batch actions are disabled', async () => {
+    setup(defaultProps, { enableBatchActions: false });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing while batch actions config is loading', () => {
+    setup(defaultProps, { isConfigLoading: true });
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when batch actions config errors', async () => {
+    setup(defaultProps, { isConfigError: true });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders the batch workflow action button when enabled', async () => {
+    setup(defaultProps);
+
+    expect(
+      await screen.findByRole('button', { name: 'Batch workflow actions' })
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to batch actions with query params when clicked', async () => {
+    const { user } = setup(defaultProps);
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Batch workflow actions' })
+    );
+
+    expect(mockPush).toHaveBeenCalledWith(
+      'batch-actions?status=RUNNING&batch-query=WorkflowType+%3D+%22test%22&bid=draft'
+    );
+  });
+});
+
+function setup(
+  props: DomainPageActionButtonProps,
+  options: {
+    enableBatchActions?: boolean;
+    isConfigLoading?: boolean;
+    isConfigError?: boolean;
+  } = {}
+) {
+  const user = userEvent.setup();
+  const {
+    enableBatchActions = true,
+    isConfigLoading = false,
+    isConfigError = false,
+  } = options;
+
+  render(<DomainPageActionsBatchWorkflow {...props} />, {
+    endpointsMocks: [
+      {
+        path: '/api/config',
+        httpMethod: 'GET',
+        mockOnce: false,
+        httpResolver: async ({ request }) => {
+          const url = new URL(request.url);
+          const configKey = url.searchParams.get('configKey');
+
+          if (configKey !== 'BATCH_ACTIONS_ENABLED') {
+            return HttpResponse.json(false);
+          }
+
+          if (isConfigError) {
+            return HttpResponse.json(
+              { error: 'Config error' },
+              { status: 500 }
+            );
+          }
+
+          if (isConfigLoading) {
+            return new Promise(() => {});
+          }
+
+          return HttpResponse.json(
+            enableBatchActions satisfies GetConfigResponse<'BATCH_ACTIONS_ENABLED'>
+          );
+        },
+      },
+    ],
+  });
+
+  return { user };
+}

--- a/src/views/domain-page/domain-page-actions-batch-workflow/domain-page-actions-batch-workflow.tsx
+++ b/src/views/domain-page/domain-page-actions-batch-workflow/domain-page-actions-batch-workflow.tsx
@@ -1,0 +1,40 @@
+import { useRouter } from 'next/navigation';
+
+import useConfigValue from '@/hooks/use-config-value/use-config-value';
+import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
+
+import domainPageQueryParamsConfig from '../config/domain-page-query-params.config';
+import { type DomainPageActionButtonProps } from '../domain-page-actions-dropdown/domain-page-actions-dropdown.types';
+import DomainPageBaseActionButton from '../domain-page-base-action-button/domain-page-base-action-button';
+
+export default function DomainPageActionsBatchWorkflow({
+  label,
+  icon,
+  onCloseMenu,
+}: DomainPageActionButtonProps) {
+  const router = useRouter();
+  const [queryParams] = usePageQueryParams(domainPageQueryParamsConfig);
+
+  const {
+    data: isBatchActionsEnabled,
+    isError,
+    isLoading,
+  } = useConfigValue('BATCH_ACTIONS_ENABLED');
+
+  if (!isBatchActionsEnabled) return null;
+
+  return (
+    <DomainPageBaseActionButton
+      label={label}
+      icon={icon}
+      disabledReason={isError || isLoading ? 'Action Unavailable' : undefined}
+      onClick={() => {
+        const params = new URLSearchParams(window.location.search);
+        params.set('batch-query', queryParams.query ?? '');
+        params.set('bid', 'draft');
+        router.push(`batch-actions?${params.toString()}`);
+        onCloseMenu();
+      }}
+    />
+  );
+}

--- a/src/views/domain-page/domain-page-actions-dropdown/__tests__/domain-page-actions-dropdown.test.tsx
+++ b/src/views/domain-page/domain-page-actions-dropdown/__tests__/domain-page-actions-dropdown.test.tsx
@@ -1,374 +1,62 @@
-import React, { useState } from 'react';
-
-import { HttpResponse } from 'msw';
-
-import { render, screen, waitFor, userEvent } from '@/test-utils/rtl';
-
-import { type WorkflowActionEnabledConfigValue } from '@/config/dynamic/resolvers/workflow-actions-enabled.types';
-import mockResolvedConfigValues from '@/utils/config/__fixtures__/resolved-config-values';
-import {
-  mockWorkflowActionsConfig,
-  mockStartActionConfig,
-} from '@/views/workflow-actions/__fixtures__/workflow-actions-config';
-import getActionDisabledReason from '@/views/workflow-actions/workflow-actions-menu/helpers/get-action-disabled-reason';
+import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import DomainPageActionsDropdown from '../domain-page-actions-dropdown';
-import type { Props } from '../domain-page-actions-dropdown.types';
-
-const mockRouterPush = jest.fn();
-jest.mock('next/navigation', () => ({
-  ...jest.requireActual('next/navigation'),
-  useRouter: () => ({ push: mockRouterPush }),
-}));
-
-const mockUsePageQueryParams = jest.fn();
-jest.mock('@/hooks/use-page-query-params/use-page-query-params', () => ({
-  __esModule: true,
-  default: (...args: Array<unknown>) => mockUsePageQueryParams(...args),
-}));
-
-jest.mock('@/views/workflow-actions/config/workflow-actions.config', () => {
-  return {
-    default: mockWorkflowActionsConfig,
-    startWorkflowActionConfig: mockStartActionConfig,
-  };
-});
+import type {
+  DomainPageActionConfig,
+  Props,
+} from '../domain-page-actions-dropdown.types';
 
 jest.mock('../../config/domain-page-actions.config', () => {
-  const startAction = {
-    id: 'start-workflow',
-    label: 'Start new workflow',
-    icon: () => 'start-icon',
-  };
-  const batchAction = {
-    id: 'batch-workflow-actions',
-    label: 'Batch workflow actions',
-    icon: () => 'batch-icon',
-  };
   return {
     __esModule: true,
-    default: [startAction, batchAction],
-    startWorkflowDomainAction: startAction,
-    batchWorkflowDomainAction: batchAction,
+    default: [
+      {
+        id: 'start-workflow',
+        label: 'Start new workflow',
+        icon: () => <div>Mock icon</div>,
+        actionButton: ({ label }) => <button>{label}</button>,
+      },
+      {
+        id: 'batch-workflow-actions',
+        label: 'Batch workflow actions',
+        icon: () => <div>Mock icon</div>,
+        actionButton: ({ label }) => <button>{label}</button>,
+      },
+    ] satisfies Array<DomainPageActionConfig>,
   };
 });
-
-jest.mock('@/components/button/button', () =>
-  jest.fn((props) => {
-    return (
-      <button
-        onClick={props.onClick}
-        data-testid="domain-actions-button"
-        disabled={props.disabled}
-      >
-        {JSON.stringify({
-          isLoading: props.isLoading,
-        })}
-        {props.children}
-      </button>
-    );
-  })
-);
-
-jest.mock('baseui/popover', () => {
-  return {
-    ...jest.requireActual('baseui/popover'),
-    StatefulPopover: jest.fn(({ content, children }) => {
-      const [isShown, setIsShown] = useState(false);
-      return (
-        <>
-          <div data-testid="popover-trigger" onClick={() => setIsShown(true)}>
-            {children}
-          </div>
-          {isShown && (
-            <div data-testid="popover-content">
-              {typeof content === 'function'
-                ? content({ close: () => setIsShown(false) })
-                : content}
-            </div>
-          )}
-        </>
-      );
-    }),
-  };
-});
-
-jest.mock('baseui/tooltip', () => {
-  return {
-    ...jest.requireActual('baseui/tooltip'),
-    StatefulTooltip: jest.fn((props) => {
-      return (
-        <>
-          <div data-testid="tooltip">{props.content}</div>
-          {props.children}
-        </>
-      );
-    }),
-  };
-});
-
-jest.mock(
-  '@/views/workflow-actions/workflow-actions-modal/workflow-actions-modal',
-  () =>
-    jest.fn((props) => {
-      return (
-        <div data-testid="actions-modal">
-          Actions Modal
-          <button data-testid="close-modal-button" onClick={props.onClose}>
-            Close
-          </button>
-        </div>
-      );
-    })
-);
-
-jest.mock(
-  '@/views/workflow-actions/workflow-actions-menu/helpers/get-action-disabled-reason'
-);
-const mockGetActionDisabledReason = getActionDisabledReason as jest.Mock;
 
 describe(DomainPageActionsDropdown.name, () => {
-  // Batch actions disabled by default; tests that need them enabled pass isBatchActionsEnabled: true.
   const defaultProps: Props = {
     domain: 'test-domain',
     cluster: 'test-cluster',
-    isBatchActionsEnabled: false,
   };
 
   beforeEach(() => {
-    // clearAllMocks resets call records but not implementations, so mock return values need explicit resets below.
     jest.clearAllMocks();
-    mockGetActionDisabledReason.mockReturnValue(undefined); // "action enabled" baseline; some tests override to a disabled reason
-    mockUsePageQueryParams.mockReturnValue([{ query: '' }, jest.fn()]); // empty-query baseline; component crashes if this returns undefined
   });
 
-  describe('trigger button', () => {
-    it('renders the domain actions button', async () => {
-      await setup(defaultProps);
+  it('renders the domain actions trigger button', () => {
+    setup(defaultProps);
 
-      expect(screen.getByTestId('domain-actions-button')).toBeInTheDocument();
-    });
-
-    it('passes isLoading as true when config is loading', async () => {
-      await setup(defaultProps, {
-        isConfigLoading: true,
-      });
-
-      expect(screen.getByTestId('domain-actions-button')).toHaveTextContent(
-        /"isLoading":true/
-      );
-    });
-
-    it('passes isLoading as true when config errors', async () => {
-      await setup(defaultProps, {
-        isConfigError: true,
-      });
-
-      expect(screen.getByTestId('domain-actions-button')).toHaveTextContent(
-        /"isLoading":true/
-      );
-    });
+    expect(
+      screen.getByRole('button', { name: 'Domain actions' })
+    ).toBeInTheDocument();
   });
 
-  describe('menu actions', () => {
-    it('shows only start workflow action when batch is disabled', async () => {
-      const { user } = await setup(defaultProps);
+  it('renders each configured action in the popover menu', async () => {
+    const { user } = setup(defaultProps);
 
-      await user.click(screen.getByTestId('popover-trigger'));
+    await user.click(screen.getByRole('button', { name: 'Domain actions' }));
 
-      expect(screen.getByText('Start new workflow')).toBeInTheDocument();
-      expect(
-        screen.queryByText('Batch workflow actions')
-      ).not.toBeInTheDocument();
-    });
-
-    it('shows both actions when batch is enabled', async () => {
-      const { user } = await setup({
-        ...defaultProps,
-        isBatchActionsEnabled: true,
-      });
-
-      await user.click(screen.getByTestId('popover-trigger'));
-
-      expect(screen.getByText('Start new workflow')).toBeInTheDocument();
-      expect(screen.getByText('Batch workflow actions')).toBeInTheDocument();
-    });
-
-    it('disables start workflow when action config disables it', async () => {
-      const disabledReason = 'Workflow action has been disabled';
-      mockGetActionDisabledReason.mockReturnValue(disabledReason);
-
-      const { user } = await setup(defaultProps);
-
-      await user.click(screen.getByTestId('popover-trigger'));
-
-      expect(screen.getByText(disabledReason)).toBeInTheDocument();
-    });
-
-    it('calls getActionDisabledReason with correct parameters', async () => {
-      await setup(defaultProps, {
-        startActionEnabledConfig: 'ENABLED',
-      });
-
-      await waitFor(() => {
-        expect(mockGetActionDisabledReason).toHaveBeenCalledWith({
-          actionEnabledConfig: 'ENABLED',
-          actionRunnableStatus: 'RUNNABLE',
-        });
-      });
-    });
-  });
-
-  describe('start workflow modal', () => {
-    it('opens modal when start workflow is clicked', async () => {
-      const { user } = await setup(defaultProps);
-
-      await user.click(screen.getByTestId('popover-trigger'));
-
-      expect(screen.queryByTestId('actions-modal')).not.toBeInTheDocument();
-
-      await user.click(screen.getByText('Start new workflow'));
-
-      expect(screen.getByTestId('actions-modal')).toBeInTheDocument();
-    });
-
-    it('closes modal when onClose is called', async () => {
-      const { user } = await setup(defaultProps);
-
-      await user.click(screen.getByTestId('popover-trigger'));
-      await user.click(screen.getByText('Start new workflow'));
-
-      expect(screen.getByTestId('actions-modal')).toBeInTheDocument();
-
-      await user.click(screen.getByTestId('close-modal-button'));
-
-      expect(screen.queryByTestId('actions-modal')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('batch workflow actions', () => {
-    it('navigates to batch-actions tab with empty batch-query when clicked without a workflows query', async () => {
-      const { user } = await setup({
-        ...defaultProps,
-        isBatchActionsEnabled: true,
-      });
-
-      await user.click(screen.getByTestId('popover-trigger'));
-      await user.click(screen.getByText('Batch workflow actions'));
-
-      expect(mockRouterPush).toHaveBeenCalledWith(
-        'batch-actions?batch-query=&bid=draft'
-      );
-    });
-
-    it('seeds batch-query from current query when navigating', async () => {
-      mockUsePageQueryParams.mockReturnValue([
-        { query: 'WorkflowType="foo"' },
-        jest.fn(),
-      ]);
-      const { user } = await setup({
-        ...defaultProps,
-        isBatchActionsEnabled: true,
-      });
-
-      await user.click(screen.getByTestId('popover-trigger'));
-      await user.click(screen.getByText('Batch workflow actions'));
-
-      const pushedTo = mockRouterPush.mock.calls[0][0];
-      const url = new URL(pushedTo, 'http://example.com/');
-      expect(url.pathname).toBe('/batch-actions');
-      expect(url.searchParams.get('batch-query')).toBe('WorkflowType="foo"');
-      expect(url.searchParams.get('bid')).toBe('draft');
-    });
-
-    it('propagates workflows query param into batch-query when navigating', async () => {
-      window.history.pushState({}, '', '?query=WorkflowType%3D%22bar%22');
-      mockUsePageQueryParams.mockReturnValue([
-        { query: 'WorkflowType="bar"' },
-        jest.fn(),
-      ]);
-
-      const { user } = await setup({
-        ...defaultProps,
-        isBatchActionsEnabled: true,
-      });
-
-      await user.click(screen.getByTestId('popover-trigger'));
-      await user.click(screen.getByText('Batch workflow actions'));
-
-      const pushedTo = mockRouterPush.mock.calls[0][0];
-      const url = new URL(pushedTo, 'http://example.com/');
-      expect(url.searchParams.get('batch-query')).toBe('WorkflowType="bar"');
-      expect(url.searchParams.get('bid')).toBe('draft');
-
-      window.history.pushState({}, '', '/');
-    });
-
-    it('preserves existing URL search params when navigating', async () => {
-      window.history.pushState({}, '', '?input=query&query=foo');
-
-      const { user } = await setup({
-        ...defaultProps,
-        isBatchActionsEnabled: true,
-      });
-
-      await user.click(screen.getByTestId('popover-trigger'));
-      await user.click(screen.getByText('Batch workflow actions'));
-
-      const pushedTo = mockRouterPush.mock.calls[0][0];
-      const url = new URL(pushedTo, 'http://example.com/');
-      expect(url.searchParams.get('input')).toBe('query');
-      expect(url.searchParams.get('query')).toBe('foo');
-      expect(url.searchParams.get('batch-query')).toBe('');
-      expect(url.searchParams.get('bid')).toBe('draft');
-
-      window.history.pushState({}, '', '/');
-    });
+    expect(screen.getByText('Start new workflow')).toBeInTheDocument();
+    expect(screen.getByText('Batch workflow actions')).toBeInTheDocument();
   });
 });
 
-function setup(
-  props: Props,
-  options: {
-    startActionEnabledConfig?: WorkflowActionEnabledConfigValue;
-    isConfigLoading?: boolean;
-    isConfigError?: boolean;
-  } = {}
-) {
+function setup(props: Props) {
   const user = userEvent.setup();
-  const {
-    startActionEnabledConfig = mockResolvedConfigValues.WORKFLOW_ACTIONS_ENABLED
-      .start,
-    isConfigLoading = false,
-    isConfigError = false,
-  } = options;
-
-  const renderResult = render(<DomainPageActionsDropdown {...props} />, {
-    endpointsMocks: [
-      {
-        path: '/api/config',
-        httpMethod: 'GET',
-        mockOnce: true,
-        httpResolver: async () => {
-          if (isConfigError) {
-            return HttpResponse.json(
-              { error: 'Config error' },
-              { status: 500 }
-            );
-          }
-          if (isConfigLoading) {
-            return new Promise(() => {});
-          }
-
-          const response = {
-            ...mockResolvedConfigValues.WORKFLOW_ACTIONS_ENABLED,
-            start: startActionEnabledConfig,
-          };
-          return HttpResponse.json(response);
-        },
-      },
-    ],
-  });
+  const renderResult = render(<DomainPageActionsDropdown {...props} />);
 
   return {
     user,

--- a/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.styles.ts
+++ b/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.styles.ts
@@ -8,6 +8,7 @@ export const styled = {
     flexDirection: 'column',
     alignItems: 'stretch',
     padding: $theme.sizing.scale200,
+    minWidth: '250px',
   })),
 };
 

--- a/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.styles.ts
+++ b/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.styles.ts
@@ -1,5 +1,4 @@
 import { styled as createStyled, type Theme } from 'baseui';
-import { type ButtonOverrides } from 'baseui/button';
 import { type PopoverOverrides } from 'baseui/popover';
 import type { StyleObject } from 'styletron-react';
 
@@ -9,14 +8,6 @@ export const styled = {
     flexDirection: 'column',
     alignItems: 'stretch',
     padding: $theme.sizing.scale200,
-  })),
-  MenuItemContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    display: 'flex',
-    gap: $theme.sizing.scale500,
-    alignItems: 'center',
-  })),
-  MenuItemLabel: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    ...$theme.typography.LabelSmall,
   })),
 };
 
@@ -28,12 +19,4 @@ export const overrides = {
       }),
     },
   } satisfies PopoverOverrides,
-  button: {
-    BaseButton: {
-      style: {
-        width: '100%',
-        justifyContent: 'flex-start',
-      } satisfies StyleObject,
-    },
-  } satisfies ButtonOverrides,
 };

--- a/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.tsx
+++ b/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.tsx
@@ -1,24 +1,12 @@
 'use client';
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 
-import { Button, KIND } from 'baseui/button';
 import { StatefulPopover } from 'baseui/popover';
-import { StatefulTooltip } from 'baseui/tooltip';
-import { useRouter } from 'next/navigation';
 import { MdArrowDropDown } from 'react-icons/md';
 
 import CustomButton from '@/components/button/button';
-import useConfigValue from '@/hooks/use-config-value/use-config-value';
-import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
-import { startWorkflowActionConfig } from '@/views/workflow-actions/config/workflow-actions.config';
-import getActionDisabledReason from '@/views/workflow-actions/workflow-actions-menu/helpers/get-action-disabled-reason';
-import WorkflowActionsModal from '@/views/workflow-actions/workflow-actions-modal/workflow-actions-modal';
 
-import domainPageActionsConfig, {
-  batchWorkflowDomainAction,
-  startWorkflowDomainAction,
-} from '../config/domain-page-actions.config';
-import domainPageQueryParamsConfig from '../config/domain-page-query-params.config';
+import domainPageActionsConfig from '../config/domain-page-actions.config';
 
 import { styled, overrides } from './domain-page-actions-dropdown.styles';
 import type {
@@ -26,126 +14,36 @@ import type {
   Props,
 } from './domain-page-actions-dropdown.types';
 
-export default function DomainPageActionsDropdown({
-  domain,
-  cluster,
-  isBatchActionsEnabled,
-}: Props) {
-  const router = useRouter();
-  const [queryParams] = usePageQueryParams(domainPageQueryParamsConfig);
-
-  const [showStartNewWorkflowModal, setShowStartNewWorkflowModal] =
-    useState(false);
-
-  const {
-    data: actionsEnabledConfig,
-    isLoading: isActionsEnabledLoading,
-    isError: isActionsEnabledError,
-  } = useConfigValue('WORKFLOW_ACTIONS_ENABLED', {
-    domain,
-    cluster,
-  });
-
-  const startDisabledReason = getActionDisabledReason({
-    actionEnabledConfig: actionsEnabledConfig?.start,
-    actionRunnableStatus: 'RUNNABLE',
-  });
-
-  const visibleActions = useMemo(() => {
-    return domainPageActionsConfig.filter((action) => {
-      if (action.id === batchWorkflowDomainAction.id) {
-        return isBatchActionsEnabled;
-      }
-      return true;
-    });
-  }, [isBatchActionsEnabled]);
-
-  const getDisabledReason = (action: DomainPageActionConfig) => {
-    if (action.id === startWorkflowDomainAction.id) {
-      return startDisabledReason;
-    }
-    return null;
-  };
-
-  const handleActionClick = (action: DomainPageActionConfig) => {
-    if (action.id === startWorkflowDomainAction.id) {
-      setShowStartNewWorkflowModal(true);
-      return;
-    }
-    if (action.id === batchWorkflowDomainAction.id) {
-      const params = new URLSearchParams(window.location.search);
-      params.set('batch-query', queryParams.query ?? '');
-      params.set('bid', 'draft');
-      router.push(`batch-actions?${params.toString()}`);
-    }
-  };
-
+export default function DomainPageActionsDropdown({ domain, cluster }: Props) {
   return (
-    <>
-      <StatefulPopover
-        placement="bottomLeft"
-        overrides={overrides.popover}
-        content={({ close }) => (
-          <styled.MenuItemsContainer>
-            {visibleActions.map((action) => {
-              const disabledReason = getDisabledReason(action);
-              return (
-                <StatefulTooltip
-                  key={action.id}
-                  content={disabledReason ?? null}
-                  ignoreBoundary
-                  placement="auto"
-                  showArrow
-                >
-                  <div>
-                    <Button
-                      kind={KIND.tertiary}
-                      overrides={overrides.button}
-                      onClick={() => {
-                        handleActionClick(action);
-                        close();
-                      }}
-                      disabled={Boolean(disabledReason)}
-                      aria-label={disabledReason ?? undefined}
-                    >
-                      <styled.MenuItemContainer>
-                        <action.icon size={20} />
-                        <styled.MenuItemLabel>
-                          {action.label}
-                        </styled.MenuItemLabel>
-                      </styled.MenuItemContainer>
-                    </Button>
-                  </div>
-                </StatefulTooltip>
-              );
-            })}
-          </styled.MenuItemsContainer>
-        )}
-        returnFocus
-        autoFocus
-      >
-        <CustomButton
-          size="compact"
-          kind="secondary"
-          endEnhancer={<MdArrowDropDown size={16} />}
-          loadingIndicatorType="skeleton"
-          isLoading={isActionsEnabledLoading || isActionsEnabledError}
-        >
-          Domain actions
-        </CustomButton>
-      </StatefulPopover>
-      {showStartNewWorkflowModal && (
-        <WorkflowActionsModal
-          domain={domain}
-          cluster={cluster}
-          runId=""
-          workflowId=""
-          action={startWorkflowActionConfig}
-          onClose={() => {
-            setShowStartNewWorkflowModal(false);
-          }}
-        />
+    <StatefulPopover
+      placement="bottomLeft"
+      overrides={overrides.popover}
+      content={({ close }) => (
+        <styled.MenuItemsContainer>
+          {domainPageActionsConfig.map((action: DomainPageActionConfig) => (
+            <action.actionButton
+              key={action.id}
+              domain={domain}
+              cluster={cluster}
+              label={action.label}
+              icon={action.icon}
+              onCloseMenu={close}
+            />
+          ))}
+        </styled.MenuItemsContainer>
       )}
-    </>
+      returnFocus
+      autoFocus
+    >
+      <CustomButton
+        size="compact"
+        kind="secondary"
+        endEnhancer={<MdArrowDropDown size={16} />}
+        loadingIndicatorType="skeleton"
+      >
+        Domain actions
+      </CustomButton>
+    </StatefulPopover>
   );
 }

--- a/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.types.ts
+++ b/src/views/domain-page/domain-page-actions-dropdown/domain-page-actions-dropdown.types.ts
@@ -1,16 +1,24 @@
 import type { IconProps } from 'baseui/icon';
 
-export type DomainPageActionConfig = {
-  id: string;
+export type DomainPageActionButtonProps = {
+  domain: string;
+  cluster: string;
   label: string;
   icon: React.ComponentType<{
     size?: IconProps['size'];
     color?: IconProps['color'];
   }>;
+  onCloseMenu: () => void;
+};
+
+export type DomainPageActionConfig = {
+  id: string;
+  label: DomainPageActionButtonProps['label'];
+  icon: DomainPageActionButtonProps['icon'];
+  actionButton: React.ComponentType<DomainPageActionButtonProps>;
 };
 
 export type Props = {
   domain: string;
   cluster: string;
-  isBatchActionsEnabled: boolean;
 };

--- a/src/views/domain-page/domain-page-actions-start-workflow/__tests__/domain-page-actions-start-workflow.test.tsx
+++ b/src/views/domain-page/domain-page-actions-start-workflow/__tests__/domain-page-actions-start-workflow.test.tsx
@@ -1,0 +1,233 @@
+import React from 'react';
+
+import { type IconProps } from 'baseui/icon';
+import { HttpResponse } from 'msw';
+
+import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
+
+import { type WorkflowActionEnabledConfigValue } from '@/config/dynamic/resolvers/workflow-actions-enabled.types';
+import mockResolvedConfigValues from '@/utils/config/__fixtures__/resolved-config-values';
+import * as getActionDisabledReasonModule from '@/views/workflow-actions/workflow-actions-menu/helpers/get-action-disabled-reason';
+
+import { type DomainPageActionButtonProps } from '../../domain-page-actions-dropdown/domain-page-actions-dropdown.types';
+import DomainPageActionsStartWorkflow from '../domain-page-actions-start-workflow';
+
+function MockIcon({ size }: IconProps) {
+  return <span data-testid="mock-icon" data-size={size} />;
+}
+
+jest.mock(
+  '../../domain-page-base-action-button/domain-page-base-action-button',
+  () =>
+    jest.fn(
+      ({
+        label,
+        onClick,
+        disabledReason,
+      }: {
+        label: string;
+        onClick: () => void;
+        disabledReason?: string;
+      }) => (
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={Boolean(disabledReason)}
+          aria-label={disabledReason ?? label}
+          data-testid="domain-page-base-action-button"
+        >
+          {label}
+        </button>
+      )
+    )
+);
+
+jest.mock(
+  '@/views/workflow-actions/workflow-actions-menu/helpers/get-action-disabled-reason'
+);
+
+jest.mock(
+  '@/views/workflow-actions/workflow-actions-modal/workflow-actions-modal',
+  () =>
+    jest.fn((props: { onClose: () => void }) => (
+      <div data-testid="actions-modal">
+        Actions Modal
+        <button
+          type="button"
+          data-testid="close-modal-button"
+          onClick={props.onClose}
+        >
+          Close
+        </button>
+      </div>
+    ))
+);
+
+describe(DomainPageActionsStartWorkflow.name, () => {
+  const defaultProps: DomainPageActionButtonProps = {
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+    label: 'Start new workflow',
+    icon: MockIcon,
+    onCloseMenu: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the start workflow action button', async () => {
+    setup(defaultProps, { startActionEnabledConfig: 'ENABLED' });
+
+    expect(
+      await screen.findByRole('button', { name: 'Start new workflow' })
+    ).toBeInTheDocument();
+  });
+
+  it('calls getActionDisabledReason with correct parameters', async () => {
+    const { getActionDisabledReasonSpy } = setup(defaultProps, {
+      startActionEnabledConfig: 'ENABLED',
+    });
+
+    await waitFor(() => {
+      expect(getActionDisabledReasonSpy).toHaveBeenCalledWith({
+        actionEnabledConfig: 'ENABLED',
+        actionRunnableStatus: 'RUNNABLE',
+      });
+    });
+  });
+
+  it('disables the button when the action is disabled', async () => {
+    setup(defaultProps, {
+      getActionDisabledReasonReturnValue:
+        'Not authorized to perform this action',
+    });
+
+    expect(
+      await screen.findByRole('button', {
+        name: 'Not authorized to perform this action',
+      })
+    ).toBeDisabled();
+  });
+
+  it('disables the button with Action Unavailable when config is loading', async () => {
+    setup(defaultProps, {
+      isConfigLoading: true,
+      getActionDisabledReasonReturnValue: undefined,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Action Unavailable' })
+      ).toBeDisabled();
+    });
+  });
+
+  it('disables the button with Action Unavailable when config errors', async () => {
+    setup(defaultProps, {
+      isConfigError: true,
+      getActionDisabledReasonReturnValue: undefined,
+    });
+
+    expect(
+      await screen.findByRole('button', { name: 'Action Unavailable' })
+    ).toBeDisabled();
+  });
+
+  it('opens the workflow actions modal when the button is clicked', async () => {
+    const { user } = setup(defaultProps, {
+      startActionEnabledConfig: 'ENABLED',
+    });
+
+    expect(screen.queryByTestId('actions-modal')).not.toBeInTheDocument();
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Start new workflow' })
+    );
+
+    expect(screen.getByTestId('actions-modal')).toBeInTheDocument();
+  });
+
+  it('closes the workflow actions modal when onClose is called', async () => {
+    const { user } = setup(defaultProps, {
+      startActionEnabledConfig: 'ENABLED',
+    });
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Start new workflow' })
+    );
+    expect(screen.getByTestId('actions-modal')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('close-modal-button'));
+
+    expect(screen.queryByTestId('actions-modal')).not.toBeInTheDocument();
+  });
+});
+
+function setup(
+  props: DomainPageActionButtonProps,
+  options: {
+    startActionEnabledConfig?: WorkflowActionEnabledConfigValue;
+    isConfigLoading?: boolean;
+    isConfigError?: boolean;
+    getActionDisabledReasonReturnValue?: string | undefined;
+  } = {}
+) {
+  const user = userEvent.setup();
+  const {
+    startActionEnabledConfig = mockResolvedConfigValues.WORKFLOW_ACTIONS_ENABLED
+      .start,
+    isConfigLoading = false,
+    isConfigError = false,
+  } = options;
+
+  const getActionDisabledReasonSpy = jest
+    .spyOn(getActionDisabledReasonModule, 'default')
+    .mockImplementation(
+      ({
+        actionEnabledConfig,
+      }: {
+        actionEnabledConfig?: WorkflowActionEnabledConfigValue;
+      }) => {
+        if ('getActionDisabledReasonReturnValue' in options) {
+          return options.getActionDisabledReasonReturnValue;
+        }
+
+        return actionEnabledConfig === 'ENABLED'
+          ? undefined
+          : 'Mock workflow action disabled reason';
+      }
+    );
+
+  const renderResult = render(<DomainPageActionsStartWorkflow {...props} />, {
+    endpointsMocks: [
+      {
+        path: '/api/config',
+        httpMethod: 'GET',
+        mockOnce: false,
+        httpResolver: async () => {
+          if (isConfigError) {
+            return HttpResponse.json(
+              { error: 'Config error' },
+              { status: 500 }
+            );
+          }
+          if (isConfigLoading) {
+            return new Promise(() => {});
+          }
+
+          return HttpResponse.json({
+            ...mockResolvedConfigValues.WORKFLOW_ACTIONS_ENABLED,
+            start: startActionEnabledConfig,
+          });
+        },
+      },
+    ],
+  });
+
+  return {
+    user,
+    getActionDisabledReasonSpy,
+    ...renderResult,
+  };
+}

--- a/src/views/domain-page/domain-page-actions-start-workflow/domain-page-actions-start-workflow.tsx
+++ b/src/views/domain-page/domain-page-actions-start-workflow/domain-page-actions-start-workflow.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+
+import useConfigValue from '@/hooks/use-config-value/use-config-value';
+import { startWorkflowActionConfig } from '@/views/workflow-actions/config/workflow-actions.config';
+import getActionDisabledReason from '@/views/workflow-actions/workflow-actions-menu/helpers/get-action-disabled-reason';
+import WorkflowActionsModal from '@/views/workflow-actions/workflow-actions-modal/workflow-actions-modal';
+
+import { type DomainPageActionButtonProps } from '../domain-page-actions-dropdown/domain-page-actions-dropdown.types';
+import DomainPageBaseActionButton from '../domain-page-base-action-button/domain-page-base-action-button';
+
+export default function DomainPageActionsStartWorkflow({
+  domain,
+  cluster,
+  label,
+  icon,
+}: DomainPageActionButtonProps) {
+  const [showStartNewWorkflowModal, setShowStartNewWorkflowModal] =
+    useState(false);
+
+  const {
+    data: actionsEnabledConfig,
+    isLoading,
+    isError,
+  } = useConfigValue('WORKFLOW_ACTIONS_ENABLED', {
+    domain,
+    cluster,
+  });
+
+  const startDisabledReason = getActionDisabledReason({
+    actionEnabledConfig: actionsEnabledConfig?.start,
+    actionRunnableStatus: 'RUNNABLE',
+  });
+
+  const buttonDisabledReason =
+    isLoading || isError ? 'Action Unavailable' : undefined;
+
+  return (
+    <>
+      <DomainPageBaseActionButton
+        label={label}
+        icon={icon}
+        disabledReason={startDisabledReason ?? buttonDisabledReason}
+        onClick={() => setShowStartNewWorkflowModal(true)}
+      />
+      {/* Note: Placing the modal as a sibling to the button means if the menu button unmounts (e.g., on menu close), the modal will unmount and close too. */}
+      {showStartNewWorkflowModal && (
+        <WorkflowActionsModal
+          domain={domain}
+          cluster={cluster}
+          runId=""
+          workflowId=""
+          action={startWorkflowActionConfig}
+          onClose={() => {
+            setShowStartNewWorkflowModal(false);
+          }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/views/domain-page/domain-page-base-action-button/__tests__/domain-page-base-action-button.test.tsx
+++ b/src/views/domain-page/domain-page-base-action-button/__tests__/domain-page-base-action-button.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+
+import { type IconProps } from 'baseui/icon';
+
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import DomainPageBaseActionButton from '../domain-page-base-action-button';
+import { type Props } from '../domain-page-base-action-button.types';
+
+function MockIcon({ size }: IconProps) {
+  return <span data-testid="mock-icon" data-size={size} />;
+}
+
+describe(DomainPageBaseActionButton.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the action label', () => {
+    setup({});
+
+    expect(screen.getByText('Start new workflow')).toBeInTheDocument();
+  });
+
+  it('renders the action icon at size 20', () => {
+    setup({});
+
+    expect(screen.getByTestId('mock-icon')).toHaveAttribute('data-size', '20');
+  });
+
+  it('calls onClick when the button is clicked', async () => {
+    const { user, onClick } = setup({});
+
+    await user.click(
+      screen.getByRole('button', { name: 'Start new workflow' })
+    );
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button when disabledReason is provided', () => {
+    setup({ disabledReason: 'Not authorized to perform this action' });
+
+    expect(
+      screen.getByRole('button', {
+        name: 'Not authorized to perform this action',
+      })
+    ).toBeDisabled();
+  });
+
+  it('does not call onClick when the button is disabled', async () => {
+    const { user, onClick } = setup({
+      disabledReason: 'Feature is disabled',
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: 'Feature is disabled' })
+    );
+
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});
+
+function setup(overrides: Partial<Props> = {}) {
+  const onClick = overrides.onClick ?? jest.fn();
+  const user = userEvent.setup();
+
+  render(
+    <DomainPageBaseActionButton
+      label="Start new workflow"
+      icon={MockIcon}
+      onClick={onClick}
+      {...overrides}
+    />
+  );
+
+  return { user, onClick };
+}

--- a/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.styles.ts
+++ b/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.styles.ts
@@ -1,0 +1,25 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import { type ButtonOverrides } from 'baseui/button';
+import type { StyleObject } from 'styletron-react';
+
+export const styled = {
+  MenuItemContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    gap: $theme.sizing.scale500,
+    alignItems: 'center',
+  })),
+  MenuItemLabel: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.LabelSmall,
+  })),
+};
+
+export const overrides = {
+  button: {
+    BaseButton: {
+      style: {
+        width: '100%',
+        justifyContent: 'flex-start',
+      } satisfies StyleObject,
+    },
+  } satisfies ButtonOverrides,
+};

--- a/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.styles.ts
+++ b/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.styles.ts
@@ -1,17 +1,5 @@
-import { styled as createStyled, type Theme } from 'baseui';
 import { type ButtonOverrides } from 'baseui/button';
 import type { StyleObject } from 'styletron-react';
-
-export const styled = {
-  MenuItemContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    display: 'flex',
-    gap: $theme.sizing.scale500,
-    alignItems: 'center',
-  })),
-  MenuItemLabel: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    ...$theme.typography.LabelSmall,
-  })),
-};
 
 export const overrides = {
   button: {

--- a/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.tsx
+++ b/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.tsx
@@ -2,7 +2,7 @@ import { StatefulTooltip } from 'baseui/tooltip';
 
 import Button from '@/components/button/button';
 
-import { styled, overrides } from './domain-page-base-action-button.styles';
+import { overrides } from './domain-page-base-action-button.styles';
 import { type Props } from './domain-page-base-action-button.types';
 
 export default function DomainPageBaseActionButton({
@@ -21,15 +21,14 @@ export default function DomainPageBaseActionButton({
       <div>
         <Button
           kind="tertiary"
+          size="compact"
           overrides={overrides.button}
           onClick={onClick}
           disabled={Boolean(disabledReason)}
           aria-label={disabledReason ?? undefined}
+          startEnhancer={() => <Icon size={20} />}
         >
-          <styled.MenuItemContainer>
-            <Icon size={20} />
-            <styled.MenuItemLabel>{label}</styled.MenuItemLabel>
-          </styled.MenuItemContainer>
+          {label}
         </Button>
       </div>
     </StatefulTooltip>

--- a/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.tsx
+++ b/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.tsx
@@ -1,0 +1,37 @@
+import { StatefulTooltip } from 'baseui/tooltip';
+
+import Button from '@/components/button/button';
+
+import { styled, overrides } from './domain-page-base-action-button.styles';
+import { type Props } from './domain-page-base-action-button.types';
+
+export default function DomainPageBaseActionButton({
+  label,
+  icon: Icon,
+  onClick,
+  disabledReason,
+}: Props) {
+  return (
+    <StatefulTooltip
+      content={disabledReason ?? null}
+      ignoreBoundary
+      placement="auto"
+      showArrow
+    >
+      <div>
+        <Button
+          kind="tertiary"
+          overrides={overrides.button}
+          onClick={onClick}
+          disabled={Boolean(disabledReason)}
+          aria-label={disabledReason ?? undefined}
+        >
+          <styled.MenuItemContainer>
+            <Icon size={20} />
+            <styled.MenuItemLabel>{label}</styled.MenuItemLabel>
+          </styled.MenuItemContainer>
+        </Button>
+      </div>
+    </StatefulTooltip>
+  );
+}

--- a/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.types.ts
+++ b/src/views/domain-page/domain-page-base-action-button/domain-page-base-action-button.types.ts
@@ -1,0 +1,8 @@
+import { type DomainPageActionButtonProps } from '../domain-page-actions-dropdown/domain-page-actions-dropdown.types';
+
+export type Props = {
+  label: DomainPageActionButtonProps['label'];
+  icon: DomainPageActionButtonProps['icon'];
+  disabledReason?: string;
+  onClick: () => void;
+};

--- a/src/views/domain-page/domain-page-help-item-button/domain-page-help-item-button.tsx
+++ b/src/views/domain-page/domain-page-help-item-button/domain-page-help-item-button.tsx
@@ -40,6 +40,7 @@ export default function DomainPageHelpItemButton(item: DomainPageHelpItem) {
         <Button {...baseButtonProps} onClick={() => setIsModalOpen(true)}>
           {item.text}
         </Button>
+        {/* Note: Placing the modal as a sibling to the button means if the menu button unmounts (e.g., on menu close), the modal will unmount and close too. */}
         <item.modal
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}

--- a/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
+++ b/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
@@ -97,10 +97,7 @@ export default function DomainPageTabs() {
         }}
         endEnhancer={
           <styled.EndButtonsContainer>
-            <DomainPageActionsDropdown
-              {...decodedParams}
-              isBatchActionsEnabled={isBatchActionsEnabled}
-            />
+            <DomainPageActionsDropdown {...decodedParams} />
             <DomainPageHelp />
           </styled.EndButtonsContainer>
         }


### PR DESCRIPTION
## Summary
- Rewrite the Domain Page Actions menu to make it easier to add new actions
- Tweak the designs to make better use of space

Note: the menu no longer closes when opening a modal from it, because doing so unmounts the open modal and closes it.

## Test plan
Added/updated unit tests + ran locally.

### With batch actions enabled

https://github.com/user-attachments/assets/1d203bca-8f8e-4938-92aa-a101c86d17c9

### With batch actions disabled

<img width="309" height="163" alt="Screenshot 2026-05-28 at 14 16 56" src="https://github.com/user-attachments/assets/4baa5c88-40cb-491a-959f-85e65091fb55" />