### PR TITLE
feat: Batch draft query is now required and prefilled

### DIFF
--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -104,7 +104,7 @@ describe(DomainBatchActions.name, () => {
     expect(mockSetQueryParams).toHaveBeenCalledWith({ batchActionId: '4' });
   });
 
-  it('sets batchActionId to draft when "New batch action" is clicked', async () => {
+  it('sets batchActionId to draft and prefills the query when "New batch action" is clicked', async () => {
     const user = userEvent.setup();
 
     setup();
@@ -113,6 +113,7 @@ describe(DomainBatchActions.name, () => {
 
     expect(mockSetQueryParams).toHaveBeenCalledWith({
       batchActionId: 'draft',
+      batchQuery: 'CloseTime = missing',
     });
   });
 

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { HttpResponse } from 'msw';
+import { Controller } from 'react-hook-form';
 
 import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 
@@ -29,7 +30,6 @@ jest.mock(
   '../../domain-batch-actions-new-action-params/domain-batch-actions-new-action-params',
   () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const { Controller } = require('react-hook-form');
     return function MockParams({ control }: any) {
       return (
         <div data-testid="mock-params">
@@ -200,16 +200,6 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
     expect(
       screen.queryByText(/Showing all running workflows/i)
     ).not.toBeInTheDocument();
-    expect(
-      screen.queryByText('Query must not be empty')
-    ).not.toBeInTheDocument();
-  });
-
-  it('does not show the required-query error before an action is attempted', async () => {
-    setQueryParams({ batchQuery: '' });
-    setup({});
-
-    expect(await screen.findByTestId('mock-floating-bar')).toBeInTheDocument();
     expect(
       screen.queryByText('Query must not be empty')
     ).not.toBeInTheDocument();

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/__tests__/domain-batch-actions-new-action-detail.test.tsx
@@ -11,6 +11,7 @@ import { type CountWorkflowsResponse } from '@/views/shared/hooks/use-count-work
 import { mockWorkflowsListSystemColumns } from '@/views/shared/workflows-list/__fixtures__/mock-workflows-list-columns';
 
 import { type Props as MSWMocksHandlersProps } from '../../../../test-utils/msw-mock-handlers/msw-mock-handlers.types';
+import { BATCH_ACTION_DEFAULT_QUERY } from '../../domain-batch-actions.constants';
 import DomainBatchActionsNewActionDetail from '../domain-batch-actions-new-action-detail';
 
 jest.mock('react-icons/md', () => ({
@@ -22,19 +23,44 @@ jest.mock('query-string', () => ({
   stringifyUrl: jest.fn(({ url }: { url: string }) => url),
 }));
 
+// Render a real Controller-wired Description input so tests can make the form
+// valid, while keeping the mock-params testid for isolation.
 jest.mock(
   '../../domain-batch-actions-new-action-params/domain-batch-actions-new-action-params',
-  () => jest.fn(() => <div data-testid="mock-params" />)
+  () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { Controller } = require('react-hook-form');
+    return function MockParams({ control }: any) {
+      return (
+        <div data-testid="mock-params">
+          <Controller
+            name="description"
+            control={control}
+            render={({ field }: any) => (
+              <input aria-label="Description" {...field} />
+            )}
+          />
+        </div>
+      );
+    };
+  }
 );
 
 jest.mock(
   '../../domain-batch-actions-new-action-floating-bar/domain-batch-actions-new-action-floating-bar',
   () =>
-    jest.fn(({ selectedCount, totalCount }) => (
-      <div data-testid="mock-floating-bar">
-        {`${selectedCount} of ${totalCount} workflows included`}
-      </div>
-    ))
+    jest.fn(
+      ({ selectedCount, totalCount, actions, onActionClick, disabled }) => (
+        <div data-testid="mock-floating-bar" data-disabled={String(disabled)}>
+          <span>{`${selectedCount} of ${totalCount} workflows included`}</span>
+          {actions.map((action: { id: string }) => (
+            <button key={action.id} onClick={() => onActionClick(action.id)}>
+              {`action-${action.id}`}
+            </button>
+          ))}
+        </div>
+      )
+    )
 );
 
 jest.mock('@/components/error-panel/error-panel', () =>
@@ -153,7 +179,133 @@ describe(DomainBatchActionsNewActionDetail.name, () => {
 
     expect(screen.queryByText(/workflows included/i)).not.toBeInTheDocument();
   });
+
+  it('shows the running-workflows caption when the query is the default', async () => {
+    setQueryParams({ batchQuery: BATCH_ACTION_DEFAULT_QUERY });
+    setup({});
+
+    expect(
+      await screen.findByText(/Showing all running workflows/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText('Query must not be empty')
+    ).not.toBeInTheDocument();
+  });
+
+  it('hides the caption once the query has been edited', async () => {
+    setQueryParams({ batchQuery: 'WorkflowType="foo"' });
+    setup({});
+
+    expect(await screen.findByTestId('mock-floating-bar')).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Showing all running workflows/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('Query must not be empty')
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not show the required-query error before an action is attempted', async () => {
+    setQueryParams({ batchQuery: '' });
+    setup({});
+
+    expect(await screen.findByTestId('mock-floating-bar')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Query must not be empty')
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows the required-query error and blocks the action when the query is empty', async () => {
+    setQueryParams({ batchQuery: '' });
+    const { user } = setup({});
+
+    await user.click(await screen.findByText('action-cancel'));
+
+    expect(
+      await screen.findByText('Query must not be empty')
+    ).toBeInTheDocument();
+    // The confirmation modal must not open for an empty query.
+    expect(screen.queryByText('Start Batch Action')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Showing all running workflows/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('blocks submission when the description is valid but the query is empty', async () => {
+    setQueryParams({ batchQuery: '' });
+    const { user } = setup({});
+
+    await user.type(await screen.findByLabelText('Description'), 'cleanup');
+    await user.click(screen.getByText('action-cancel'));
+
+    expect(
+      await screen.findByText('Query must not be empty')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Start Batch Action')).not.toBeInTheDocument();
+  });
+
+  it('disables the floating bar after an empty-query action attempt', async () => {
+    setQueryParams({ batchQuery: '' });
+    const { user } = setup({});
+
+    expect(await screen.findByTestId('mock-floating-bar')).toHaveAttribute(
+      'data-disabled',
+      'false'
+    );
+
+    await user.click(screen.getByText('action-cancel'));
+
+    expect(screen.getByTestId('mock-floating-bar')).toHaveAttribute(
+      'data-disabled',
+      'true'
+    );
+  });
+
+  it('opens the confirmation modal when the query and description are valid', async () => {
+    setQueryParams({ batchQuery: 'WorkflowType="foo"' });
+    const { user } = setup({});
+
+    await user.type(await screen.findByLabelText('Description'), 'cleanup');
+    await user.click(screen.getByText('action-cancel'));
+
+    expect(await screen.findByText('Start Batch Action')).toBeInTheDocument();
+  });
+
+  it('closes the confirmation modal without starting the action', async () => {
+    setQueryParams({ batchQuery: 'WorkflowType="foo"' });
+    const { user } = setup({});
+
+    await user.type(await screen.findByLabelText('Description'), 'cleanup');
+    await user.click(screen.getByText('action-cancel'));
+    await user.click(await screen.findByText('Close'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Start Batch Action')).not.toBeInTheDocument();
+    });
+  });
+
+  it('starts the batch action and closes the modal on success when confirmed', async () => {
+    setQueryParams({ batchQuery: 'WorkflowType="foo"' });
+    const { user } = setup({});
+
+    await user.type(await screen.findByLabelText('Description'), 'cleanup');
+    await user.click(screen.getByText('action-cancel'));
+    await user.click(await screen.findByText('Start Batch Action'));
+
+    // A successful start triggers onSuccess -> setActiveAction(null), closing
+    // the modal.
+    await waitFor(() => {
+      expect(screen.queryByText('Start Batch Action')).not.toBeInTheDocument();
+    });
+  });
 });
+
+function setQueryParams(overrides: Record<string, unknown>) {
+  mockUsePageQueryParams.mockReturnValue([
+    { ...mockDomainPageQueryParamsValues, ...overrides },
+    mockSetQueryParams,
+  ]);
+}
 
 function setup({
   onDiscard = jest.fn(),
@@ -206,6 +358,12 @@ function setup({
                   { status: 500 }
                 )
               : HttpResponse.json(countResponse),
+        },
+        {
+          path: '/api/domains/:domain/:cluster/workflows/start',
+          httpMethod: 'POST',
+          mockOnce: false,
+          httpResolver: async () => HttpResponse.json({}),
         },
       ] as MSWMocksHandlersProps['endpointsMocks'],
     }

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.styles.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.styles.ts
@@ -32,4 +32,14 @@ export const styled = {
     alignSelf: 'center',
     display: 'flex',
   })),
+  QueryCaption: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.ParagraphXSmall,
+    color: $theme.colors.contentSecondary,
+    marginTop: $theme.sizing.scale100,
+  })),
+  QueryError: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.ParagraphXSmall,
+    color: $theme.colors.contentNegative,
+    marginTop: $theme.sizing.scale100,
+  })),
 };

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
@@ -27,7 +27,10 @@ import DomainBatchActionsNewActionFloatingBar from '../domain-batch-actions-new-
 import DomainBatchActionsNewActionInfoBanner from '../domain-batch-actions-new-action-info-banner/domain-batch-actions-new-action-info-banner';
 import DomainBatchActionsNewActionParams from '../domain-batch-actions-new-action-params/domain-batch-actions-new-action-params';
 import batchActionParamsSchema from '../domain-batch-actions-new-action-params/schemas/batch-action-params-schema';
-import { BATCH_ACTION_RPS_DEFAULT } from '../domain-batch-actions.constants';
+import {
+  BATCH_ACTION_DEFAULT_QUERY,
+  BATCH_ACTION_RPS_DEFAULT,
+} from '../domain-batch-actions.constants';
 import { type BatchActionConfirmableType } from '../domain-batch-actions.types';
 import useConfirmBatchAction from '../hooks/use-confirm-batch-action';
 
@@ -56,7 +59,15 @@ export default function DomainBatchActionsNewActionDetail({
 
   const [activeAction, setActiveAction] =
     useState<BatchActionConfirmableType | null>(null);
-  const hasValidationErrors = isSubmitted && !isValid;
+  const [submitAttempted, setSubmitAttempted] = useState(false);
+
+  // The query lives in URL params (not the form), so we validate it in parallel
+  // with the form to mirror how the Description field behaves: required, with
+  // the error shown only after a submit attempt.
+  const isQueryEmpty = !queryParams.batchQuery?.trim();
+  const showQueryError = submitAttempted && isQueryEmpty;
+  const isDefaultQuery = queryParams.batchQuery === BATCH_ACTION_DEFAULT_QUERY;
+  const hasValidationErrors = (isSubmitted && !isValid) || showQueryError;
 
   const { handleConfirm, isPending: isStartingBatchAction } =
     useConfirmBatchAction({
@@ -67,12 +78,14 @@ export default function DomainBatchActionsNewActionDetail({
 
   const handleActionClick = useCallback(
     (actionId: string) => {
+      setSubmitAttempted(true);
       handleSubmit(() => {
+        if (isQueryEmpty) return;
         if (!(actionId in domainBatchActionsConfirmationModalConfig)) return;
         setActiveAction(actionId as BatchActionConfirmableType);
       })();
     },
-    [handleSubmit]
+    [handleSubmit, isQueryEmpty]
   );
 
   // Reuse the workflows tab's column selection (persisted per-domain in
@@ -140,17 +153,28 @@ export default function DomainBatchActionsNewActionDetail({
         control={control}
         fieldErrors={errors}
       />
-      <WorkflowsHeader
-        pageQueryParamsConfig={domainPageQueryParamsConfig}
-        pageFiltersConfig={domainWorkflowsFiltersConfig}
-        inputTypeQueryParamKey="batchInputType"
-        searchQueryParamKey="search"
-        queryStringQueryParamKey="batchQuery"
-        refetchQuery={refetch}
-        isQueryRunning={isFetching}
-        showQueryInputOnly
-        noSpacing
-      />
+      <div>
+        <WorkflowsHeader
+          pageQueryParamsConfig={domainPageQueryParamsConfig}
+          pageFiltersConfig={domainWorkflowsFiltersConfig}
+          inputTypeQueryParamKey="batchInputType"
+          searchQueryParamKey="search"
+          queryStringQueryParamKey="batchQuery"
+          refetchQuery={refetch}
+          isQueryRunning={isFetching}
+          showQueryInputOnly
+          noSpacing
+        />
+        {showQueryError ? (
+          <styled.QueryError>Query must not be empty</styled.QueryError>
+        ) : (
+          isDefaultQuery && (
+            <styled.QueryCaption>
+              Showing all running workflows. Edit the query to narrow the set.
+            </styled.QueryCaption>
+          )
+        )}
+      </div>
       {isDataLoading && <SectionLoadingIndicator />}
       {!isDataLoading && errorPanelProps && (
         <PanelSection>
@@ -186,10 +210,9 @@ export default function DomainBatchActionsNewActionDetail({
         onConfirm={(payload) =>
           handleConfirm({
             batchType: payload.actionId,
-            // TODO: queryParams.batchQuery is empty until the user clicks
-            // "Run Query" — typing alone doesn't commit. The batcher rejects
-            // an empty Query, so this needs gating before submit. (CDNC-19042)
-            query: queryParams.batchQuery ?? '',
+            // An empty query is blocked before submit (see the required-query
+            // validation above), so batchQuery is guaranteed non-empty here.
+            query: queryParams.batchQuery,
             reason: getValues('description'),
             rps: getValues('rps'),
             signalParams:

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-info-banner/domain-batch-actions-new-action-info-banner.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-info-banner/domain-batch-actions-new-action-info-banner.tsx
@@ -24,8 +24,7 @@ export default function DomainBatchActionsNewActionInfoBanner() {
         </styled.Title>
         <styled.Subtitle>
           That means that the workflows listed below are subject to change. If a
-          workflow changes state from running, it will be ignored. Only selected
-          workflows will be submitted.
+          workflow changes state from running, it will be ignored.
         </styled.Subtitle>
       </styled.TextContainer>
     </DomainBatchActionsBanner>

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -3,5 +3,9 @@ export const DRAFT_ACTION_ID = 'draft';
 export const BATCH_ACTION_RPS_DEFAULT = 100;
 export const BATCH_ACTIONS_PAGE_SIZE = 10;
 
+// Prefilled query for a new batch action: all running (not-yet-closed)
+// workflows on the domain.
+export const BATCH_ACTION_DEFAULT_QUERY = 'CloseTime = missing';
+
 export const BATCH_ACTION_TASK_LIST = 'cadence-sys-batcher-tasklist';
 export const BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS = 20 * 365 * 24 * 60 * 60;

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -13,6 +13,7 @@ import DomainBatchActionsNoActionsPlaceholder from './domain-batch-actions-no-ac
 import DomainBatchActionsSidebar from './domain-batch-actions-sidebar/domain-batch-actions-sidebar';
 import {
   BATCH_ACTIONS_PAGE_SIZE,
+  BATCH_ACTION_DEFAULT_QUERY,
   DRAFT_ACTION_ID,
 } from './domain-batch-actions.constants';
 import { styled } from './domain-batch-actions.styles';
@@ -71,7 +72,10 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
 
   const handleCreateNew = () => {
     setIsDraftOpen(true);
-    setQueryParams({ batchActionId: DRAFT_ACTION_ID });
+    setQueryParams({
+      batchActionId: DRAFT_ACTION_ID,
+      batchQuery: BATCH_ACTION_DEFAULT_QUERY,
+    });
   };
 
   const handleSelectAction = (id: string) => {


### PR DESCRIPTION
- Batch Action draft now accepts query as required. Batch workflow cannot work with empty qeury.
- The query is not prefilled with `CloseTime = missing` that shows running workflows.
- This query is not self explanatory and can confuse users, which is why I added a query caption that explains it.
- Caption is dismissed when user is editing the query, or turns into an error when query is missing.
<img width="1298" height="494" alt="image" src="https://github.com/user-attachments/assets/71a9cd32-9e03-4b6f-9dc2-af4b61ce6115" />
<img width="1276" height="437" alt="image" src="https://github.com/user-attachments/assets/9722532e-c23f-45a2-8baa-0ca7a7e99fca" />
<img width="1315" height="744" alt="image" src="https://github.com/user-attachments/assets/dec6304a-e5b3-4b5b-9cdf-ef719cee6a56" />
