### PR TITLE
feat: Add opt-in checkbox selection column to WorkflowsList

### DIFF
--- a/src/views/shared/workflows-list/__tests__/workflows-list.test.tsx
+++ b/src/views/shared/workflows-list/__tests__/workflows-list.test.tsx
@@ -220,7 +220,109 @@ describe(WorkflowsList.name, () => {
     expect(screen.getByText('Workflow ID')).toBeInTheDocument();
     expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
+
+  it('does not render checkboxes when selection is not provided', () => {
+    setup({});
+
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('renders a select-all checkbox and one checkbox per row when selection is provided', () => {
+    setup({ selection: makeSelection() });
+
+    // select-all + one per row
+    expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+    expect(
+      screen.getByRole('checkbox', { name: 'Select all workflows' })
+    ).toBeInTheDocument();
+  });
+
+  it('toggles a row without navigating when its checkbox is clicked', async () => {
+    const selection = makeSelection();
+    const { user } = setup({ selection });
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select workflow wf-1' })
+    );
+
+    expect(selection.onToggle).toHaveBeenCalledTimes(1);
+    expect(selection.onToggle).toHaveBeenCalledWith(MOCK_WORKFLOWS[0]);
+  });
+
+  it('calls onToggleAll when the select-all checkbox is clicked', async () => {
+    const selection = makeSelection();
+    const { user } = setup({ selection });
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select all workflows' })
+    );
+
+    expect(selection.onToggleAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders rows checked and disabled while select all is active', () => {
+    setup({
+      selection: makeSelection({
+        isAllSelected: true,
+        isRowToggleDisabled: true,
+        isSelected: () => true,
+      }),
+    });
+
+    const rowCheckbox = screen.getByRole('checkbox', {
+      name: 'Select workflow wf-1',
+    });
+    expect(rowCheckbox).toBeChecked();
+    expect(rowCheckbox).toBeDisabled();
+  });
+
+  it('does not toggle a disabled row checkbox', async () => {
+    const selection = makeSelection({
+      isAllSelected: true,
+      isRowToggleDisabled: true,
+      isSelected: () => true,
+    });
+    const { user } = setup({ selection });
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'Select workflow wf-1' })
+    );
+
+    expect(selection.onToggle).not.toHaveBeenCalled();
+  });
+
+  it('shows the disabled-reason tooltip when hovering a disabled row checkbox', async () => {
+    const { user } = setup({
+      selection: makeSelection({
+        isAllSelected: true,
+        isRowToggleDisabled: true,
+        isSelected: () => true,
+        rowToggleDisabledReason: 'All selected',
+      }),
+    });
+
+    await user.hover(
+      screen.getByRole('checkbox', { name: 'Select workflow wf-1' })
+    );
+
+    expect(await screen.findByText('All selected')).toBeInTheDocument();
+  });
 });
+
+function makeSelection(
+  overrides: Partial<
+    React.ComponentProps<typeof WorkflowsList>['selection']
+  > = {}
+): NonNullable<React.ComponentProps<typeof WorkflowsList>['selection']> {
+  return {
+    isAllSelected: false,
+    onToggleAll: jest.fn(),
+    isSelected: () => false,
+    isRowToggleDisabled: false,
+    onToggle: jest.fn(),
+    ...overrides,
+  };
+}
 
 function setup({
   workflows = MOCK_WORKFLOWS,
@@ -229,6 +331,7 @@ function setup({
   hasNextPage = false,
   isFetchingNextPage = false,
   sortParams,
+  selection,
 }: Partial<React.ComponentProps<typeof WorkflowsList>> = {}) {
   const user = userEvent.setup();
   render(
@@ -240,6 +343,7 @@ function setup({
       fetchNextPage={jest.fn()}
       isFetchingNextPage={isFetchingNextPage}
       sortParams={sortParams}
+      selection={selection}
     />
   );
   return { user };

--- a/src/views/shared/workflows-list/__tests__/workflows-list.test.tsx
+++ b/src/views/shared/workflows-list/__tests__/workflows-list.test.tsx
@@ -242,7 +242,7 @@ describe(WorkflowsList.name, () => {
     const { user } = setup({ selection });
 
     await user.click(
-      screen.getByRole('checkbox', { name: 'Select workflow wf-1' })
+      screen.getByRole('checkbox', { name: 'Select workflow wf-1 run run-1' })
     );
 
     expect(selection.onToggle).toHaveBeenCalledTimes(1);
@@ -270,7 +270,7 @@ describe(WorkflowsList.name, () => {
     });
 
     const rowCheckbox = screen.getByRole('checkbox', {
-      name: 'Select workflow wf-1',
+      name: 'Select workflow wf-1 run run-1',
     });
     expect(rowCheckbox).toBeChecked();
     expect(rowCheckbox).toBeDisabled();
@@ -285,7 +285,7 @@ describe(WorkflowsList.name, () => {
     const { user } = setup({ selection });
 
     await user.click(
-      screen.getByRole('checkbox', { name: 'Select workflow wf-1' })
+      screen.getByRole('checkbox', { name: 'Select workflow wf-1 run run-1' })
     );
 
     expect(selection.onToggle).not.toHaveBeenCalled();
@@ -302,7 +302,7 @@ describe(WorkflowsList.name, () => {
     });
 
     await user.hover(
-      screen.getByRole('checkbox', { name: 'Select workflow wf-1' })
+      screen.getByRole('checkbox', { name: 'Select workflow wf-1 run run-1' })
     );
 
     expect(await screen.findByText('All selected')).toBeInTheDocument();

--- a/src/views/shared/workflows-list/workflows-list-selection-cell/workflows-list-selection-cell.styles.ts
+++ b/src/views/shared/workflows-list/workflows-list-selection-cell/workflows-list-selection-cell.styles.ts
@@ -1,0 +1,12 @@
+import { styled as createStyled, type Theme } from 'baseui';
+
+export const styled = {
+  CheckboxCell: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    width: $theme.sizing.scale800,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: $theme.sizing.scale400,
+    paddingBottom: $theme.sizing.scale400,
+  })),
+};

--- a/src/views/shared/workflows-list/workflows-list-selection-cell/workflows-list-selection-cell.tsx
+++ b/src/views/shared/workflows-list/workflows-list-selection-cell/workflows-list-selection-cell.tsx
@@ -1,0 +1,48 @@
+import { type MouseEvent } from 'react';
+
+import { Checkbox } from 'baseui/checkbox';
+import { StatefulTooltip } from 'baseui/tooltip';
+
+import { styled } from './workflows-list-selection-cell.styles';
+import { type Props } from './workflows-list-selection-cell.types';
+
+export default function WorkflowsListSelectionCell({
+  selection,
+  workflow,
+}: Props) {
+  const checkbox = (
+    <Checkbox
+      checked={selection.isSelected(workflow)}
+      disabled={selection.isRowToggleDisabled}
+      onChange={() => {}}
+      aria-label={`Select workflow ${workflow.workflowID} run ${workflow.runID}`}
+    />
+  );
+
+  return (
+    <styled.CheckboxCell
+      onClickCapture={(e: MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!selection.isRowToggleDisabled) {
+          selection.onToggle(workflow);
+        }
+      }}
+    >
+      {selection.isRowToggleDisabled && selection.rowToggleDisabledReason ? (
+        <StatefulTooltip
+          placement="right"
+          showArrow
+          accessibilityType="tooltip"
+          content={selection.rowToggleDisabledReason}
+        >
+          {/* span so the tooltip can attach hover handlers — a disabled checkbox
+              does not receive them. */}
+          <span>{checkbox}</span>
+        </StatefulTooltip>
+      ) : (
+        checkbox
+      )}
+    </styled.CheckboxCell>
+  );
+}

--- a/src/views/shared/workflows-list/workflows-list-selection-cell/workflows-list-selection-cell.types.ts
+++ b/src/views/shared/workflows-list/workflows-list-selection-cell/workflows-list-selection-cell.types.ts
@@ -1,0 +1,8 @@
+import { type DomainWorkflow } from '@/views/domain-page/domain-page.types';
+
+import { type SelectionParams } from '../workflows-list.types';
+
+export type Props = {
+  selection: SelectionParams;
+  workflow: DomainWorkflow;
+};

--- a/src/views/shared/workflows-list/workflows-list.styles.ts
+++ b/src/views/shared/workflows-list/workflows-list.styles.ts
@@ -95,6 +95,14 @@ export const styled = {
     color: $theme.colors.contentTertiary,
     fontStyle: 'italic',
   })),
+  CheckboxCell: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    width: $theme.sizing.scale800,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingTop: $theme.sizing.scale400,
+    paddingBottom: $theme.sizing.scale400,
+  })),
   FooterContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
     display: 'flex',
     justifyContent: 'center',

--- a/src/views/shared/workflows-list/workflows-list.styles.ts
+++ b/src/views/shared/workflows-list/workflows-list.styles.ts
@@ -95,14 +95,6 @@ export const styled = {
     color: $theme.colors.contentTertiary,
     fontStyle: 'italic',
   })),
-  CheckboxCell: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    width: $theme.sizing.scale800,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    paddingTop: $theme.sizing.scale400,
-    paddingBottom: $theme.sizing.scale400,
-  })),
   FooterContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
     display: 'flex',
     justifyContent: 'center',

--- a/src/views/shared/workflows-list/workflows-list.tsx
+++ b/src/views/shared/workflows-list/workflows-list.tsx
@@ -1,14 +1,15 @@
-import { type MouseEvent, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { Checkbox } from 'baseui/checkbox';
 import ChevronDown from 'baseui/icon/chevron-down';
 import ChevronUp from 'baseui/icon/chevron-up';
-import { StatefulTooltip } from 'baseui/tooltip';
 import isNil from 'lodash/isNil';
 import NextLink from 'next/link';
 
 import TableInfiniteScrollLoader from '@/components/table/table-infinite-scroll-loader/table-infinite-scroll-loader';
 
+import WorkflowsListSelectionCell from './workflows-list-selection-cell/workflows-list-selection-cell';
+import { styled as selectionCellStyled } from './workflows-list-selection-cell/workflows-list-selection-cell.styles';
 import { styled } from './workflows-list.styles';
 import { type Props } from './workflows-list.types';
 
@@ -45,13 +46,13 @@ export default function WorkflowsList({
                 on the per-row checkbox below to drop the capture-phase
                 preventDefault workaround. */}
             {selection && (
-              <styled.CheckboxCell>
+              <selectionCellStyled.CheckboxCell>
                 <Checkbox
                   checked={selection.isAllSelected}
                   onChange={selection.onToggleAll}
                   aria-label="Select all workflows"
                 />
-              </styled.CheckboxCell>
+              </selectionCellStyled.CheckboxCell>
             )}
             {columns.map((col) => {
               if (col.sortable && sortParams) {
@@ -94,18 +95,6 @@ export default function WorkflowsList({
           </styled.GridHeader>
           {hasWorkflows &&
             workflows.map((workflow, index) => {
-              // Toggling is handled by the cell's onClickCapture below (so we
-              // can stop the surrounding link from navigating), hence the no-op
-              // onChange.
-              const rowCheckbox = selection && (
-                <Checkbox
-                  checked={selection.isSelected(workflow)}
-                  disabled={selection.isRowToggleDisabled}
-                  onChange={() => {}}
-                  aria-label={`Select workflow ${workflow.workflowID}`}
-                />
-              );
-
               return (
                 <styled.GridRow
                   key={`${workflow.workflowID}-${workflow.runID}-${index}`}
@@ -115,34 +104,10 @@ export default function WorkflowsList({
                   $gridTemplateColumns={gridTemplateColumns}
                 >
                   {selection && (
-                    <styled.CheckboxCell
-                      // The row is a link and baseui's Checkbox stops click
-                      // propagation, so intercept in the capture phase: prevent
-                      // navigation and toggle selection ourselves.
-                      onClickCapture={(e: MouseEvent) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        if (!selection.isRowToggleDisabled) {
-                          selection.onToggle(workflow);
-                        }
-                      }}
-                    >
-                      {selection.isRowToggleDisabled &&
-                      selection.rowToggleDisabledReason ? (
-                        <StatefulTooltip
-                          placement="right"
-                          showArrow
-                          accessibilityType="tooltip"
-                          content={selection.rowToggleDisabledReason}
-                        >
-                          {/* span so the tooltip can attach hover handlers — a
-                              disabled checkbox does not receive them. */}
-                          <span>{rowCheckbox}</span>
-                        </StatefulTooltip>
-                      ) : (
-                        rowCheckbox
-                      )}
-                    </styled.CheckboxCell>
+                    <WorkflowsListSelectionCell
+                      selection={selection}
+                      workflow={workflow}
+                    />
                   )}
                   {columns.map((col) => {
                     const content = col.renderCell(workflow);

--- a/src/views/shared/workflows-list/workflows-list.tsx
+++ b/src/views/shared/workflows-list/workflows-list.tsx
@@ -1,7 +1,9 @@
-import { useMemo } from 'react';
+import { type MouseEvent, useMemo } from 'react';
 
+import { Checkbox } from 'baseui/checkbox';
 import ChevronDown from 'baseui/icon/chevron-down';
 import ChevronUp from 'baseui/icon/chevron-up';
+import { StatefulTooltip } from 'baseui/tooltip';
 import isNil from 'lodash/isNil';
 import NextLink from 'next/link';
 
@@ -18,11 +20,17 @@ export default function WorkflowsList({
   fetchNextPage,
   isFetchingNextPage,
   sortParams,
+  selection,
 }: Props) {
-  const gridTemplateColumns = useMemo(
-    () => columns.map((col) => col.width).join(' '),
-    [columns]
-  );
+  const gridTemplateColumns = useMemo(() => {
+    const columnWidths = columns.map((col) => col.width);
+    if (selection) {
+      // 'auto' sizes this track to the checkbox cell's themed width
+      // (see CheckboxCell in workflows-list.styles.ts).
+      columnWidths.unshift('auto');
+    }
+    return columnWidths.join(' ');
+  }, [columns, selection]);
 
   const hasWorkflows = workflows.length > 0;
 
@@ -31,6 +39,20 @@ export default function WorkflowsList({
       <styled.ScrollArea>
         <styled.Container>
           <styled.GridHeader $gridTemplateColumns={gridTemplateColumns}>
+            {/* TODO: once baseui is upgraded to >=16.1, switch to checkbox-v2
+                (baseui/checkbox-v2) and use `isIndeterminate` here for the
+                some-but-not-all-selected state, and `containsInteractiveElement`
+                on the per-row checkbox below to drop the capture-phase
+                preventDefault workaround. */}
+            {selection && (
+              <styled.CheckboxCell>
+                <Checkbox
+                  checked={selection.isAllSelected}
+                  onChange={selection.onToggleAll}
+                  aria-label="Select all workflows"
+                />
+              </styled.CheckboxCell>
+            )}
             {columns.map((col) => {
               if (col.sortable && sortParams) {
                 const isActive = sortParams.sortColumn === col.id;
@@ -71,28 +93,72 @@ export default function WorkflowsList({
             })}
           </styled.GridHeader>
           {hasWorkflows &&
-            workflows.map((workflow, index) => (
-              <styled.GridRow
-                key={`${workflow.workflowID}-${workflow.runID}-${index}`}
-                $as={NextLink}
-                href={`workflows/${encodeURIComponent(workflow.workflowID)}/${encodeURIComponent(workflow.runID)}`}
-                prefetch={false}
-                $gridTemplateColumns={gridTemplateColumns}
-              >
-                {columns.map((col) => {
-                  const content = col.renderCell(workflow);
-                  return (
-                    <styled.GridCell key={col.id}>
-                      {isNil(content) ? (
-                        <styled.CellPlaceholder>None</styled.CellPlaceholder>
+            workflows.map((workflow, index) => {
+              // Toggling is handled by the cell's onClickCapture below (so we
+              // can stop the surrounding link from navigating), hence the no-op
+              // onChange.
+              const rowCheckbox = selection && (
+                <Checkbox
+                  checked={selection.isSelected(workflow)}
+                  disabled={selection.isRowToggleDisabled}
+                  onChange={() => {}}
+                  aria-label={`Select workflow ${workflow.workflowID}`}
+                />
+              );
+
+              return (
+                <styled.GridRow
+                  key={`${workflow.workflowID}-${workflow.runID}-${index}`}
+                  $as={NextLink}
+                  href={`workflows/${encodeURIComponent(workflow.workflowID)}/${encodeURIComponent(workflow.runID)}`}
+                  prefetch={false}
+                  $gridTemplateColumns={gridTemplateColumns}
+                >
+                  {selection && (
+                    <styled.CheckboxCell
+                      // The row is a link and baseui's Checkbox stops click
+                      // propagation, so intercept in the capture phase: prevent
+                      // navigation and toggle selection ourselves.
+                      onClickCapture={(e: MouseEvent) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        if (!selection.isRowToggleDisabled) {
+                          selection.onToggle(workflow);
+                        }
+                      }}
+                    >
+                      {selection.isRowToggleDisabled &&
+                      selection.rowToggleDisabledReason ? (
+                        <StatefulTooltip
+                          placement="right"
+                          showArrow
+                          accessibilityType="tooltip"
+                          content={selection.rowToggleDisabledReason}
+                        >
+                          {/* span so the tooltip can attach hover handlers — a
+                              disabled checkbox does not receive them. */}
+                          <span>{rowCheckbox}</span>
+                        </StatefulTooltip>
                       ) : (
-                        content
+                        rowCheckbox
                       )}
-                    </styled.GridCell>
-                  );
-                })}
-              </styled.GridRow>
-            ))}
+                    </styled.CheckboxCell>
+                  )}
+                  {columns.map((col) => {
+                    const content = col.renderCell(workflow);
+                    return (
+                      <styled.GridCell key={col.id}>
+                        {isNil(content) ? (
+                          <styled.CellPlaceholder>None</styled.CellPlaceholder>
+                        ) : (
+                          content
+                        )}
+                      </styled.GridCell>
+                    );
+                  })}
+                </styled.GridRow>
+              );
+            })}
         </styled.Container>
       </styled.ScrollArea>
       <styled.FooterContainer>

--- a/src/views/shared/workflows-list/workflows-list.types.ts
+++ b/src/views/shared/workflows-list/workflows-list.types.ts
@@ -27,20 +27,26 @@ export type SortParams = {
   sortOrder: SortOrder;
 };
 
-// Opt-in row selection. When provided, the list renders a leading checkbox
-// column (a "select all" checkbox in the header and one per row). The list is
-// stateless about selection: a parent owns the state (e.g. via
-// useBatchActionSelection)
-// and passes the derived predicates/handlers here.
+/**
+ * Opt-in row selection. When provided, the list renders a leading checkbox
+ * column (a "select all" checkbox in the header and one per row).
+ *
+ * The list is stateless about selection: a parent owns the state (e.g. via
+ * `useBatchActionSelection`) and passes the derived predicates/handlers here.
+ */
 export type SelectionParams = {
   isAllSelected: boolean;
   onToggleAll: () => void;
   isSelected: (workflow: DomainWorkflow) => boolean;
-  // When true, per-row checkboxes are rendered checked but disabled (used while
-  // "select all" is active).
+  /**
+   * When true, per-row checkboxes are rendered checked but disabled (used while
+   * "select all" is active).
+   */
   isRowToggleDisabled: boolean;
-  // Optional short message shown in a tooltip when hovering a disabled per-row
-  // checkbox, explaining why it cannot be toggled.
+  /**
+   * Optional short message shown in a tooltip when hovering a disabled per-row
+   * checkbox, explaining why it cannot be toggled.
+   */
   rowToggleDisabledReason?: string;
   onToggle: (workflow: DomainWorkflow) => void;
 };

--- a/src/views/shared/workflows-list/workflows-list.types.ts
+++ b/src/views/shared/workflows-list/workflows-list.types.ts
@@ -27,6 +27,23 @@ export type SortParams = {
   sortOrder: SortOrder;
 };
 
+// Opt-in row selection. When provided, the list renders a leading checkbox
+// column (a "select all" checkbox in the header and one per row). The list is
+// stateless about selection: a parent owns the state (e.g. via useListSelection)
+// and passes the derived predicates/handlers here.
+export type SelectionParams = {
+  isAllSelected: boolean;
+  onToggleAll: () => void;
+  isSelected: (workflow: DomainWorkflow) => boolean;
+  // When true, per-row checkboxes are rendered checked but disabled (used while
+  // "select all" is active).
+  isRowToggleDisabled: boolean;
+  // Optional short message shown in a tooltip when hovering a disabled per-row
+  // checkbox, explaining why it cannot be toggled.
+  rowToggleDisabledReason?: string;
+  onToggle: (workflow: DomainWorkflow) => void;
+};
+
 export type Props = {
   workflows: Array<DomainWorkflow>;
   columns: Array<WorkflowsListColumn>;
@@ -35,4 +52,5 @@ export type Props = {
   fetchNextPage: () => void;
   isFetchingNextPage: boolean;
   sortParams?: SortParams;
+  selection?: SelectionParams;
 };

--- a/src/views/shared/workflows-list/workflows-list.types.ts
+++ b/src/views/shared/workflows-list/workflows-list.types.ts
@@ -29,7 +29,8 @@ export type SortParams = {
 
 // Opt-in row selection. When provided, the list renders a leading checkbox
 // column (a "select all" checkbox in the header and one per row). The list is
-// stateless about selection: a parent owns the state (e.g. via useListSelection)
+// stateless about selection: a parent owns the state (e.g. via
+// useBatchActionSelection)
 // and passes the derived predicates/handlers here.
 export type SelectionParams = {
   isAllSelected: boolean;


### PR DESCRIPTION
## Summary

Adds an **opt-in** checkbox selection column to the shared `WorkflowsList`.
Existing pages are unaffected because it is entirely opt-in via a new prop.

## Details

- New optional `selection` prop on `WorkflowsList`. When provided, a leading
  checkbox column renders a "select all" checkbox in the header and one per row.
- Rows are `NextLink` anchors and baseui's `Checkbox` stops click propagation,
  so the cell intercepts clicks in the **capture phase** to toggle selection
  without navigating.
- Disabled per-row checkboxes can show a short tooltip explaining the disabled
  state, driven by an optional reason on the `selection` prop.
- Checkbox column width uses a theme token (no raw px); the grid track is `auto`.
- When `selection` is absent, the list renders exactly as before.

## Testing

- `npm run test:unit:browser -- workflows-list`
- `npm run typecheck && npm run lint`

