### PR TITLE
feat: Allow customizing the WorkflowsHeader search segment label

### DIFF
--- a/src/views/shared/workflows-header/__tests__/workflows-header.test.tsx
+++ b/src/views/shared/workflows-header/__tests__/workflows-header.test.tsx
@@ -132,16 +132,25 @@ describe(WorkflowsHeader.name, () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('renders a custom search segment label when provided', async () => {
+    setup({ searchSegmentLabel: 'Select' });
+
+    expect(await screen.findByText('Select')).toBeInTheDocument();
+    expect(screen.queryByText('Search')).not.toBeInTheDocument();
+  });
 });
 
 function setup({
   isQueryRunning,
   expandFiltersByDefault,
   showQueryInputOnly,
+  searchSegmentLabel,
 }: {
   isQueryRunning?: boolean;
   expandFiltersByDefault?: boolean;
   showQueryInputOnly?: boolean;
+  searchSegmentLabel?: string;
 }) {
   const user = userEvent.setup();
   const renderResult = render(
@@ -155,6 +164,7 @@ function setup({
       isQueryRunning={isQueryRunning ?? false}
       expandFiltersByDefault={expandFiltersByDefault}
       showQueryInputOnly={showQueryInputOnly}
+      searchSegmentLabel={searchSegmentLabel}
     />
   );
 

--- a/src/views/shared/workflows-header/workflows-header.tsx
+++ b/src/views/shared/workflows-header/workflows-header.tsx
@@ -39,6 +39,7 @@ export default function WorkflowsHeader<
   showQueryInputOnly,
   noSpacing,
   columnsPickerProps,
+  searchSegmentLabel = 'Search',
 }: Props<P, I, S, Q>) {
   const [areFiltersShown, setAreFiltersShown] = useState(
     expandFiltersByDefault ?? false
@@ -72,7 +73,7 @@ export default function WorkflowsHeader<
             <Segment
               overrides={overrides.inputToggleSegment}
               key="search"
-              label="Search"
+              label={searchSegmentLabel}
             />
           )}
           <Segment

--- a/src/views/shared/workflows-header/workflows-header.types.ts
+++ b/src/views/shared/workflows-header/workflows-header.types.ts
@@ -31,4 +31,6 @@ export type Props<
   showQueryInputOnly?: boolean;
   noSpacing?: boolean;
   columnsPickerProps?: ColumnsPickerProps;
+  // Label for the non-query toggle segment (default "Search")
+  searchSegmentLabel?: string;
 };


### PR DESCRIPTION
## Summary

Adds an optional `searchSegmentLabel` prop to the shared `WorkflowsHeader` so the
Search/Query segmented toggle can be relabeled. The batch-action draft needs the
non-query segment to read **"Select"** instead of "Search".

## Details

- New optional `searchSegmentLabel` prop (defaults to `"Search"`) used as the
  segmented-control label for the search segment.
- No behavior change for existing callers — the default preserves the current
  "Search" label everywhere it's already used.

## Testing

- `npm run test:unit:browser -- workflows-header`
- `npm run typecheck && npm run lint`

---

📚 Stacked on #1336. Until that merges, this PR's diff also includes the
checkbox-selection-column commit from the parent branch.
