### PR TITLE
fix: Tweak overflow styles in JSON renderer to prevent spillovers

### DIFF
--- a/src/components/pretty-json/pretty-json.styles.ts
+++ b/src/components/pretty-json/pretty-json.styles.ts
@@ -6,6 +6,7 @@ import type {
 const cssStylesObj = {
   container: (theme) => ({
     ...theme.typography.MonoLabelXSmall,
+    overflowWrap: 'anywhere',
   }),
   basicChildStyle: (theme) => ({
     marginLeft: theme.sizing.scale550,
@@ -33,10 +34,12 @@ const cssStylesObj = {
     color: '#016974',
     marginRight: theme.sizing.scale200,
     cursor: 'pointer',
+    wordBreak: 'break-all',
   }),
   label: {
     color: '#016974',
     marginRight: '7px',
+    wordBreak: 'break-all',
   },
   numberValue: {
     color: '#06C167',


### PR DESCRIPTION
## Summary
### Problem
Long field names in JSON do not break midway when rendered using the PrettyJson component, causing them to overflow outside their container.

### Solution
Add overflow styling to force long words to break early.

## Test plan
Ran locally.

### Before
<img width="1397" height="891" alt="Screenshot 2026-06-08 at 15 00 14" src="https://github.com/user-attachments/assets/261e68e5-6845-4abc-823d-7762c11d6f25" />
<img width="1369" height="670" alt="Screenshot 2026-06-08 at 15 00 09" src="https://github.com/user-attachments/assets/0dbfb05e-13ba-46a2-8d88-115b7e9a214e" />

### After
<img width="1399" height="958" alt="Screenshot 2026-06-08 at 15 07 26" src="https://github.com/user-attachments/assets/5a9a5960-8275-46fc-b890-e94d8adeff96" />
<img width="1369" height="657" alt="Screenshot 2026-06-08 at 14 59 11" src="https://github.com/user-attachments/assets/a9e45bfd-9f3f-4c6a-a689-f3d808ead231" />

 