### PR TITLE
feat(schedules): add Create schedule button adjacent to filters

### DIFF
--- a/src/views/domain-schedules/domain-schedules-header/__tests__/domain-schedules-header.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-header/__tests__/domain-schedules-header.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, userEvent } from '@/test-utils/rtl';
 import { mockDomainPageQueryParamsValues } from '@/views/domain-page/__fixtures__/domain-page-query-params';
 
 import DomainSchedulesHeader from '../domain-schedules-header';
+import { type Props } from '../domain-schedules-header.types';
 
 const mockSetQueryParams = jest.fn();
 jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
@@ -13,12 +14,7 @@ jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
 
 describe(DomainSchedulesHeader.name, () => {
   it('renders the title without count when count is undefined', () => {
-    render(
-      <DomainSchedulesHeader
-        count={undefined}
-        onCreateScheduleClick={jest.fn()}
-      />
-    );
+    setup({ count: undefined });
 
     expect(
       screen.getByRole('heading', { name: 'Schedules' })
@@ -26,9 +22,7 @@ describe(DomainSchedulesHeader.name, () => {
   });
 
   it('renders the title with count when count is provided', () => {
-    render(
-      <DomainSchedulesHeader count={5} onCreateScheduleClick={jest.fn()} />
-    );
+    setup({ count: 5 });
 
     expect(
       screen.getByRole('heading', { name: 'Schedules (5)' })
@@ -36,9 +30,7 @@ describe(DomainSchedulesHeader.name, () => {
   });
 
   it('renders zero count', () => {
-    render(
-      <DomainSchedulesHeader count={0} onCreateScheduleClick={jest.fn()} />
-    );
+    setup({ count: 0 });
 
     expect(
       screen.getByRole('heading', { name: 'Schedules (0)' })
@@ -46,9 +38,7 @@ describe(DomainSchedulesHeader.name, () => {
   });
 
   it('renders the page filters search input', () => {
-    render(
-      <DomainSchedulesHeader count={0} onCreateScheduleClick={jest.fn()} />
-    );
+    setup({ count: 0 });
 
     expect(
       screen.getByPlaceholderText('Find schedule by ID or workflow type')
@@ -56,18 +46,22 @@ describe(DomainSchedulesHeader.name, () => {
   });
 
   it('calls onCreateScheduleClick when Create schedule is pressed', async () => {
-    const onCreateScheduleClick = jest.fn();
-    const user = userEvent.setup();
-
-    render(
-      <DomainSchedulesHeader
-        count={0}
-        onCreateScheduleClick={onCreateScheduleClick}
-      />
-    );
+    const { user, mockedOnCreateScheduleClick } = setup({ count: 0 });
 
     await user.click(screen.getByRole('button', { name: 'Create schedule' }));
 
-    expect(onCreateScheduleClick).toHaveBeenCalledTimes(1);
+    expect(mockedOnCreateScheduleClick).toHaveBeenCalledTimes(1);
   });
 });
+
+function setup(props: Partial<Pick<Props, 'count'>> = {}) {
+  const mockedOnCreateScheduleClick = jest.fn();
+  const user = userEvent.setup();
+  render(
+    <DomainSchedulesHeader
+      onCreateScheduleClick={mockedOnCreateScheduleClick}
+      count={props.count}
+    />
+  );
+  return { user, mockedOnCreateScheduleClick };
+}

--- a/src/views/domain-schedules/domain-schedules-header/__tests__/domain-schedules-header.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-header/__tests__/domain-schedules-header.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@/test-utils/rtl';
+import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import { mockDomainPageQueryParamsValues } from '@/views/domain-page/__fixtures__/domain-page-query-params';
 
@@ -13,7 +13,12 @@ jest.mock('@/hooks/use-page-query-params/use-page-query-params', () =>
 
 describe(DomainSchedulesHeader.name, () => {
   it('renders the title without count when count is undefined', () => {
-    render(<DomainSchedulesHeader count={undefined} />);
+    render(
+      <DomainSchedulesHeader
+        count={undefined}
+        onCreateScheduleClick={jest.fn()}
+      />
+    );
 
     expect(
       screen.getByRole('heading', { name: 'Schedules' })
@@ -21,7 +26,9 @@ describe(DomainSchedulesHeader.name, () => {
   });
 
   it('renders the title with count when count is provided', () => {
-    render(<DomainSchedulesHeader count={5} />);
+    render(
+      <DomainSchedulesHeader count={5} onCreateScheduleClick={jest.fn()} />
+    );
 
     expect(
       screen.getByRole('heading', { name: 'Schedules (5)' })
@@ -29,7 +36,9 @@ describe(DomainSchedulesHeader.name, () => {
   });
 
   it('renders zero count', () => {
-    render(<DomainSchedulesHeader count={0} />);
+    render(
+      <DomainSchedulesHeader count={0} onCreateScheduleClick={jest.fn()} />
+    );
 
     expect(
       screen.getByRole('heading', { name: 'Schedules (0)' })
@@ -37,10 +46,28 @@ describe(DomainSchedulesHeader.name, () => {
   });
 
   it('renders the page filters search input', () => {
-    render(<DomainSchedulesHeader count={0} />);
+    render(
+      <DomainSchedulesHeader count={0} onCreateScheduleClick={jest.fn()} />
+    );
 
     expect(
       screen.getByPlaceholderText('Find schedule by ID or workflow type')
     ).toBeInTheDocument();
+  });
+
+  it('calls onCreateScheduleClick when Create schedule is pressed', async () => {
+    const onCreateScheduleClick = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <DomainSchedulesHeader
+        count={0}
+        onCreateScheduleClick={onCreateScheduleClick}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Create schedule' }));
+
+    expect(onCreateScheduleClick).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.styles.ts
+++ b/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.styles.ts
@@ -29,4 +29,35 @@ export const styled = {
       marginBottom: 0,
     })
   ),
+  FiltersToolbar: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'stretch',
+      gap: $theme.sizing.scale500,
+      [$theme.mediaQuery.medium]: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      },
+    })
+  ),
+  FiltersSlot: createStyled(
+    'div',
+    (): StyleObject => ({
+      flex: 1,
+      minWidth: 0,
+    })
+  ),
+  CreateButtonWrap: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      flexShrink: 0,
+      alignSelf: 'flex-start',
+      [$theme.mediaQuery.medium]: {
+        alignSelf: 'center',
+      },
+    })
+  ),
 };

--- a/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.styles.ts
+++ b/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.styles.ts
@@ -1,5 +1,19 @@
 import { styled as createStyled, type Theme } from 'baseui';
+import { type ButtonOverrides } from 'baseui/button';
 import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  createScheduleButton: {
+    BaseButton: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        width: '100%',
+        [$theme.mediaQuery.medium]: {
+          width: 'auto',
+        },
+      }),
+    },
+  } satisfies ButtonOverrides,
+};
 
 export const styled = {
   Container: createStyled(
@@ -53,10 +67,12 @@ export const styled = {
   CreateButtonWrap: createStyled(
     'div',
     ({ $theme }: { $theme: Theme }): StyleObject => ({
-      flexShrink: 0,
-      alignSelf: 'flex-start',
+      alignSelf: 'stretch',
+      width: '100%',
       [$theme.mediaQuery.medium]: {
         alignSelf: 'center',
+        width: 'auto',
+        flexShrink: 0,
       },
     })
   ),

--- a/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.tsx
+++ b/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.tsx
@@ -9,7 +9,7 @@ import domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-
 
 import domainSchedulesFiltersConfig from '../config/domain-schedules-filters.config';
 
-import { styled } from './domain-schedules-header.styles';
+import { overrides, styled } from './domain-schedules-header.styles';
 import { type Props } from './domain-schedules-header.types';
 
 export default function DomainSchedulesHeader({
@@ -37,8 +37,9 @@ export default function DomainSchedulesHeader({
             kind={KIND.primary}
             size={SIZE.compact}
             shape={SHAPE.default}
-            startEnhancer={<MdAdd size={18} aria-hidden />}
+            startEnhancer={<MdAdd size={16} aria-hidden />}
             onClick={onCreateScheduleClick}
+            overrides={overrides.createScheduleButton}
           >
             Create schedule
           </Button>

--- a/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.tsx
+++ b/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.tsx
@@ -1,6 +1,9 @@
 'use client';
 import React from 'react';
 
+import { Button, KIND, SHAPE, SIZE } from 'baseui/button';
+import { MdAdd } from 'react-icons/md';
+
 import PageFilters from '@/components/page-filters/page-filters';
 import domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-query-params.config';
 
@@ -9,7 +12,10 @@ import domainSchedulesFiltersConfig from '../config/domain-schedules-filters.con
 import { styled } from './domain-schedules-header.styles';
 import { type Props } from './domain-schedules-header.types';
 
-export default function DomainSchedulesHeader({ count }: Props) {
+export default function DomainSchedulesHeader({
+  count,
+  onCreateScheduleClick,
+}: Props) {
   const title = count === undefined ? 'Schedules' : `Schedules (${count})`;
 
   return (
@@ -17,12 +23,27 @@ export default function DomainSchedulesHeader({ count }: Props) {
       <styled.TitleRow>
         <styled.Title>{title}</styled.Title>
       </styled.TitleRow>
-      <PageFilters
-        searchQueryParamKey="schedulesSearch"
-        searchPlaceholder="Find schedule by ID or workflow type"
-        pageFiltersConfig={domainSchedulesFiltersConfig}
-        pageQueryParamsConfig={domainPageQueryParamsConfig}
-      />
+      <styled.FiltersToolbar>
+        <styled.FiltersSlot>
+          <PageFilters
+            searchQueryParamKey="schedulesSearch"
+            searchPlaceholder="Find schedule by ID or workflow type"
+            pageFiltersConfig={domainSchedulesFiltersConfig}
+            pageQueryParamsConfig={domainPageQueryParamsConfig}
+          />
+        </styled.FiltersSlot>
+        <styled.CreateButtonWrap>
+          <Button
+            kind={KIND.primary}
+            size={SIZE.compact}
+            shape={SHAPE.default}
+            startEnhancer={<MdAdd size={18} aria-hidden />}
+            onClick={onCreateScheduleClick}
+          >
+            Create schedule
+          </Button>
+        </styled.CreateButtonWrap>
+      </styled.FiltersToolbar>
     </styled.Container>
   );
 }

--- a/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.tsx
+++ b/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.tsx
@@ -34,9 +34,9 @@ export default function DomainSchedulesHeader({
         </styled.FiltersSlot>
         <styled.CreateButtonWrap>
           <Button
-            kind={KIND.primary}
-            size={SIZE.compact}
-            shape={SHAPE.default}
+            kind="primary"
+            size="compact"
+            shape="default"
             startEnhancer={<MdAdd size={16} aria-hidden />}
             onClick={onCreateScheduleClick}
             overrides={overrides.createScheduleButton}

--- a/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.types.ts
+++ b/src/views/domain-schedules/domain-schedules-header/domain-schedules-header.types.ts
@@ -1,3 +1,4 @@
 export type Props = {
   count: number | undefined;
+  onCreateScheduleClick: () => void;
 };

--- a/src/views/domain-schedules/domain-schedules.tsx
+++ b/src/views/domain-schedules/domain-schedules.tsx
@@ -126,6 +126,7 @@ export default function DomainSchedules({ domain, cluster }: Props) {
     <styled.Root>
       <DomainSchedulesHeader
         count={isLoading ? undefined : filteredSchedules.length}
+        onCreateScheduleClick={() => setIsCreateModalOpen(true)}
       />
       {content}
       <DomainSchedulesCreateModal

--- a/src/views/domain-schedules/domain-schedules.tsx
+++ b/src/views/domain-schedules/domain-schedules.tsx
@@ -88,7 +88,7 @@ export default function DomainSchedules({ domain, cluster }: Props) {
               onClick: () => setIsCreateModalOpen(true),
               buttonKind: 'primary',
               shape: 'default',
-              startEnhancer: <MdAdd size={18} aria-hidden />,
+              startEnhancer: <MdAdd size={16} aria-hidden />,
             },
           ]}
         />


### PR DESCRIPTION
## Summary
Adds a **Create** button adjacent to the filters in `DomainSchedulesHeader`, wired to the same open-create-modal handler as the empty-state entry point.

## Stack position: PR07 (stacked on PR06 — feat/schedule-create-pr06-worker-sdk-input)

## Changes

- `domain-schedules-header.types.ts` — adds `onCreateSchedule: () => void` to Props
- `domain-schedules-header.tsx` — renders Create button inside a `FiltersRow` next to `PageFilters`
- `domain-schedules-header.styles.ts` — adds `FiltersRow` styled component
- `domain-schedules.tsx` — passes `() => setIsCreateModalOpen(true)` as `onCreateSchedule`; imports modal from `domain-schedules-create-modal/`
- `domain-schedules-create-modal/` — create-schedule modal + form + schema + tests (moved/renamed from `create-schedule-modal/`)
- `multi-json-input/*`, `workflow-action-start-form/*` — MultiJSON error shape + start-workflow alignment
- `.gitignore` — local agent planning paths

## Testing
<img width="455" height="832" alt="Screenshot 2026-06-16 at 13 41 27" src="https://github.com/user-attachments/assets/83f221fd-6de3-46bc-9a06-37d3a9167372" />
<img width="1197" height="828" alt="Screenshot 2026-06-16 at 13 41 34" src="https://github.com/user-attachments/assets/ce812522-2f5f-458b-bd8e-f1cd0567914b" />
<img width="1199" height="830" alt="Screenshot 2026-06-16 at 13 41 41" src="https://github.com/user-attachments/assets/c6f0ab0f-5ebc-4dde-9fd9-655974e91c82" />

## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- Schedules Create Form
  - #1302
  - #1303
  - #1305
  - #1306
  - #1307
  - #1340
  - #1341
- Schedules Details
- Schedules Actions
- Schedules Backfills
