### PR TITLE
feat(schedules): create-schedule advanced accordion and basic fields

### DIFF
--- a/src/route-handlers/create-schedule/helpers/__tests__/transform-create-schedule-body-to-grpc-input.node.ts
+++ b/src/route-handlers/create-schedule/helpers/__tests__/transform-create-schedule-body-to-grpc-input.node.ts
@@ -86,6 +86,15 @@ describe(transformCreateScheduleBodyToGrpcInput.name, () => {
     expect(grpc.spec?.jitter).toEqual({ seconds: 1, nanos: 500_000_000 });
   });
 
+  it('omits zero jitter seconds', () => {
+    const grpc = transformCreateScheduleBodyToGrpcInput({
+      domain: 'd',
+      body: minimalBody({ jitterSeconds: 0 }),
+    });
+
+    expect(grpc.spec?.jitter).toBeUndefined();
+  });
+
   it('maps schedule policies', () => {
     const grpc = transformCreateScheduleBodyToGrpcInput({
       domain: 'd',

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { useForm } from 'react-hook-form';
+
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type DomainSchedulesCreateFormData } from '../../domain-schedules-create-modal/domain-schedules-create-modal.types';
+import DomainSchedulesCreateAdvancedForm from '../domain-schedules-create-advanced-form';
+
+describe(DomainSchedulesCreateAdvancedForm.name, () => {
+  it('renders the accordion toggle and is collapsed by default', () => {
+    setup();
+
+    expect(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText('Schedule Id')).not.toBeInTheDocument();
+  });
+
+  it('expands advanced fields when the toggle is clicked', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(
+      screen.getByRole('button', { name: /hide advanced configurations/i })
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Schedule Id')).toBeInTheDocument();
+    expect(screen.getByLabelText('Jitter duration')).toBeInTheDocument();
+    expect(screen.getByLabelText('Workflow Id Prefix')).toBeInTheDocument();
+  });
+
+  it('collapses advanced fields when the toggle is clicked again', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+    expect(screen.getByLabelText('Schedule Id')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: /hide advanced configurations/i })
+    );
+    expect(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    ).toBeInTheDocument();
+  });
+});
+
+function setup() {
+  const user = userEvent.setup();
+
+  function Wrapper() {
+    const {
+      control,
+      formState: { errors: fieldErrors },
+    } = useForm<DomainSchedulesCreateFormData>({
+      defaultValues: {},
+    });
+    return (
+      <DomainSchedulesCreateAdvancedForm
+        control={control}
+        fieldErrors={fieldErrors}
+      />
+    );
+  }
+
+  render(<Wrapper />);
+  return { user };
+}

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -1,0 +1,14 @@
+/** Stable ids for advanced create-schedule horizontal fields. */
+export const CREATE_SCHEDULE_ADVANCED_FIELD_IDS = {
+  scheduleId: 'domain-schedules-create-form-schedule-id',
+  jitterSeconds: 'domain-schedules-create-form-jitter-seconds',
+  workflowIdPrefix: 'domain-schedules-create-form-workflow-id-prefix',
+} as const;
+
+export const CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS = {
+  scheduleId: 'Unique name provided by users to name the schedule.',
+  jitterSeconds:
+    'Time range to distribute starting workflows across. This helps avoiding burst of workflow creations in a single point of time.',
+  workflowIdPrefix:
+    'Prefix text to add into started workflows. Ids are formed as `${Prefix}+{auto generated postfix}`.',
+} as const;

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
@@ -1,0 +1,39 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import { type PanelOverrides } from 'baseui/accordion';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  panel: {
+    PanelContainer: {
+      style: {
+        borderWidth: '0',
+      },
+    },
+    Content: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        paddingTop: $theme.sizing.scale600,
+        paddingBottom: 0,
+        paddingLeft: 0,
+        paddingRight: 0,
+      }),
+    },
+  } satisfies PanelOverrides,
+};
+
+export const styled = {
+  ToggleRow: createStyled(
+    'div',
+    (): StyleObject => ({
+      display: 'flex',
+      alignItems: 'center',
+    })
+  ),
+  Divider: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      flex: 1,
+      height: '1px',
+      backgroundColor: $theme.colors.borderOpaque,
+    })
+  ),
+};

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import React from 'react';
+
+import { StatefulPanel } from 'baseui/accordion';
+import { Button } from 'baseui/button';
+import { mergeOverrides } from 'baseui/helpers/overrides';
+import { Input } from 'baseui/input';
+import { LabelXSmall } from 'baseui/typography';
+import { Controller } from 'react-hook-form';
+import { MdExpandLess, MdExpandMore } from 'react-icons/md';
+
+import DomainSchedulesHorizontalField from '@/views/domain-schedules/domain-schedules-horizontal-field/domain-schedules-horizontal-field';
+import getFieldErrorMessage from '@/views/workflow-actions/workflow-action-start-form/helpers/get-field-error-message';
+
+import {
+  CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS,
+  CREATE_SCHEDULE_ADVANCED_FIELD_IDS,
+} from './domain-schedules-create-advanced-form.constants';
+import {
+  overrides,
+  styled,
+} from './domain-schedules-create-advanced-form.styles';
+import { type Props } from './domain-schedules-create-advanced-form.types';
+
+export default function DomainSchedulesCreateAdvancedForm({
+  control,
+  fieldErrors,
+}: Props) {
+  return (
+    <StatefulPanel
+      overrides={mergeOverrides(overrides.panel, {
+        Header: {
+          component: (props) => (
+            <styled.ToggleRow>
+              <Button
+                size="mini"
+                kind="tertiary"
+                type="button"
+                startEnhancer={
+                  props.$expanded ? (
+                    <MdExpandLess size={20} />
+                  ) : (
+                    <MdExpandMore size={20} />
+                  )
+                }
+                onClick={() => props.onClick?.({ expanded: !props.$expanded })}
+              >
+                {props.$expanded
+                  ? 'Hide advanced configurations'
+                  : 'Show advanced configurations'}
+              </Button>
+              <styled.Divider />
+            </styled.ToggleRow>
+          ),
+        },
+      })}
+    >
+      <>
+        <DomainSchedulesHorizontalField
+          label="Schedule Id"
+          description={CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.scheduleId}
+          htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.scheduleId}
+          error={getFieldErrorMessage(fieldErrors, 'scheduleId')}
+        >
+          <Controller
+            name="scheduleId"
+            control={control}
+            defaultValue=""
+            render={({ field: { ref, ...field } }) => (
+              <Input
+                {...field}
+                id={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.scheduleId}
+                // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
+                inputRef={ref}
+                aria-label="Schedule Id"
+                onChange={(e) => field.onChange(e.target.value || undefined)}
+                onBlur={field.onBlur}
+                error={Boolean(getFieldErrorMessage(fieldErrors, 'scheduleId'))}
+                size="compact"
+                placeholder="Add schedule id"
+              />
+            )}
+          />
+        </DomainSchedulesHorizontalField>
+
+        <DomainSchedulesHorizontalField
+          label="Jitter duration"
+          description={
+            CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.jitterSeconds
+          }
+          htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.jitterSeconds}
+          error={getFieldErrorMessage(fieldErrors, 'jitterSeconds')}
+        >
+          <Controller
+            name="jitterSeconds"
+            control={control}
+            defaultValue=""
+            render={({ field: { ref, ...field } }) => (
+              <Input
+                {...field}
+                id={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.jitterSeconds}
+                // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
+                inputRef={ref}
+                aria-label="Jitter duration"
+                type="number"
+                min={0}
+                onBlur={field.onBlur}
+                error={Boolean(
+                  getFieldErrorMessage(fieldErrors, 'jitterSeconds')
+                )}
+                size="compact"
+                placeholder="Add Jitter duration"
+                endEnhancer={<LabelXSmall>Seconds</LabelXSmall>}
+              />
+            )}
+          />
+        </DomainSchedulesHorizontalField>
+
+        <DomainSchedulesHorizontalField
+          label="Workflow Id Prefix"
+          description={
+            CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.workflowIdPrefix
+          }
+          htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.workflowIdPrefix}
+          error={getFieldErrorMessage(fieldErrors, 'workflowIdPrefix')}
+        >
+          <Controller
+            name="workflowIdPrefix"
+            control={control}
+            defaultValue=""
+            render={({ field: { ref, ...field } }) => (
+              <Input
+                {...field}
+                id={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.workflowIdPrefix}
+                // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
+                inputRef={ref}
+                aria-label="Workflow Id Prefix"
+                onChange={(e) => field.onChange(e.target.value || undefined)}
+                onBlur={field.onBlur}
+                error={Boolean(
+                  getFieldErrorMessage(fieldErrors, 'workflowIdPrefix')
+                )}
+                size="compact"
+                placeholder="Add workflow id prefix"
+              />
+            )}
+          />
+        </DomainSchedulesHorizontalField>
+      </>
+    </StatefulPanel>
+  );
+}

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
@@ -1,0 +1,8 @@
+import { type Control, type FieldErrors } from 'react-hook-form';
+
+import { type DomainSchedulesCreateFormData } from '../domain-schedules-create-modal/domain-schedules-create-modal.types';
+
+export type Props = {
+  control: Control<DomainSchedulesCreateFormData>;
+  fieldErrors: FieldErrors<DomainSchedulesCreateFormData>;
+};

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -12,6 +12,7 @@ import CronScheduleInput from '@/components/cron-schedule-input/cron-schedule-in
 import MultiJsonInput from '@/components/multi-json-input/multi-json-input';
 // TODO(refactor): WORKER_SDK_LANGUAGES is imported from start-workflow — extract to shared constants once both features stabilise
 import { WORKER_SDK_LANGUAGES } from '@/route-handlers/start-workflow/start-workflow.constants';
+import DomainSchedulesCreateAdvancedForm from '@/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form';
 import DomainSchedulesHorizontalField from '@/views/domain-schedules/domain-schedules-horizontal-field/domain-schedules-horizontal-field';
 // TODO(refactor): getFieldErrorMessage and getFieldObjectErrorMessages are imported from start-workflow helpers — extract to shared utils
 import getFieldErrorMessage from '@/views/workflow-actions/workflow-action-start-form/helpers/get-field-error-message';
@@ -301,6 +302,11 @@ export default function DomainSchedulesCreateForm({ control, trigger }: Props) {
           )}
         />
       </DomainSchedulesHorizontalField>
+
+      <DomainSchedulesCreateAdvancedForm
+        control={control}
+        fieldErrors={fieldErrors}
+      />
     </div>
   );
 }

--- a/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
@@ -52,14 +52,27 @@ describe(transformDomainSchedulesCreateFormToBody.name, () => {
     expect(result.startWorkflow.input).toBeUndefined();
   });
 
-  it('trims workflow type and task list names', () => {
+  it('trims text fields', () => {
     const result = transformDomainSchedulesCreateFormToBody({
       ...baseForm,
       workflowType: { name: ' DemoWorkflow ' },
       taskList: { name: ' demo-tl ' },
+      scheduleId: '  my-schedule  ',
+      workflowIdPrefix: '  wf-prefix  ',
     });
 
     expect(result.startWorkflow.workflowType.name).toBe('DemoWorkflow');
     expect(result.startWorkflow.taskList.name).toBe('demo-tl');
+    expect(result.scheduleId).toBe('my-schedule');
+    expect(result.startWorkflow.workflowIdPrefix).toBe('wf-prefix');
+  });
+
+  it('passes 0 seconds as jitter', () => {
+    const result = transformDomainSchedulesCreateFormToBody({
+      ...baseForm,
+      jitterSeconds: '0',
+    });
+
+    expect(result.jitterSeconds).toBe(0);
   });
 });

--- a/src/views/domain-schedules/domain-schedules-create-modal/domain-schedules-create-modal.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-modal/domain-schedules-create-modal.tsx
@@ -90,7 +90,7 @@ export default function DomainSchedulesCreateModal({
       overrides={overrides.modal}
     >
       <styled.ModalHeader>Create Schedule</styled.ModalHeader>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form noValidate onSubmit={handleSubmit(onSubmit)}>
         <styled.ModalBody>
           {createScheduleError && (
             <div ref={errorAlertRef} role="alert">

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
@@ -25,7 +25,16 @@ export default function transformDomainSchedulesCreateFormToBody(
         formData.executionStartToCloseTimeoutSeconds,
       taskStartToCloseTimeoutSeconds: formData.taskStartToCloseTimeoutSeconds,
       ...(parsedInput && parsedInput.length > 0 ? { input: parsedInput } : {}),
+      ...(formData.workflowIdPrefix?.trim()
+        ? { workflowIdPrefix: formData.workflowIdPrefix.trim() }
+        : {}),
     },
     pauseOnFailure: formData.pauseOnFailure,
+    ...(formData.scheduleId?.trim()
+      ? { scheduleId: formData.scheduleId.trim() }
+      : {}),
+    ...(formData.jitterSeconds
+      ? { jitterSeconds: parseFloat(formData.jitterSeconds) }
+      : {}),
   };
 }

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -62,6 +62,7 @@ const cronExpressionFieldsSchema = z
   });
 
 export const createScheduleFormSchema = z.object({
+  // --- Main fields ---
   cronExpression: cronExpressionFieldsSchema,
   workflowType: z.object({
     name: z.string().min(1, 'Workflow type is required'),
@@ -106,4 +107,14 @@ export const createScheduleFormSchema = z.object({
       }
     }),
   pauseOnFailure: z.boolean().optional().default(false),
+
+  // --- Advanced fields ---
+  scheduleId: z.string().min(1).optional(),
+  jitterSeconds: z
+    .string()
+    .refine((v) => v === '' || Number(v) >= 0, {
+      message: 'Jitter seconds must be zero or positive',
+    })
+    .optional(),
+  workflowIdPrefix: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
Add collapsible advanced fields sections with few basic fields `scheduleId`, `jitterSeconds`, `workflowIdPrefix`

## Test plan

<img width="996" height="1091" alt="Screenshot 2026-06-24 at 16 25 56" src="https://github.com/user-attachments/assets/63a9959e-0754-45f4-aeed-bb303486bd17" />

https://github.com/user-attachments/assets/a70ae0d4-ba9c-4ef9-b93e-e497331f0277

## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- Schedules Create Form
  - #1302
  - #1303
  - #1305
  - #1306
  - #1307
  - #1340
  - #1342
  - #1343
- Schedules Details
- Schedules Actions



