### PR TITLE
feat(schedule-details): describeSchedule gRPC + GET route handler

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { describeSchedule } from '@/route-handlers/describe-schedule/describe-schedule';
+import { type RouteParams } from '@/route-handlers/describe-schedule/describe-schedule.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function GET(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    describeSchedule,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response.ts
+++ b/src/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response.ts
@@ -1,0 +1,45 @@
+import { type DescribeScheduleResponse } from '../describe-schedule.types';
+
+export const mockDescribeScheduleResponse: DescribeScheduleResponse = {
+  spec: null,
+  action: null,
+  policies: null,
+  state: { paused: false, pauseInfo: null },
+  info: null,
+  memo: null,
+  searchAttributes: null,
+};
+
+export function getMockDescribeScheduleResponse(
+  overrides: Partial<DescribeScheduleResponse> = {}
+): DescribeScheduleResponse {
+  return {
+    ...mockDescribeScheduleResponse,
+    ...overrides,
+  };
+}
+
+export function getMockRunningDescribeScheduleResponse(
+  overrides: Partial<DescribeScheduleResponse> = {}
+): DescribeScheduleResponse {
+  return getMockDescribeScheduleResponse({
+    state: { paused: false, pauseInfo: null },
+    ...overrides,
+  });
+}
+
+export function getMockPausedDescribeScheduleResponse(
+  overrides: Partial<DescribeScheduleResponse> = {}
+): DescribeScheduleResponse {
+  return getMockDescribeScheduleResponse({
+    state: {
+      paused: true,
+      pauseInfo: {
+        pausedBy: 'operator@example.com',
+        reason: 'Paused for maintenance',
+        pausedAt: null,
+      },
+    },
+    ...overrides,
+  });
+}

--- a/src/route-handlers/describe-schedule/__tests__/describe-schedule.node.ts
+++ b/src/route-handlers/describe-schedule/__tests__/describe-schedule.node.ts
@@ -1,0 +1,123 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import { describeSchedule } from '../describe-schedule';
+import {
+  type Context,
+  type DescribeScheduleResponse,
+  type RequestParams,
+} from '../describe-schedule.types';
+
+jest.mock('@/utils/logger');
+
+const mockDescribeScheduleResponse: DescribeScheduleResponse = {
+  spec: null,
+  action: null,
+  policies: null,
+  state: null,
+  info: null,
+  memo: null,
+  searchAttributes: null,
+};
+
+describe(describeSchedule.name, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls describeSchedule and returns valid response', async () => {
+    const { res, mockDescribeSchedule } = await setup({});
+
+    expect(mockDescribeSchedule).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      scheduleId: 'mock-schedule-id',
+    });
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual(mockDescribeScheduleResponse);
+  });
+
+  it('returns error when describeSchedule throws a GRPCError', async () => {
+    const { res, mockDescribeSchedule } = await setup({
+      error: new GRPCError('Schedule not found', {
+        grpcStatusCode: status.NOT_FOUND,
+      }),
+    });
+
+    expect(mockDescribeSchedule).toHaveBeenCalled();
+    expect(res.status).toEqual(404);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Schedule not found',
+      })
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: {
+          domain: 'mock-domain',
+          cluster: 'mock-cluster',
+          scheduleId: 'mock-schedule-id',
+        },
+        error: expect.any(GRPCError),
+      }),
+      'Error fetching schedule details: Schedule not found'
+    );
+  });
+
+  it('returns error when describeSchedule throws a generic error', async () => {
+    const { res, mockDescribeSchedule } = await setup({
+      error: new Error('Network error'),
+    });
+
+    expect(mockDescribeSchedule).toHaveBeenCalled();
+    expect(res.status).toEqual(500);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Error fetching schedule details',
+      })
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: {
+          domain: 'mock-domain',
+          cluster: 'mock-cluster',
+          scheduleId: 'mock-schedule-id',
+        },
+        error: expect.any(Error),
+      }),
+      'Error fetching schedule details'
+    );
+  });
+});
+
+async function setup({ error }: { error?: Error }) {
+  const mockDescribeSchedule = jest
+    .spyOn(mockGrpcClusterMethods, 'describeSchedule')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw error;
+      }
+      return mockDescribeScheduleResponse;
+    });
+
+  const res = await describeSchedule(
+    new NextRequest('http://localhost'),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        scheduleId: 'mock-schedule-id',
+      },
+    } as RequestParams,
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockDescribeSchedule };
+}

--- a/src/route-handlers/describe-schedule/describe-schedule.ts
+++ b/src/route-handlers/describe-schedule/describe-schedule.ts
@@ -1,0 +1,46 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import type {
+  Context,
+  DescribeScheduleResponse,
+  RequestParams,
+  RouteParams,
+} from './describe-schedule.types';
+
+export async function describeSchedule(
+  _: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const params = requestParams.params as RouteParams;
+
+  try {
+    const response: DescribeScheduleResponse =
+      await ctx.grpcClusterMethods.describeSchedule({
+        domain: params.domain,
+        scheduleId: params.scheduleId,
+      });
+
+    return NextResponse.json(response);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: params, error: e },
+      'Error fetching schedule details' +
+        (e instanceof GRPCError ? ': ' + e.message : '')
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError
+            ? e.message
+            : 'Error fetching schedule details',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/describe-schedule/describe-schedule.types.ts
+++ b/src/route-handlers/describe-schedule/describe-schedule.types.ts
@@ -1,0 +1,16 @@
+import { type DescribeScheduleResponse as DescribeScheduleResponseProto } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeScheduleResponse';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+  scheduleId: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type DescribeScheduleResponse = DescribeScheduleResponseProto;
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -7,6 +7,8 @@ import { type CreateScheduleRequest__Input } from '@/__generated__/proto-ts/uber
 import { type CreateScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/CreateScheduleResponse';
 import { type DescribeDomainRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainRequest';
 import { type DescribeDomainResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeDomainResponse';
+import { type DescribeScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeScheduleRequest';
+import { type DescribeScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeScheduleResponse';
 import { type DescribeTaskListRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeTaskListRequest';
 import { type DescribeTaskListResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeTaskListResponse';
 import { type DescribeWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeWorkflowExecutionResponse';
@@ -80,6 +82,9 @@ export type GRPCClusterMethods = {
   createSchedule: (
     payload: CreateScheduleRequest__Input
   ) => Promise<CreateScheduleResponse>;
+  describeSchedule: (
+    payload: DescribeScheduleRequest__Input
+  ) => Promise<DescribeScheduleResponse>;
   describeCluster: (
     payload: DescribeClusterRequest__Input
   ) => Promise<DescribeClusterResponse>;
@@ -253,6 +258,13 @@ const getClusterServicesMethods = async (
       CreateScheduleResponse
     >({
       method: 'CreateSchedule',
+      metadata: metadata,
+    }),
+    describeSchedule: scheduleService.request<
+      DescribeScheduleRequest__Input,
+      DescribeScheduleResponse
+    >({
+      method: 'DescribeSchedule',
       metadata: metadata,
     }),
     describeCluster: adminService.request<

--- a/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
@@ -5,6 +5,7 @@ export const mockGrpcClusterMethods: GRPCClusterMethods = {
   closedWorkflows: jest.fn(),
   countWorkflows: jest.fn(),
   createSchedule: jest.fn(),
+  describeSchedule: jest.fn(),
   describeCluster: jest.fn(),
   describeDomain: jest.fn(),
   updateDomain: jest.fn(),

--- a/src/views/shared/hooks/use-describe-schedule/__tests__/get-describe-schedule-query-options.test.ts
+++ b/src/views/shared/hooks/use-describe-schedule/__tests__/get-describe-schedule-query-options.test.ts
@@ -1,0 +1,102 @@
+import { type Query } from '@tanstack/react-query';
+
+import {
+  getMockPausedDescribeScheduleResponse,
+  getMockRunningDescribeScheduleResponse,
+} from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type RequestError } from '@/utils/request/request-error';
+
+import getDescribeScheduleQueryOptions from '../get-describe-schedule-query-options';
+import {
+  type DescribeScheduleQueryKey,
+  type DescribeScheduleResponse,
+} from '../use-describe-schedule.types';
+
+const params = {
+  domain: 'test-domain',
+  cluster: 'test-cluster',
+  scheduleId: 'test-schedule-id',
+};
+
+const mockRunningDescribeScheduleResponse =
+  getMockRunningDescribeScheduleResponse();
+
+const mockPausedDescribeScheduleResponse =
+  getMockPausedDescribeScheduleResponse();
+
+type RefetchTypeIntervalArg = Query<
+  DescribeScheduleResponse,
+  RequestError,
+  DescribeScheduleResponse,
+  DescribeScheduleQueryKey
+>;
+
+describe(getDescribeScheduleQueryOptions.name, () => {
+  it('returns namespaced queryKey including domain, cluster, and scheduleId', () => {
+    const options = getDescribeScheduleQueryOptions(params);
+    expect(options.queryKey).toEqual(['describeSchedule', params]);
+  });
+
+  it('returns refetchInterval of 10s by default when schedule is running', () => {
+    const options = getDescribeScheduleQueryOptions(params);
+    const refetchInterval = options.refetchInterval;
+
+    if (typeof refetchInterval !== 'function') {
+      throw new Error('Expected refetchInterval to be a function');
+    }
+
+    const mockQuery = {
+      state: {
+        data: mockRunningDescribeScheduleResponse as DescribeScheduleResponse,
+      },
+    } as RefetchTypeIntervalArg;
+
+    expect(refetchInterval(mockQuery)).toBe(10_000);
+  });
+
+  it('returns refetchInterval false when schedule is paused', () => {
+    const options = getDescribeScheduleQueryOptions(params);
+    const refetchInterval = options.refetchInterval;
+
+    if (typeof refetchInterval !== 'function') {
+      throw new Error('Expected refetchInterval to be a function');
+    }
+
+    const mockQuery = {
+      state: {
+        data: mockPausedDescribeScheduleResponse as DescribeScheduleResponse,
+      },
+    } as RefetchTypeIntervalArg;
+
+    expect(refetchInterval(mockQuery)).toBe(false);
+  });
+
+  it('uses custom runningScheduleRefetchIntervalMs when provided', () => {
+    const options = getDescribeScheduleQueryOptions({
+      ...params,
+      runningScheduleRefetchIntervalMs: 5_000,
+    });
+    const refetchInterval = options.refetchInterval;
+
+    if (typeof refetchInterval !== 'function') {
+      throw new Error('Expected refetchInterval to be a function');
+    }
+
+    const mockQuery = {
+      state: {
+        data: mockRunningDescribeScheduleResponse as DescribeScheduleResponse,
+      },
+    } as RefetchTypeIntervalArg;
+
+    expect(refetchInterval(mockQuery)).toBe(5_000);
+  });
+
+  it('does not include runningScheduleRefetchIntervalMs in queryKey', () => {
+    const options = getDescribeScheduleQueryOptions({
+      ...params,
+      runningScheduleRefetchIntervalMs: 5_000,
+    });
+
+    expect(options.queryKey).toEqual(['describeSchedule', params]);
+  });
+});

--- a/src/views/shared/hooks/use-describe-schedule/__tests__/use-describe-schedule.test.ts
+++ b/src/views/shared/hooks/use-describe-schedule/__tests__/use-describe-schedule.test.ts
@@ -1,0 +1,75 @@
+import { HttpResponse } from 'msw';
+
+import { renderHook, waitFor } from '@/test-utils/rtl';
+
+import { getMockRunningDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+
+import useDescribeSchedule from '../use-describe-schedule';
+import { type DescribeScheduleResponse } from '../use-describe-schedule.types';
+
+const mockRunningDescribeScheduleResponse =
+  getMockRunningDescribeScheduleResponse();
+describe(useDescribeSchedule.name, () => {
+  it('returns describe data for a schedule', async () => {
+    const { result } = setup({
+      response: mockRunningDescribeScheduleResponse,
+    });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(mockRunningDescribeScheduleResponse);
+    });
+  });
+
+  it('surfaces error when API fails', async () => {
+    const { result } = setup({ error: true });
+
+    await waitFor(() => {
+      expect(result.current.error).toBeDefined();
+    });
+  });
+
+  it('exposes isLoading during initial fetch', () => {
+    const { result } = setup({
+      response: mockRunningDescribeScheduleResponse,
+    });
+
+    expect(result.current.isLoading).toBe(true);
+  });
+});
+
+function setup({
+  response,
+  error = false,
+}: {
+  response?: DescribeScheduleResponse;
+  error?: boolean;
+} = {}) {
+  return renderHook(
+    () =>
+      useDescribeSchedule({
+        domain: 'test-domain',
+        cluster: 'test-cluster',
+        scheduleId: 'test-schedule-id',
+      }),
+    {
+      endpointsMocks: [
+        {
+          path: '/api/domains/:domain/:cluster/schedules/:scheduleId',
+          httpMethod: 'GET',
+          mockOnce: false,
+          httpResolver: async () => {
+            if (error) {
+              return HttpResponse.json(
+                { message: 'Failed to describe schedule' },
+                { status: 500 }
+              );
+            }
+            return HttpResponse.json(
+              response ?? mockRunningDescribeScheduleResponse
+            );
+          },
+        },
+      ],
+    }
+  );
+}

--- a/src/views/shared/hooks/use-describe-schedule/get-describe-schedule-query-options.ts
+++ b/src/views/shared/hooks/use-describe-schedule/get-describe-schedule-query-options.ts
@@ -1,0 +1,27 @@
+import request from '@/utils/request';
+
+import {
+  type DescribeScheduleQueryKey,
+  type UseDescribeScheduleParams,
+  type UseDescribeScheduleQueryOptions,
+} from './use-describe-schedule.types';
+
+export default function getDescribeScheduleQueryOptions({
+  runningScheduleRefetchIntervalMs = 10000, // 10 seconds
+  ...params
+}: UseDescribeScheduleParams): UseDescribeScheduleQueryOptions {
+  return {
+    queryKey: ['describeSchedule', params] satisfies DescribeScheduleQueryKey,
+    queryFn: ({ queryKey: [_, p] }: { queryKey: DescribeScheduleQueryKey }) =>
+      request(
+        `/api/domains/${encodeURIComponent(p.domain)}/${encodeURIComponent(p.cluster)}/schedules/${encodeURIComponent(p.scheduleId)}`
+      ).then((res) => res.json()),
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      if (data?.state?.paused === false) {
+        return runningScheduleRefetchIntervalMs;
+      }
+      return false;
+    },
+  };
+}

--- a/src/views/shared/hooks/use-describe-schedule/use-describe-schedule.ts
+++ b/src/views/shared/hooks/use-describe-schedule/use-describe-schedule.ts
@@ -1,0 +1,20 @@
+'use client';
+import { useQuery } from '@tanstack/react-query';
+
+import { type RequestError } from '@/utils/request/request-error';
+
+import getDescribeScheduleQueryOptions from './get-describe-schedule-query-options';
+import {
+  type DescribeScheduleResponse,
+  type DescribeScheduleQueryKey,
+  type UseDescribeScheduleParams,
+} from './use-describe-schedule.types';
+
+export default function useDescribeSchedule(params: UseDescribeScheduleParams) {
+  return useQuery<
+    DescribeScheduleResponse,
+    RequestError,
+    DescribeScheduleResponse,
+    DescribeScheduleQueryKey
+  >(getDescribeScheduleQueryOptions(params));
+}

--- a/src/views/shared/hooks/use-describe-schedule/use-describe-schedule.types.ts
+++ b/src/views/shared/hooks/use-describe-schedule/use-describe-schedule.types.ts
@@ -1,0 +1,25 @@
+import { type UseQueryOptions } from '@tanstack/react-query';
+
+import {
+  type DescribeScheduleResponse,
+  type RouteParams as DescribeScheduleRouteParams,
+} from '@/route-handlers/describe-schedule/describe-schedule.types';
+import { type RequestError } from '@/utils/request/request-error';
+
+export { type DescribeScheduleResponse };
+
+export type DescribeScheduleQueryKey = [
+  'describeSchedule',
+  DescribeScheduleRouteParams,
+];
+
+export type UseDescribeScheduleParams = DescribeScheduleRouteParams & {
+  runningScheduleRefetchIntervalMs?: number;
+};
+
+export type UseDescribeScheduleQueryOptions = UseQueryOptions<
+  DescribeScheduleResponse,
+  RequestError,
+  DescribeScheduleResponse,
+  DescribeScheduleQueryKey
+>;


### PR DESCRIPTION
## Summary

Wires `DescribeSchedule` into the gRPC client and exposes a typed `GET /api/domains/[domain]/[cluster]/schedules/[scheduleId]` route handler.


## Test plan
- Ran locally
<img width="1728" height="874" alt="Screenshot 2026-06-18 at 20 28 45" src="https://github.com/user-attachments/assets/352c4b44-a371-4681-82f6-d1be38898208" />

## Feature plans
- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- [x] Schedules Create Form
- Schedules Details
   -  #1345
   -  #1353
   - #1346
   - #1348
- Schedules Actions
