### PR TITLE
feat: remove Concurrency field from batch action details

### DIFF
--- a/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
+++ b/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
@@ -135,7 +135,6 @@ export const mockBatcherStartedHistory = buildHistoryResponse({
   Reason: 'cleanup',
   BatchType: 'terminate',
   RPS: 100,
-  Concurrency: 5,
 });
 
 export const mockBatcherStartedHistoryWithUnknownType = buildHistoryResponse({

--- a/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
+++ b/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
@@ -56,7 +56,6 @@ describe(describeBatchAction.name, () => {
       endTime: 1717409148258,
       actionType: 'terminate',
       rps: 100,
-      concurrency: 5,
     });
   });
 

--- a/src/route-handlers/describe-batch-action/describe-batch-action.types.ts
+++ b/src/route-handlers/describe-batch-action/describe-batch-action.types.ts
@@ -19,9 +19,6 @@ export type RequestParams = {
 
 export type DescribeBatchActionResponse = BatchAction;
 
-export type BatcherInputFields = Pick<
-  BatchAction,
-  'actionType' | 'rps' | 'concurrency'
->;
+export type BatcherInputFields = Pick<BatchAction, 'actionType' | 'rps'>;
 
 export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/describe-batch-action/schemas/batcher-input-schema.ts
+++ b/src/route-handlers/describe-batch-action/schemas/batcher-input-schema.ts
@@ -6,12 +6,10 @@ const batcherInputSchema = z
   .object({
     BatchType: z.nativeEnum(BATCH_ACTION_TYPE).optional(),
     RPS: z.number().optional(),
-    Concurrency: z.number().optional(),
   })
-  .transform(({ BatchType, RPS, Concurrency }) => ({
+  .transform(({ BatchType, RPS }) => ({
     actionType: BatchType,
     rps: RPS, // TODO: Get latest RPS value if it was updated mid flight
-    concurrency: Concurrency,
   }));
 
 export default batcherInputSchema;

--- a/src/route-handlers/list-batch-actions/list-batch-actions.types.ts
+++ b/src/route-handlers/list-batch-actions/list-batch-actions.types.ts
@@ -12,7 +12,7 @@ export type RequestParams = {
 };
 
 // Slim shape returned by the sidebar list endpoint. The full BatchAction
-// (with actionType, rps, concurrency, etc.) is only available via a per-row
+// (with actionType, rps, etc.) is only available via a per-row
 // describe call planned for a follow-up PR.
 export type BatchActionListItem = {
   id: string;

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/__tests__/domain-batch-actions-header-info.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/__tests__/domain-batch-actions-header-info.test.tsx
@@ -24,7 +24,6 @@ const MOCK_RUNNING_ACTION: BatchAction = {
   actionType: 'cancel',
   startTime: new Date('2024-03-13T08:28:50.000Z').getTime(),
   rps: 200,
-  concurrency: 10,
 };
 
 describe(DomainBatchActionHeaderInfo.name, () => {
@@ -41,7 +40,6 @@ describe(DomainBatchActionHeaderInfo.name, () => {
     expect(screen.queryByText('Ended')).not.toBeInTheDocument();
     expect(screen.getByText('Duration')).toBeInTheDocument();
     expect(screen.getByText('RPS')).toBeInTheDocument();
-    expect(screen.getByText('Concurrency')).toBeInTheDocument();
   });
 
   it('shows Ended field for completed actions', () => {
@@ -105,12 +103,11 @@ describe(DomainBatchActionHeaderInfo.name, () => {
     expect(screen.getByText('Cancel')).toBeInTheDocument();
   });
 
-  it('renders rps and concurrency values with Edit buttons', () => {
+  it('renders the rps value with an Edit button', () => {
     render(<DomainBatchActionHeaderInfo batchAction={MOCK_RUNNING_ACTION} />);
 
     expect(screen.getByText('200')).toBeInTheDocument();
-    expect(screen.getByText('10')).toBeInTheDocument();
-    expect(screen.getAllByText('Edit')).toHaveLength(2);
+    expect(screen.getAllByText('Edit')).toHaveLength(1);
   });
 
   it('renders dashes when optional fields are missing', () => {
@@ -121,6 +118,6 @@ describe(DomainBatchActionHeaderInfo.name, () => {
     };
     render(<DomainBatchActionHeaderInfo batchAction={action} />);
 
-    expect(screen.getAllByText('—')).toHaveLength(5); // startTime, ended, duration, rps, concurrency
+    expect(screen.getAllByText('—')).toHaveLength(4); // startTime, ended, duration, rps
   });
 });

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info-items.config.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info-items.config.tsx
@@ -64,16 +64,6 @@ const batchActionHeaderInfoItemsConfig = [
     ),
     placeholderSize: '80px',
   },
-  {
-    title: 'Concurrency',
-    render: ({ batchAction }) => (
-      <DomainBatchActionEditableValue
-        value={batchAction.concurrency}
-        editable={batchAction.status === 'RUNNING'}
-      />
-    ),
-    placeholderSize: '80px',
-  },
 ] as const satisfies DomainBatchActionHeaderInfoItemsConfig;
 
 export default batchActionHeaderInfoItemsConfig;

--- a/src/views/domain-batch-actions/domain-batch-actions.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.types.ts
@@ -64,7 +64,6 @@ export type BatchAction = {
   startTime?: number;
   endTime?: number;
   rps?: number;
-  concurrency?: number;
 };
 
 export type BatchActionConfirmPayload<SubmissionData> = {


### PR DESCRIPTION
## Summary

Removes the **Concurrency** field from batch action details end-to-end. It is not relevant to users, so there is no reason to display it or carry it through the data layer.

## Changes

- **UI:** drop the `Concurrency` item from the batch action header-info config.
- **Types:** remove `concurrency` from `BatchAction` and from `BatcherInputFields` (`Pick<BatchAction, 'actionType' | 'rps'>`).
- **Parsing:** stop reading/transforming `Concurrency` in the batcher-input schema.
- **Fixtures/tests:** drop concurrency from the describe-batch-action fixture and node test, and from the header-info test (field title, edit-button count, and the missing-fields dash count).

## Note for reviewers

This changes the `describe-batch-action` response shape: the `concurrency` field is **no longer returned**. RPS is unchanged (still shown and editable).

