### PR TITLE
feat(batch-actions): share RPS schema, add tune-signal constant

### DIFF
--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-params/schemas/batch-action-params-schema.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-params/schemas/batch-action-params-schema.ts
@@ -1,12 +1,10 @@
 import { z } from 'zod';
 
+import { rpsSchema } from '@/views/domain-batch-actions/schemas/rps-schema';
+
 const batchActionParamsSchema = z.object({
   description: z.string().min(1, 'Description is required'),
-  rps: z
-    .number()
-    .int()
-    .min(1, 'Must be between 1 and 999')
-    .max(999, 'Must be between 1 and 999'),
+  rps: rpsSchema,
 });
 
 export default batchActionParamsSchema;

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -28,6 +28,9 @@ export const BATCH_ACTION_DEFAULT_QUERY_HINT =
 export const BATCH_ACTION_TASK_LIST = 'cadence-sys-batcher-tasklist';
 export const BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS = 20 * 365 * 24 * 60 * 60;
 
+// Signal sent to a running batcher workflow to adjust its RPS on the fly.
+export const BATCH_ACTION_TUNE_SIGNAL_NAME = 'cadence-sys-batch-tune-signal';
+
 export const BATCH_ACTION_DETAIL_REFETCH_INTERVAL = 10000;
 
 // Tooltip shown on a disabled per-row checkbox while "select all" is active.

--- a/src/views/domain-batch-actions/schemas/rps-schema.ts
+++ b/src/views/domain-batch-actions/schemas/rps-schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+// Shared RPS validation used by both the new-batch-action draft form and the
+// Edit RPS modal, so the two never drift.
+export const rpsSchema = z
+  .number()
+  .int()
+  .min(1, 'Must be between 1 and 999')
+  .max(999, 'Must be between 1 and 999');


### PR DESCRIPTION
**Stacked PR 1 of 3** — foundation for wiring the RPS "Edit" action on the batch-action detail page. No user-facing behavior change.

## Changes
- Extract the RPS validation (integer, 1–999) into a shared `rpsSchema` reused by the new-batch-action form, so the upcoming Edit RPS modal validates identically.
- Add the `BATCH_ACTION_TUNE_SIGNAL_NAME` (`cadence-sys-batch-tune-signal`) constant.

## Stack
1. **This PR** — foundation
2. Edit RPS modal + tune-signal hook #1358 
3. Wire the RPS Edit button to the modal #1359