### PR TITLE
feat(batch-actions): wire the RPS Edit button to the tune-signal modal

### DIFF
--- a/src/views/domain-batch-actions/config/domain-batch-actions-header-info-items.config.ts
+++ b/src/views/domain-batch-actions/config/domain-batch-actions-header-info-items.config.ts
@@ -1,19 +1,19 @@
-import React from 'react';
+import { createElement } from 'react';
 
 import formatDate from '@/utils/data-formatters/format-date';
 import formatTimeDiff from '@/utils/datetime/format-time-diff';
 
-import DomainBatchActionEditableValue from '../domain-batch-actions-editable-value/domain-batch-actions-editable-value';
+import { type DomainBatchActionHeaderInfoItemsConfig } from '../domain-batch-actions-header-info/domain-batch-actions-header-info.types';
+import DomainBatchActionRpsValue from '../domain-batch-actions-rps-value/domain-batch-actions-rps-value';
 import DomainBatchActionStatusBadge from '../domain-batch-actions-status-badge/domain-batch-actions-status-badge';
-
-import { type DomainBatchActionHeaderInfoItemsConfig } from './domain-batch-actions-header-info.types';
 
 const batchActionHeaderInfoItemsConfig = [
   {
     title: 'Status',
-    render: ({ batchAction }) => (
-      <DomainBatchActionStatusBadge status={batchAction.status} />
-    ),
+    render: ({ batchAction }) =>
+      createElement(DomainBatchActionStatusBadge, {
+        status: batchAction.status,
+      }),
     placeholderSize: '100px',
   },
   {
@@ -56,13 +56,13 @@ const batchActionHeaderInfoItemsConfig = [
   },
   {
     title: 'RPS',
-    render: ({ batchAction, onEditRps }) => (
-      <DomainBatchActionEditableValue
-        value={batchAction.rps}
-        editable={batchAction.status === 'RUNNING'}
-        onEdit={onEditRps}
-      />
-    ),
+    render: ({ batchAction, domain, cluster, workflowId }) =>
+      createElement(DomainBatchActionRpsValue, {
+        domain,
+        cluster,
+        workflowId,
+        batchAction,
+      }),
     placeholderSize: '80px',
   },
 ] as const satisfies DomainBatchActionHeaderInfoItemsConfig;

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/__tests__/domain-batch-actions-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/__tests__/domain-batch-actions-detail.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@/test-utils/rtl';
+import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import { type BatchAction } from '../../domain-batch-actions.types';
 import DomainBatchActionDetail from '../domain-batch-actions-detail';
@@ -11,6 +11,27 @@ jest.mock(
   () =>
     function MockProgressBar({ status }: { status: string }) {
       return <div>Mock progress bar: {status}</div>;
+    }
+);
+
+const mockEditRps = jest.fn();
+jest.mock('../../hooks/use-edit-batch-action-rps', () => ({
+  __esModule: true,
+  default: () => ({ editRps: mockEditRps, isPending: false }),
+}));
+
+jest.mock(
+  '../../domain-batch-actions-edit-rps-modal/domain-batch-actions-edit-rps-modal',
+  () =>
+    function MockEditRpsModal({ isOpen, onSubmit, onClose }: any) {
+      if (!isOpen) return null;
+      return (
+        <div>
+          <span>mock-edit-rps-modal</span>
+          <button onClick={() => onSubmit(250)}>mock-save</button>
+          <button onClick={onClose}>mock-close</button>
+        </div>
+      );
     }
 );
 
@@ -26,61 +47,42 @@ describe(DomainBatchActionDetail.name, () => {
   });
 
   it('renders the batch action title', () => {
-    const action: BatchAction = {
-      runId: '5',
-      status: 'COMPLETED',
-      actionType: 'cancel',
-    };
-
-    render(<DomainBatchActionDetail batchAction={action} />);
+    setup({
+      batchAction: { runId: '5', status: 'COMPLETED', actionType: 'cancel' },
+    });
 
     expect(screen.getByText('Batch action #5')).toBeInTheDocument();
   });
 
   it('shows abort button when status is running', () => {
-    const action: BatchAction = {
-      runId: '3',
-      status: 'RUNNING',
-      actionType: 'cancel',
-    };
-
-    render(<DomainBatchActionDetail batchAction={action} />);
+    setup({
+      batchAction: { runId: '3', status: 'RUNNING', actionType: 'cancel' },
+    });
 
     expect(screen.getByText('Abort batch action')).toBeInTheDocument();
   });
 
   it('does not show abort button when status is completed', () => {
-    const action: BatchAction = {
-      runId: '2',
-      status: 'COMPLETED',
-      actionType: 'cancel',
-    };
-
-    render(<DomainBatchActionDetail batchAction={action} />);
+    setup({
+      batchAction: { runId: '2', status: 'COMPLETED', actionType: 'cancel' },
+    });
 
     expect(screen.queryByText('Abort batch action')).not.toBeInTheDocument();
   });
 
   it('does not show abort button when status is aborted', () => {
-    const action: BatchAction = {
-      runId: '1',
-      status: 'ABORTED',
-      actionType: 'cancel',
-    };
-
-    render(<DomainBatchActionDetail batchAction={action} />);
+    setup({
+      batchAction: { runId: '1', status: 'ABORTED', actionType: 'cancel' },
+    });
 
     expect(screen.queryByText('Abort batch action')).not.toBeInTheDocument();
   });
 
   it('keeps the title and abort button while loading details', () => {
-    const action: BatchAction = {
-      runId: '7',
-      status: 'RUNNING',
-      actionType: 'cancel',
-    };
-
-    render(<DomainBatchActionDetail batchAction={action} loading />);
+    setup({
+      batchAction: { runId: '7', status: 'RUNNING', actionType: 'cancel' },
+      loading: true,
+    });
 
     // Header chrome keeps rendering — runId and status come from the slim list item.
     expect(screen.getByText('Batch action #7')).toBeInTheDocument();
@@ -91,7 +93,7 @@ describe(DomainBatchActionDetail.name, () => {
   });
 
   it('renders no title or abort button before any details have loaded', () => {
-    render(<DomainBatchActionDetail loading />);
+    setup({ loading: true });
 
     expect(screen.queryByText(/Batch action #/)).not.toBeInTheDocument();
     expect(screen.queryByText('Abort batch action')).not.toBeInTheDocument();
@@ -114,10 +116,50 @@ describe(DomainBatchActionDetail.name, () => {
 
     expect(screen.queryByText(/Mock progress bar/)).not.toBeInTheDocument();
   });
+
+  it('opens the edit RPS modal when the RPS Edit button is clicked', async () => {
+    const { user } = setup({
+      batchAction: {
+        runId: '9',
+        status: 'RUNNING',
+        actionType: 'cancel',
+        rps: 100,
+      },
+    });
+
+    expect(screen.queryByText('mock-edit-rps-modal')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('Edit'));
+
+    expect(screen.getByText('mock-edit-rps-modal')).toBeInTheDocument();
+  });
+
+  it('submits the new RPS through the edit hook', async () => {
+    const { user } = setup({
+      batchAction: {
+        runId: '9',
+        status: 'RUNNING',
+        actionType: 'cancel',
+        rps: 100,
+      },
+    });
+
+    await user.click(screen.getByText('Edit'));
+    await user.click(screen.getByText('mock-save'));
+
+    expect(mockEditRps).toHaveBeenCalledWith(250);
+  });
 });
 
-function setup({ batchAction, loading }: Partial<Props> = {}) {
+function setup(props: Partial<Props> = {}) {
+  const user = userEvent.setup();
   render(
-    <DomainBatchActionDetail batchAction={batchAction} loading={loading} />
+    <DomainBatchActionDetail
+      domain="domain1"
+      cluster="cluster1"
+      workflowId="workflow1"
+      {...props}
+    />
   );
+  return { user };
 }

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/__tests__/domain-batch-actions-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/__tests__/domain-batch-actions-detail.test.tsx
@@ -14,24 +14,11 @@ jest.mock(
     }
 );
 
-const mockEditRps = jest.fn();
-jest.mock('../../hooks/use-edit-batch-action-rps', () => ({
-  __esModule: true,
-  default: () => ({ editRps: mockEditRps, isPending: false }),
-}));
-
 jest.mock(
-  '../../domain-batch-actions-edit-rps-modal/domain-batch-actions-edit-rps-modal',
+  '../../domain-batch-actions-rps-value/domain-batch-actions-rps-value',
   () =>
-    function MockEditRpsModal({ isOpen, onSubmit, onClose }: any) {
-      if (!isOpen) return null;
-      return (
-        <div>
-          <span>mock-edit-rps-modal</span>
-          <button onClick={() => onSubmit(250)}>mock-save</button>
-          <button onClick={onClose}>mock-close</button>
-        </div>
-      );
+    function MockRpsValue({ batchAction }: any) {
+      return <div>Mock rps value: {batchAction.rps}</div>;
     }
 );
 
@@ -115,39 +102,6 @@ describe(DomainBatchActionDetail.name, () => {
     setup({ loading: true });
 
     expect(screen.queryByText(/Mock progress bar/)).not.toBeInTheDocument();
-  });
-
-  it('opens the edit RPS modal when the RPS Edit button is clicked', async () => {
-    const { user } = setup({
-      batchAction: {
-        runId: '9',
-        status: 'RUNNING',
-        actionType: 'cancel',
-        rps: 100,
-      },
-    });
-
-    expect(screen.queryByText('mock-edit-rps-modal')).not.toBeInTheDocument();
-
-    await user.click(screen.getByText('Edit'));
-
-    expect(screen.getByText('mock-edit-rps-modal')).toBeInTheDocument();
-  });
-
-  it('submits the new RPS through the edit hook', async () => {
-    const { user } = setup({
-      batchAction: {
-        runId: '9',
-        status: 'RUNNING',
-        actionType: 'cancel',
-        rps: 100,
-      },
-    });
-
-    await user.click(screen.getByText('Edit'));
-    await user.click(screen.getByText('mock-save'));
-
-    expect(mockEditRps).toHaveBeenCalledWith(250);
   });
 });
 

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.tsx
@@ -1,15 +1,13 @@
 'use client';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Skeleton } from 'baseui/skeleton';
 import { MdCancel } from 'react-icons/md';
 
 import Button from '@/components/button/button';
 
-import DomainBatchActionsEditRpsModal from '../domain-batch-actions-edit-rps-modal/domain-batch-actions-edit-rps-modal';
 import DomainBatchActionHeaderInfo from '../domain-batch-actions-header-info/domain-batch-actions-header-info';
 import DomainBatchActionsProgressBar from '../domain-batch-actions-progress-bar/domain-batch-actions-progress-bar';
-import useEditBatchActionRps from '../hooks/use-edit-batch-action-rps';
 
 import { overrides, styled } from './domain-batch-actions-detail.styles';
 import { type Props } from './domain-batch-actions-detail.types';
@@ -22,15 +20,6 @@ export default function DomainBatchActionDetail({
   loading = false,
 }: Props) {
   const status = batchAction?.status;
-  const [isRpsModalOpen, setIsRpsModalOpen] = useState(false);
-
-  const { editRps, isPending: isEditingRps } = useEditBatchActionRps({
-    domain,
-    cluster,
-    workflowId,
-    runId: batchAction?.runId ?? '',
-    onSuccess: () => setIsRpsModalOpen(false),
-  });
 
   return (
     <styled.Container>
@@ -55,7 +44,9 @@ export default function DomainBatchActionDetail({
         <DomainBatchActionHeaderInfo
           batchAction={batchAction}
           loading={loading}
-          onEditRps={() => setIsRpsModalOpen(true)}
+          domain={domain}
+          cluster={cluster}
+          workflowId={workflowId}
         />
       </div>
       <styled.ProgressSection>
@@ -67,13 +58,6 @@ export default function DomainBatchActionDetail({
           />
         )}
       </styled.ProgressSection>
-      <DomainBatchActionsEditRpsModal
-        isOpen={isRpsModalOpen}
-        currentRps={batchAction?.rps}
-        isSubmitting={isEditingRps}
-        onClose={() => setIsRpsModalOpen(false)}
-        onSubmit={editRps}
-      />
     </styled.Container>
   );
 }

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.tsx
@@ -1,22 +1,36 @@
 'use client';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Skeleton } from 'baseui/skeleton';
 import { MdCancel } from 'react-icons/md';
 
 import Button from '@/components/button/button';
 
+import DomainBatchActionsEditRpsModal from '../domain-batch-actions-edit-rps-modal/domain-batch-actions-edit-rps-modal';
 import DomainBatchActionHeaderInfo from '../domain-batch-actions-header-info/domain-batch-actions-header-info';
 import DomainBatchActionsProgressBar from '../domain-batch-actions-progress-bar/domain-batch-actions-progress-bar';
+import useEditBatchActionRps from '../hooks/use-edit-batch-action-rps';
 
 import { overrides, styled } from './domain-batch-actions-detail.styles';
 import { type Props } from './domain-batch-actions-detail.types';
 
 export default function DomainBatchActionDetail({
+  domain,
+  cluster,
+  workflowId,
   batchAction,
   loading = false,
 }: Props) {
   const status = batchAction?.status;
+  const [isRpsModalOpen, setIsRpsModalOpen] = useState(false);
+
+  const { editRps, isPending: isEditingRps } = useEditBatchActionRps({
+    domain,
+    cluster,
+    workflowId,
+    runId: batchAction?.runId ?? '',
+    onSuccess: () => setIsRpsModalOpen(false),
+  });
 
   return (
     <styled.Container>
@@ -41,6 +55,7 @@ export default function DomainBatchActionDetail({
         <DomainBatchActionHeaderInfo
           batchAction={batchAction}
           loading={loading}
+          onEditRps={() => setIsRpsModalOpen(true)}
         />
       </div>
       <styled.ProgressSection>
@@ -52,6 +67,13 @@ export default function DomainBatchActionDetail({
           />
         )}
       </styled.ProgressSection>
+      <DomainBatchActionsEditRpsModal
+        isOpen={isRpsModalOpen}
+        currentRps={batchAction?.rps}
+        isSubmitting={isEditingRps}
+        onClose={() => setIsRpsModalOpen(false)}
+        onSubmit={editRps}
+      />
     </styled.Container>
   );
 }

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.types.ts
@@ -1,6 +1,9 @@
 import { type BatchAction } from '../domain-batch-actions.types';
 
 export type Props = {
+  domain: string;
+  cluster: string;
+  workflowId: string;
   batchAction?: BatchAction;
   loading?: boolean;
 };

--- a/src/views/domain-batch-actions/domain-batch-actions-editable-value/__tests__/domain-batch-actions-editable-value.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-editable-value/__tests__/domain-batch-actions-editable-value.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import DomainBatchActionEditableValue from '../domain-batch-actions-editable-value';
+import { type Props } from '../domain-batch-actions-editable-value.types';
+
+describe(DomainBatchActionEditableValue.name, () => {
+  it('renders the value', () => {
+    setup({ value: 200 });
+    expect(screen.getByText('200')).toBeInTheDocument();
+  });
+
+  it('renders a dash when value is undefined', () => {
+    setup({ value: undefined });
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('does not render the Edit button when not editable', () => {
+    setup({ value: 200, editable: false });
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+  });
+
+  it('renders the Edit button when editable', () => {
+    setup({ value: 200, editable: true });
+    expect(screen.getByText('Edit')).toBeInTheDocument();
+  });
+
+  it('calls onEdit when the Edit button is clicked', async () => {
+    const { user, onEdit } = setup({ value: 200, editable: true });
+    await user.click(screen.getByText('Edit'));
+    expect(onEdit).toHaveBeenCalledTimes(1);
+  });
+});
+
+function setup(props: Partial<Props>) {
+  const onEdit = jest.fn();
+  const user = userEvent.setup();
+  render(
+    <DomainBatchActionEditableValue
+      value={undefined}
+      onEdit={onEdit}
+      {...props}
+    />
+  );
+  return { user, onEdit };
+}

--- a/src/views/domain-batch-actions/domain-batch-actions-editable-value/domain-batch-actions-editable-value.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-editable-value/domain-batch-actions-editable-value.tsx
@@ -14,6 +14,7 @@ import { type Props } from './domain-batch-actions-editable-value.types';
 export default function DomainBatchActionEditableValue({
   value,
   editable,
+  onEdit,
 }: Props) {
   return (
     <styled.Container>
@@ -24,6 +25,7 @@ export default function DomainBatchActionEditableValue({
           size="mini"
           overrides={overrides.editButton}
           startEnhancer={<MdOutlineEdit />}
+          onClick={onEdit}
         >
           Edit
         </Button>

--- a/src/views/domain-batch-actions/domain-batch-actions-editable-value/domain-batch-actions-editable-value.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-editable-value/domain-batch-actions-editable-value.types.ts
@@ -1,4 +1,5 @@
 export type Props = {
   value: number | undefined;
   editable?: boolean;
+  onEdit?: () => void;
 };

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/__tests__/domain-batch-actions-header-info.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/__tests__/domain-batch-actions-header-info.test.tsx
@@ -4,154 +4,98 @@ import { render, screen } from '@/test-utils/rtl';
 
 import { type BatchAction } from '../../domain-batch-actions.types';
 import DomainBatchActionHeaderInfo from '../domain-batch-actions-header-info';
+import { type Props } from '../domain-batch-actions-header-info.types';
 
-jest.mock('react-icons/md', () => ({
-  ...jest.requireActual('react-icons/md'),
-  MdCheckCircle: () => <div>Check Icon</div>,
-  MdOutlineCancel: () => <div>Cancel Icon</div>,
-  MdWarning: () => <div>Warning Icon</div>,
-  MdEdit: () => <div>Edit Icon</div>,
+jest.mock(
+  '../../domain-batch-actions-header-info-item/domain-batch-actions-header-info-item',
+  () =>
+    function MockItem({ title, content, loading, placeholderSize }: any) {
+      return (
+        <div>
+          <span>title: {title}</span>
+          {loading ? (
+            <span>loading: {placeholderSize}</span>
+          ) : (
+            <span>content: {content}</span>
+          )}
+        </div>
+      );
+    }
+);
+
+jest.mock('../../config/domain-batch-actions-header-info-items.config', () => ({
+  __esModule: true,
+  default: [
+    {
+      title: 'Always',
+      // Echoes the runtime context so we can assert it is threaded through.
+      render: ({ batchAction, domain, cluster, workflowId }: any) =>
+        `${batchAction.runId}/${domain}/${cluster}/${workflowId}`,
+      placeholderSize: '10px',
+    },
+    {
+      title: 'Conditional',
+      hidden: ({ batchAction }: any) => batchAction.status === 'COMPLETED',
+      render: () => 'conditional-content',
+      placeholderSize: '20px',
+    },
+  ],
 }));
 
-jest.mock('baseui/spinner', () => ({
-  Spinner: () => <div>Spinner</div>,
-}));
-
-const MOCK_RUNNING_ACTION: BatchAction = {
-  runId: '5',
-  status: 'RUNNING',
-  progress: { totalEstimate: 200, successCount: 120, errorCount: 5 },
-  actionType: 'cancel',
-  startTime: new Date('2024-03-13T08:28:50.000Z').getTime(),
-  rps: 200,
-};
+const RUNNING_ACTION: BatchAction = { runId: '5', status: 'RUNNING' };
 
 describe(DomainBatchActionHeaderInfo.name, () => {
-  afterEach(() => {
-    jest.clearAllMocks();
+  it('renders an item per config entry, threading runtime context into render', () => {
+    setup({ batchAction: RUNNING_ACTION });
+
+    expect(screen.getByText('title: Always')).toBeInTheDocument();
+    expect(
+      screen.getByText('content: 5/domain1/cluster1/workflow1')
+    ).toBeInTheDocument();
   });
 
-  it('renders all field titles', () => {
-    render(<DomainBatchActionHeaderInfo batchAction={MOCK_RUNNING_ACTION} />);
+  it('omits items whose hidden predicate returns true', () => {
+    setup({ batchAction: { runId: '5', status: 'COMPLETED' } });
 
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Action')).toBeInTheDocument();
-    expect(screen.getByText('Started')).toBeInTheDocument();
-    expect(screen.queryByText('Ended')).not.toBeInTheDocument();
-    expect(screen.getByText('Duration')).toBeInTheDocument();
-    expect(screen.getByText('RPS')).toBeInTheDocument();
+    expect(screen.getByText('title: Always')).toBeInTheDocument();
+    expect(screen.queryByText('title: Conditional')).not.toBeInTheDocument();
   });
 
-  it('shows Ended field for completed actions', () => {
-    const action: BatchAction = {
-      runId: '4',
-      status: 'COMPLETED',
-      actionType: 'cancel',
-      endTime: new Date('2024-03-13T09:00:00.000Z').getTime(),
-    };
-    render(<DomainBatchActionHeaderInfo batchAction={action} />);
+  it('keeps items whose hidden predicate returns false', () => {
+    setup({ batchAction: RUNNING_ACTION });
 
-    expect(screen.getByText('Ended')).toBeInTheDocument();
+    expect(screen.getByText('title: Conditional')).toBeInTheDocument();
+    expect(
+      screen.getByText('content: conditional-content')
+    ).toBeInTheDocument();
   });
 
-  it('renders Processing badge with spinner for running status', () => {
-    render(<DomainBatchActionHeaderInfo batchAction={MOCK_RUNNING_ACTION} />);
+  it('renders every item as a loading placeholder with no content when there is no batch action', () => {
+    setup({ batchAction: undefined });
 
-    expect(screen.getByText('Processing')).toBeInTheDocument();
-    expect(screen.getByText('Spinner')).toBeInTheDocument();
+    // hidden filter is skipped without a batch action, so all items show.
+    expect(screen.getByText('title: Always')).toBeInTheDocument();
+    expect(screen.getByText('title: Conditional')).toBeInTheDocument();
+    expect(screen.getByText('loading: 10px')).toBeInTheDocument();
+    expect(screen.queryByText(/^content:/)).not.toBeInTheDocument();
   });
 
-  it('renders Completed badge with check icon for completed status', () => {
-    const action: BatchAction = {
-      runId: '4',
-      status: 'COMPLETED',
-      actionType: 'cancel',
-    };
-    render(<DomainBatchActionHeaderInfo batchAction={action} />);
+  it('renders items as loading placeholders when loading is true', () => {
+    setup({ batchAction: RUNNING_ACTION, loading: true });
 
-    expect(screen.getByText('Completed')).toBeInTheDocument();
-    expect(screen.getByText('Check Icon')).toBeInTheDocument();
-  });
-
-  it('renders Aborted badge with cancel icon for aborted status', () => {
-    const action: BatchAction = {
-      runId: '1',
-      status: 'ABORTED',
-      actionType: 'cancel',
-    };
-    render(<DomainBatchActionHeaderInfo batchAction={action} />);
-
-    expect(screen.getByText('Aborted')).toBeInTheDocument();
-    expect(screen.getByText('Cancel Icon')).toBeInTheDocument();
-  });
-
-  it('renders Failed badge with warning icon for failed status', () => {
-    const action: BatchAction = {
-      runId: '2',
-      status: 'FAILED',
-      actionType: 'cancel',
-    };
-    render(<DomainBatchActionHeaderInfo batchAction={action} />);
-
-    expect(screen.getByText('Failed')).toBeInTheDocument();
-    expect(screen.getByText('Warning Icon')).toBeInTheDocument();
-  });
-
-  it('renders capitalized action type', () => {
-    render(<DomainBatchActionHeaderInfo batchAction={MOCK_RUNNING_ACTION} />);
-
-    expect(screen.getByText('Cancel')).toBeInTheDocument();
-  });
-
-  it('renders the rps value with an Edit button', () => {
-    render(<DomainBatchActionHeaderInfo batchAction={MOCK_RUNNING_ACTION} />);
-
-    expect(screen.getByText('200')).toBeInTheDocument();
-    expect(screen.getAllByText('Edit')).toHaveLength(1);
-  });
-
-  it('renders dashes when optional fields are missing', () => {
-    const action: BatchAction = {
-      runId: '2',
-      status: 'COMPLETED',
-      actionType: 'cancel',
-    };
-    render(<DomainBatchActionHeaderInfo batchAction={action} />);
-
-    expect(screen.getAllByText('—')).toHaveLength(4); // startTime, ended, duration, rps
-  });
-
-  it('replaces field values with skeleton placeholders when loading', () => {
-    render(
-      <DomainBatchActionHeaderInfo batchAction={MOCK_RUNNING_ACTION} loading />
-    );
-
-    // Titles still render
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Action')).toBeInTheDocument();
-    expect(screen.getByText('RPS')).toBeInTheDocument();
-
-    // Values do not
-    expect(screen.queryByText('Processing')).not.toBeInTheDocument();
-    expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
-    expect(screen.queryByText('200')).not.toBeInTheDocument();
-    expect(screen.queryByText('10')).not.toBeInTheDocument();
-  });
-
-  it('replaces field values with skeleton placeholders when loading', () => {
-    render(
-      <DomainBatchActionHeaderInfo batchAction={MOCK_RUNNING_ACTION} loading />
-    );
-
-    // Titles still render
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Action')).toBeInTheDocument();
-    expect(screen.getByText('RPS')).toBeInTheDocument();
-
-    // Values do not
-    expect(screen.queryByText('Processing')).not.toBeInTheDocument();
-    expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
-    expect(screen.queryByText('200')).not.toBeInTheDocument();
-    expect(screen.queryByText('10')).not.toBeInTheDocument();
+    expect(screen.getByText('title: Always')).toBeInTheDocument();
+    expect(screen.getByText('loading: 10px')).toBeInTheDocument();
+    expect(screen.queryByText(/^content:/)).not.toBeInTheDocument();
   });
 });
+
+function setup(props: Partial<Props> = {}) {
+  render(
+    <DomainBatchActionHeaderInfo
+      domain="domain1"
+      cluster="cluster1"
+      workflowId="workflow1"
+      {...props}
+    />
+  );
+}

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info-items.config.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info-items.config.tsx
@@ -56,10 +56,11 @@ const batchActionHeaderInfoItemsConfig = [
   },
   {
     title: 'RPS',
-    render: ({ batchAction }) => (
+    render: ({ batchAction, onEditRps }) => (
       <DomainBatchActionEditableValue
         value={batchAction.rps}
         editable={batchAction.status === 'RUNNING'}
+        onEdit={onEditRps}
       />
     ),
     placeholderSize: '80px',

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.tsx
@@ -13,6 +13,7 @@ import {
 export default function DomainBatchActionHeaderInfo({
   batchAction,
   loading = false,
+  onEditRps,
 }: Props) {
   return (
     <styled.DetailsContainer>
@@ -26,7 +27,9 @@ export default function DomainBatchActionHeaderInfo({
             key={configItem.title}
             title={configItem.title}
             loading={loading || !batchAction}
-            content={batchAction ? configItem.render({ batchAction }) : null}
+            content={
+              batchAction ? configItem.render({ batchAction, onEditRps }) : null
+            }
             placeholderSize={configItem.placeholderSize}
           />
         ))}

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.tsx
@@ -1,9 +1,9 @@
 'use client';
 import React from 'react';
 
+import batchActionHeaderInfoItemsConfig from '../config/domain-batch-actions-header-info-items.config';
 import DomainBatchActionHeaderInfoItem from '../domain-batch-actions-header-info-item/domain-batch-actions-header-info-item';
 
-import batchActionHeaderInfoItemsConfig from './domain-batch-actions-header-info-items.config';
 import { styled } from './domain-batch-actions-header-info.styles';
 import {
   type DomainBatchActionHeaderInfoItemConfig,
@@ -13,7 +13,9 @@ import {
 export default function DomainBatchActionHeaderInfo({
   batchAction,
   loading = false,
-  onEditRps,
+  domain,
+  cluster,
+  workflowId,
 }: Props) {
   return (
     <styled.DetailsContainer>
@@ -28,7 +30,14 @@ export default function DomainBatchActionHeaderInfo({
             title={configItem.title}
             loading={loading || !batchAction}
             content={
-              batchAction ? configItem.render({ batchAction, onEditRps }) : null
+              batchAction
+                ? configItem.render({
+                    batchAction,
+                    domain,
+                    cluster,
+                    workflowId,
+                  })
+                : null
             }
             placeholderSize={configItem.placeholderSize}
           />

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.types.ts
@@ -5,18 +5,24 @@ import { type BatchAction } from '@/views/domain-batch-actions/domain-batch-acti
 export type Props = {
   batchAction?: BatchAction;
   loading?: boolean;
-  onEditRps?: () => void;
+  domain: string;
+  cluster: string;
+  workflowId: string;
 };
 
 export type DomainBatchActionHeaderInfoItemProps = {
   batchAction: BatchAction;
-  onEditRps?: () => void;
+  domain: string;
+  cluster: string;
+  workflowId: string;
 };
 
 export type DomainBatchActionHeaderInfoItemConfig = {
   title: string;
   placeholderSize: string;
-  hidden?: (props: DomainBatchActionHeaderInfoItemProps) => boolean;
+  hidden?: (
+    props: Pick<DomainBatchActionHeaderInfoItemProps, 'batchAction'>
+  ) => boolean;
   render: (props: DomainBatchActionHeaderInfoItemProps) => React.ReactNode;
 };
 

--- a/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-header-info/domain-batch-actions-header-info.types.ts
@@ -5,10 +5,12 @@ import { type BatchAction } from '@/views/domain-batch-actions/domain-batch-acti
 export type Props = {
   batchAction?: BatchAction;
   loading?: boolean;
+  onEditRps?: () => void;
 };
 
 export type DomainBatchActionHeaderInfoItemProps = {
   batchAction: BatchAction;
+  onEditRps?: () => void;
 };
 
 export type DomainBatchActionHeaderInfoItemConfig = {

--- a/src/views/domain-batch-actions/domain-batch-actions-rps-value/__tests__/domain-batch-actions-rps-value.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-rps-value/__tests__/domain-batch-actions-rps-value.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type BatchAction } from '../../domain-batch-actions.types';
+import DomainBatchActionRpsValue from '../domain-batch-actions-rps-value';
+import { type Props } from '../domain-batch-actions-rps-value.types';
+
+const mockEditRps = jest.fn();
+jest.mock('../../hooks/use-edit-batch-action-rps', () => ({
+  __esModule: true,
+  default: () => ({ editRps: mockEditRps, isPending: false }),
+}));
+
+jest.mock(
+  '../../domain-batch-actions-editable-value/domain-batch-actions-editable-value',
+  () =>
+    function MockEditableValue({ value, editable, onEdit }: any) {
+      return (
+        <div>
+          <span>value: {value ?? '—'}</span>
+          {editable && <button onClick={onEdit}>Edit</button>}
+        </div>
+      );
+    }
+);
+
+jest.mock(
+  '../../domain-batch-actions-edit-rps-modal/domain-batch-actions-edit-rps-modal',
+  () =>
+    function MockEditRpsModal({ isOpen, onSubmit, onClose }: any) {
+      if (!isOpen) return null;
+      return (
+        <div>
+          <span>mock-edit-rps-modal</span>
+          <button onClick={() => onSubmit(250)}>mock-save</button>
+          <button onClick={onClose}>mock-close</button>
+        </div>
+      );
+    }
+);
+
+const RUNNING_ACTION: BatchAction = {
+  runId: '9',
+  status: 'RUNNING',
+  actionType: 'cancel',
+  rps: 100,
+};
+
+describe(DomainBatchActionRpsValue.name, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the rps value', () => {
+    setup({ batchAction: RUNNING_ACTION });
+
+    expect(screen.getByText('value: 100')).toBeInTheDocument();
+  });
+
+  it('shows the Edit button only when the action is running', () => {
+    setup({
+      batchAction: { runId: '2', status: 'COMPLETED', rps: 100 },
+    });
+
+    expect(screen.queryByText('Edit')).not.toBeInTheDocument();
+  });
+
+  it('opens the edit modal when Edit is clicked', async () => {
+    const { user } = setup({ batchAction: RUNNING_ACTION });
+
+    expect(screen.queryByText('mock-edit-rps-modal')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('Edit'));
+
+    expect(screen.getByText('mock-edit-rps-modal')).toBeInTheDocument();
+  });
+
+  it('submits the new rps through the edit hook', async () => {
+    const { user } = setup({ batchAction: RUNNING_ACTION });
+
+    await user.click(screen.getByText('Edit'));
+    await user.click(screen.getByText('mock-save'));
+
+    expect(mockEditRps).toHaveBeenCalledWith(250);
+  });
+});
+
+function setup(props: Partial<Props> = {}) {
+  const user = userEvent.setup();
+  render(
+    <DomainBatchActionRpsValue
+      domain="domain1"
+      cluster="cluster1"
+      workflowId="workflow1"
+      batchAction={RUNNING_ACTION}
+      {...props}
+    />
+  );
+  return { user };
+}

--- a/src/views/domain-batch-actions/domain-batch-actions-rps-value/domain-batch-actions-rps-value.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-rps-value/domain-batch-actions-rps-value.tsx
@@ -1,0 +1,42 @@
+'use client';
+import React, { useState } from 'react';
+
+import DomainBatchActionsEditRpsModal from '../domain-batch-actions-edit-rps-modal/domain-batch-actions-edit-rps-modal';
+import DomainBatchActionEditableValue from '../domain-batch-actions-editable-value/domain-batch-actions-editable-value';
+import useEditBatchActionRps from '../hooks/use-edit-batch-action-rps';
+
+import { type Props } from './domain-batch-actions-rps-value.types';
+
+export default function DomainBatchActionRpsValue({
+  domain,
+  cluster,
+  workflowId,
+  batchAction,
+}: Props) {
+  const [isRpsModalOpen, setIsRpsModalOpen] = useState(false);
+
+  const { editRps, isPending: isEditingRps } = useEditBatchActionRps({
+    domain,
+    cluster,
+    workflowId,
+    runId: batchAction.runId,
+    onSuccess: () => setIsRpsModalOpen(false),
+  });
+
+  return (
+    <>
+      <DomainBatchActionEditableValue
+        value={batchAction.rps}
+        editable={batchAction.status === 'RUNNING'}
+        onEdit={() => setIsRpsModalOpen(true)}
+      />
+      <DomainBatchActionsEditRpsModal
+        isOpen={isRpsModalOpen}
+        currentRps={batchAction.rps}
+        isSubmitting={isEditingRps}
+        onClose={() => setIsRpsModalOpen(false)}
+        onSubmit={editRps}
+      />
+    </>
+  );
+}

--- a/src/views/domain-batch-actions/domain-batch-actions-rps-value/domain-batch-actions-rps-value.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-rps-value/domain-batch-actions-rps-value.types.ts
@@ -1,0 +1,8 @@
+import { type BatchAction } from '../domain-batch-actions.types';
+
+export type Props = {
+  domain: string;
+  cluster: string;
+  workflowId: string;
+  batchAction: BatchAction;
+};

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -237,6 +237,9 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
                   </Banner>
                 )}
                 <DomainBatchActionDetail
+                  domain={props.domain}
+                  cluster={props.cluster}
+                  workflowId={selectedWorkflowId ?? ''}
                   batchAction={batchActionDetail}
                   loading={isLoadingBatchActionDetail}
                 />

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -211,6 +211,7 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
               ]}
             />
           ) : (
+            selectedWorkflowId &&
             (isLoadingBatchActionDetail || batchActionDetail) && (
               <>
                 {batchActionDetailError && batchActionDetail && (
@@ -239,7 +240,7 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
                 <DomainBatchActionDetail
                   domain={props.domain}
                   cluster={props.cluster}
-                  workflowId={selectedWorkflowId ?? ''}
+                  workflowId={selectedWorkflowId}
                   batchAction={batchActionDetail}
                   loading={isLoadingBatchActionDetail}
                 />


### PR DESCRIPTION
**Stacked PR 3 of 3** — connects the previously inert RPS "Edit" button (shown for RUNNING actions) to the Edit RPS modal, and submits an RPS-tuning signal to the batcher workflow.

> Review/merge after #1358 — this PR is based on `batch-ui-rps-2-modal-hook`.

## Changes
- Add a self-contained `DomainBatchActionRpsValue` component that owns the Edit RPS modal state and the `useEditBatchActionRps` tune-signal mutation. Clicking **Edit** (shown for RUNNING actions) opens the modal and submits the new RPS.
- The header-info items config owns the RPS action via this component (config-owns-the-action, per #1320); `DomainBatchActionHeaderInfo` stays a generic iterator and no longer threads an `onEditRps` callback. `domain`/`cluster`/`workflowId` flow through the config render context.
- Move the header-info items config to `config/` and rename `.tsx` → `.ts` (JSX → `createElement`).
- `runId` is read directly from the loaded `batchAction` (no `?? ''` fallback), since the RPS component only renders once details are loaded.

## Stack
1. Foundation (#1357)
2. Edit RPS modal + tune-signal hook (#1358)
3. **This PR** — wiring
