### PR TITLE
feat(batch-actions): tag batcher workflows with CustomDomain search attribute

### DIFF
--- a/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
@@ -41,6 +41,7 @@ describe(useStartBatchAction.name, () => {
       ],
       workerSDKLanguage: 'GO',
       executionStartToCloseTimeoutSeconds: 20 * 365 * 24 * 60 * 60,
+      searchAttributes: { CustomDomain: 'cadence-samples' },
     });
     expect(result.current.data).toEqual({
       workflowId: 'wf-1',

--- a/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
+++ b/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
@@ -4,6 +4,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import {
   BATCH_ACTION_BATCHER_DOMAIN,
+  BATCH_ACTION_DOMAIN_SEARCH_ATTRIBUTE,
   BATCH_ACTION_WORKFLOW_TYPE,
 } from '@/route-handlers/list-batch-actions/list-batch-actions.constants';
 import request from '@/utils/request';
@@ -46,6 +47,12 @@ export default function useStartBatchAction({
             workerSDKLanguage: 'GO',
             executionStartToCloseTimeoutSeconds:
               BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS,
+            // Tag the batcher workflow with the target domain so batch actions
+            // can be searched/filtered by the domain they operate on. Uses the
+            // same search attribute the list query filters on.
+            searchAttributes: {
+              [BATCH_ACTION_DOMAIN_SEARCH_ATTRIBUTE]: input.domain,
+            },
           }),
         }
       ).then((res): Promise<StartBatchActionResponse> => res.json());


### PR DESCRIPTION
## What

When starting a batch action, set the `CustomDomain` search attribute to the target domain on the batcher workflow.

## Why

The batch actions list query already filters batcher workflows by the `CustomDomain` search attribute (`WorkflowType = "cadence-sys-batch-workflow-v2" AND CustomDomain = "<domain>"`). Until now nothing set that attribute when a batch action was started, so batcher workflows were not tagged with the domain they operate on. This change writes the attribute at start time so the list can correctly scope batch actions to their domain.