### PR TITLE
fix(domain-batch-actions): reset all batch draft query params on discard

### DIFF
--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -12,6 +12,7 @@ import DomainBatchActions from '../domain-batch-actions';
 import { type Props as DetailProps } from '../domain-batch-actions-detail/domain-batch-actions-detail.types';
 import { type Props as NewActionDetailProps } from '../domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.types';
 import { type Props as SidebarProps } from '../domain-batch-actions-sidebar/domain-batch-actions-sidebar.types';
+import { BATCH_DRAFT_RESET_PARAMS } from '../domain-batch-actions.constants';
 import { type BatchAction } from '../domain-batch-actions.types';
 
 const mockSetQueryParams = jest.fn();
@@ -122,7 +123,7 @@ describe(DomainBatchActions.name, () => {
     expect(mockSetQueryParams).toHaveBeenCalledWith({ batchActionId: '4' });
   });
 
-  it('sets batchActionId to draft and prefills the query when "New batch action" is clicked', async () => {
+  it('resets all batch draft params and prefills the query when "New batch action" is clicked', async () => {
     const user = userEvent.setup();
 
     setup();
@@ -130,12 +131,13 @@ describe(DomainBatchActions.name, () => {
     await user.click(await screen.findByText('mock-new-batch-action'));
 
     expect(mockSetQueryParams).toHaveBeenCalledWith({
+      ...BATCH_DRAFT_RESET_PARAMS,
       batchActionId: 'draft',
       batchQuery: 'CloseTime = missing',
     });
   });
 
-  it('clears batchActionId and batchQuery on discard', async () => {
+  it('clears all batch draft params on discard', async () => {
     mockUsePageQueryParams.mockReturnValue([
       {
         ...mockDomainPageQueryParamsValues,
@@ -151,10 +153,7 @@ describe(DomainBatchActions.name, () => {
 
     await user.click(await screen.findByText('Discard batch action'));
 
-    expect(mockSetQueryParams).toHaveBeenCalledWith({
-      batchActionId: undefined,
-      batchQuery: '',
-    });
+    expect(mockSetQueryParams).toHaveBeenCalledWith(BATCH_DRAFT_RESET_PARAMS);
   });
 
   it('opens the draft when batchActionId is "draft" (no batchQuery)', async () => {

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -1,4 +1,17 @@
+import { type PageQueryParamSetterValues } from '@/hooks/use-page-query-params/use-page-query-params.types';
+import { domainBatchActionsQueryParamsConfig } from '@/views/domain-page/config/domain-page-query-params.config';
+
 export const DRAFT_ACTION_ID = 'draft';
+
+// Derived from the batch query params config
+// so a new batch param is reset automatically. Discarding or starting a new
+// draft applies this, preventing stale "Select"/"Query" mode state from
+// leaking across drafts.
+export const BATCH_DRAFT_RESET_PARAMS = Object.fromEntries(
+  domainBatchActionsQueryParamsConfig.map((param) => [param.key, undefined])
+) as Partial<
+  PageQueryParamSetterValues<typeof domainBatchActionsQueryParamsConfig>
+>;
 
 export const BATCH_ACTION_RPS_DEFAULT = 100;
 export const BATCH_ACTIONS_PAGE_SIZE = 10;

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -20,6 +20,7 @@ import {
   BATCH_ACTIONS_PAGE_SIZE,
   BATCH_ACTION_DEFAULT_QUERY,
   BATCH_ACTION_DETAIL_REFETCH_INTERVAL,
+  BATCH_DRAFT_RESET_PARAMS,
   DRAFT_ACTION_ID,
 } from './domain-batch-actions.constants';
 import { styled } from './domain-batch-actions.styles';
@@ -99,6 +100,7 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
   const handleCreateNew = () => {
     setIsDraftOpen(true);
     setQueryParams({
+      ...BATCH_DRAFT_RESET_PARAMS,
       batchActionId: DRAFT_ACTION_ID,
       batchQuery: BATCH_ACTION_DEFAULT_QUERY,
     });
@@ -114,7 +116,7 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
 
   const handleDiscard = () => {
     setIsDraftOpen(false);
-    setQueryParams({ batchActionId: undefined, batchQuery: '' });
+    setQueryParams(BATCH_DRAFT_RESET_PARAMS);
   };
 
   if (batchActions.length === 0 && !isDraftOpen) {

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -14,6 +14,64 @@ import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-work
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 import { type WorkflowsHeaderInputType } from '@/views/shared/workflows-header/workflows-header.types';
 
+// URL params scoped to the batch action draft. Defined here (rather than in the
+// batch-actions feature) and spread into domainPageQueryParamsConfig below so
+// every page key lives in one file and collisions stay easy to spot. Exported
+// so the batch feature can derive BATCH_DRAFT_RESET_PARAMS from this single
+// definition: adding a batch param here wires it into both the URL parsing and
+// the draft reset automatically.
+//
+// They use separate `batch-*` URL keys from the workflows tab so the two tabs
+// do not overwrite each other's search/query/filter state.
+export const domainBatchActionsQueryParamsConfig: [
+  PageQueryParam<'batchInputType', WorkflowsHeaderInputType>,
+  PageQueryParam<'batchQuery', string>,
+  PageQueryParam<'batchSearch', string>,
+  PageQueryParamMultiValue<'batchStatuses', Array<WorkflowStatus> | undefined>,
+  PageQueryParam<'batchTimeRangeStart', DateFilterValue | undefined>,
+  PageQueryParam<'batchTimeRangeEnd', DateFilterValue>,
+  PageQueryParam<'batchActionId', string | undefined>,
+] = [
+  {
+    key: 'batchInputType',
+    queryParamKey: 'batch-input',
+    defaultValue: 'query',
+    parseValue: (value: string) => (value === 'search' ? 'search' : 'query'),
+  },
+  {
+    key: 'batchQuery',
+    queryParamKey: 'batch-query',
+    defaultValue: '',
+  },
+  {
+    key: 'batchSearch',
+    queryParamKey: 'batch-search',
+    defaultValue: '',
+  },
+  {
+    key: 'batchStatuses',
+    queryParamKey: 'batch-status',
+    isMultiValue: true,
+    parseValue: (value: Array<string>) =>
+      value.every(isWorkflowStatus) ? value : undefined,
+  },
+  {
+    key: 'batchTimeRangeStart',
+    queryParamKey: 'batch-start',
+    parseValue: parseDateFilterValue,
+  },
+  {
+    key: 'batchTimeRangeEnd',
+    queryParamKey: 'batch-end',
+    defaultValue: 'now',
+    parseValue: (v) => parseDateFilterValue(v) ?? 'now',
+  },
+  {
+    key: 'batchActionId',
+    queryParamKey: 'bid',
+  },
+] as const;
+
 const domainPageQueryParamsConfig: [
   PageQueryParam<'inputType', WorkflowsHeaderInputType>,
   // Search input
@@ -25,17 +83,8 @@ const domainPageQueryParamsConfig: [
   PageQueryParam<'sortOrder', SortOrder>,
   // Query input
   PageQueryParam<'query', string>,
-  // Batch actions query input (uses separate URL params so the workflows tab
-  // and the batch action draft do not overwrite each other's state).
-  PageQueryParam<'batchInputType', WorkflowsHeaderInputType>,
-  PageQueryParam<'batchQuery', string>,
-  // Batch actions "Select" mode search/filter inputs (separate from the
-  // workflows tab's search params, mirroring the batchQuery separation above).
-  PageQueryParam<'batchSearch', string>,
-  PageQueryParamMultiValue<'batchStatuses', Array<WorkflowStatus> | undefined>,
-  PageQueryParam<'batchTimeRangeStart', DateFilterValue | undefined>,
-  PageQueryParam<'batchTimeRangeEnd', DateFilterValue>,
-  PageQueryParam<'batchActionId', string | undefined>,
+  // Batch actions query params (Query + Select mode), defined and exported above.
+  ...typeof domainBatchActionsQueryParamsConfig,
   // Basic Visibility inputs
   PageQueryParam<'workflowId', string>,
   PageQueryParam<'workflowType', string>,
@@ -104,44 +153,7 @@ const domainPageQueryParamsConfig: [
     key: 'query',
     defaultValue: '',
   },
-  {
-    key: 'batchInputType',
-    queryParamKey: 'batch-input',
-    defaultValue: 'query',
-    parseValue: (value: string) => (value === 'search' ? 'search' : 'query'),
-  },
-  {
-    key: 'batchQuery',
-    queryParamKey: 'batch-query',
-    defaultValue: '',
-  },
-  {
-    key: 'batchSearch',
-    queryParamKey: 'batch-search',
-    defaultValue: '',
-  },
-  {
-    key: 'batchStatuses',
-    queryParamKey: 'batch-status',
-    isMultiValue: true,
-    parseValue: (value: Array<string>) =>
-      value.every(isWorkflowStatus) ? value : undefined,
-  },
-  {
-    key: 'batchTimeRangeStart',
-    queryParamKey: 'batch-start',
-    parseValue: parseDateFilterValue,
-  },
-  {
-    key: 'batchTimeRangeEnd',
-    queryParamKey: 'batch-end',
-    defaultValue: 'now',
-    parseValue: (v) => parseDateFilterValue(v) ?? 'now',
-  },
-  {
-    key: 'batchActionId',
-    queryParamKey: 'bid',
-  },
+  ...domainBatchActionsQueryParamsConfig,
   {
     key: 'workflowId',
     defaultValue: '',


### PR DESCRIPTION
## Summary

Discarding a batch action draft (or starting a new one) only cleared `batchActionId` and `batchQuery`. After #1339 made the Select-mode inputs user-editable, the rest of the batch params — `batchSearch`, `batchStatuses`, `batchTimeRangeStart`, `batchTimeRangeEnd`, and `batchInputType` — were left stale in the URL on discard. A subsequent "Create new" draft would then inherit that leftover filter state.

This resets the full set of batch draft params together, on both discard and new-draft.

## Changes

- **New `config/domain-batch-actions-query-params.config.ts`** — the batch query param definitions now live in one place as `domainBatchActionsQueryParamsConfig`.
- **`domain-page-query-params.config.ts`** — spreads the batch config in (type + value) instead of inlining the batch params, so there's a single definition.
- **`domain-batch-actions.constants.ts`** — `BATCH_DRAFT_RESET_PARAMS` is derived from that config (each key → `undefined`), so adding a new batch param wires it into both URL parsing and the reset automatically.
- **`domain-batch-actions.tsx`** — `handleDiscard` and `handleCreateNew` apply the full reset.

## Test plan

- `npm run test:unit:browser` — `domain-batch-actions` (18 suites), `use-page-query-params`, `domain-workflows-filters` all pass; added/updated assertions for the discard + new-draft reset.
- `npm run typecheck` — no new errors.
- `npm run lint` — clean on changed files.