### PR TITLE
fix: Order Workflow History details row fields based on group details order

### DIFF
--- a/src/views/workflow-history-v2/helpers/__tests__/generate-history-group-details.test.ts
+++ b/src/views/workflow-history-v2/helpers/__tests__/generate-history-group-details.test.ts
@@ -297,6 +297,53 @@ describe(generateHistoryGroupDetails.name, () => {
     );
   });
 
+  it('should order summary details entries by summaryFields order, not event details order', () => {
+    mockedGenerateHistoryEventDetails.mockReturnValue([
+      {
+        key: 'activityId',
+        path: 'activityId',
+        value: '0',
+        isGroup: false,
+        renderConfig: null,
+      },
+      {
+        key: 'activityType',
+        path: 'activityType',
+        value: 'TestActivity',
+        isGroup: false,
+        renderConfig: null,
+      },
+      {
+        key: 'input',
+        path: 'input',
+        value: 'test input',
+        isGroup: false,
+        renderConfig: null,
+      },
+    ]);
+
+    const eventGroup: HistoryEventsGroup = {
+      ...mockActivityEventGroup,
+      events: [scheduleActivityTaskEvent],
+      eventsMetadata: [
+        {
+          label: 'Scheduled',
+          status: 'COMPLETED',
+          timeMs: 1725747370599,
+          timeLabel: 'Scheduled at 07 Sep, 22:16:10 UTC',
+          summaryFields: ['input', 'activityId'],
+        },
+      ],
+    };
+
+    const result = generateHistoryGroupDetails(eventGroup);
+
+    const summaryPaths = result.summaryDetailsEntries[0][1].eventDetails.map(
+      (detail) => detail.path
+    );
+    expect(summaryPaths).toEqual(['input', 'activityId']);
+  });
+
   it('should not generate summary details entries when summaryFields do not match any event details', () => {
     mockedGenerateHistoryEventDetails.mockReturnValue([
       {

--- a/src/views/workflow-history-v2/helpers/generate-history-group-details.ts
+++ b/src/views/workflow-history-v2/helpers/generate-history-group-details.ts
@@ -1,3 +1,5 @@
+import sortBy from 'lodash/sortBy';
+
 import formatPendingWorkflowHistoryEvent from '@/utils/data-formatters/format-pending-workflow-history-event';
 import formatWorkflowHistoryEvent from '@/utils/data-formatters/format-workflow-history-event';
 import isPendingHistoryEvent from '@/views/workflow-history/workflow-history-event-details/helpers/is-pending-history-event';
@@ -40,8 +42,11 @@ export default function generateHistoryGroupDetails(
       } satisfies EventDetailsTabContent,
     ]);
 
-    const eventSummaryDetails = eventDetails.filter((detail) =>
-      eventMetadata.summaryFields?.includes(detail.path)
+    const eventSummaryDetails = sortBy(
+      eventDetails.filter((detail) =>
+        eventMetadata.summaryFields?.includes(detail.path)
+      ),
+      (detail) => eventMetadata.summaryFields?.indexOf(detail.path)
     );
 
     if (eventSummaryDetails.length > 0) {

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-activity-group-from-events.test.ts
@@ -407,8 +407,8 @@ describe('getActivityGroupFromEvents', () => {
 
     // The failed event should have summaryFields
     expect(group.eventsMetadata[0].summaryFields).toEqual([
-      'details',
       'reason',
+      'details',
     ]);
   });
 

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -240,7 +240,7 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     const failedEventMetadata = group.eventsMetadata.find(
       (metadata) => metadata.status === 'FAILED'
     );
-    expect(failedEventMetadata?.negativeFields).toEqual(['details', 'reason']);
+    expect(failedEventMetadata?.negativeFields).toEqual(['reason', 'details']);
 
     // Other events should not have negativeFields
     const otherEventsMetadata = group.eventsMetadata.filter(
@@ -264,8 +264,8 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
       (metadata) => metadata.status === 'FAILED' // timeout events have FAILED status
     );
     expect(timedOutEventMetadata?.negativeFields).toEqual([
-      'details',
       'reason',
+      'details',
     ]);
 
     // Other events should not have negativeFields
@@ -314,6 +314,6 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     const failedEventMetadata = group.eventsMetadata.find(
       (metadata) => metadata.status === 'FAILED'
     );
-    expect(failedEventMetadata?.summaryFields).toEqual(['details', 'reason']);
+    expect(failedEventMetadata?.summaryFields).toEqual(['reason', 'details']);
   });
 });

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-single-event-group-from-events.test.ts
@@ -138,7 +138,7 @@ describe('getSingleEventGroupFromEvents', () => {
     const eventMetadata = group.eventsMetadata[0];
 
     expect(eventMetadata.status).toBe('FAILED');
-    expect(eventMetadata.negativeFields).toEqual(['details', 'reason']);
+    expect(eventMetadata.negativeFields).toEqual(['reason', 'details']);
   });
 
   it('should include negativeFields for terminated workflow execution events', () => {
@@ -148,7 +148,7 @@ describe('getSingleEventGroupFromEvents', () => {
     const eventMetadata = group.eventsMetadata[0];
 
     expect(eventMetadata.status).toBe('FAILED');
-    expect(eventMetadata.negativeFields).toEqual(['details', 'reason']);
+    expect(eventMetadata.negativeFields).toEqual(['reason', 'details']);
   });
 
   it('should include negativeFields for continued as new workflow execution events', () => {
@@ -159,8 +159,8 @@ describe('getSingleEventGroupFromEvents', () => {
 
     expect(eventMetadata.status).toBe('COMPLETED');
     expect(eventMetadata.negativeFields).toEqual([
-      'failureDetails',
       'failureReason',
+      'failureDetails',
     ]);
   });
 
@@ -191,7 +191,7 @@ describe('getSingleEventGroupFromEvents', () => {
     const eventMetadata = group.eventsMetadata[0];
 
     expect(eventMetadata.status).toBe('FAILED');
-    expect(eventMetadata.summaryFields).toEqual(['details', 'reason']);
+    expect(eventMetadata.summaryFields).toEqual(['reason', 'details']);
   });
 
   it('should include summaryFields for terminated workflow execution events', () => {
@@ -201,7 +201,7 @@ describe('getSingleEventGroupFromEvents', () => {
     const eventMetadata = group.eventsMetadata[0];
 
     expect(eventMetadata.status).toBe('FAILED');
-    expect(eventMetadata.summaryFields).toEqual(['details', 'reason']);
+    expect(eventMetadata.summaryFields).toEqual(['reason', 'details']);
   });
 
   it('should include summaryFields for continued as new workflow execution events', () => {
@@ -212,8 +212,8 @@ describe('getSingleEventGroupFromEvents', () => {
 
     expect(eventMetadata.status).toBe('COMPLETED');
     expect(eventMetadata.summaryFields).toEqual([
-      'failureDetails',
       'failureReason',
+      'failureDetails',
       'newExecutionRunId',
     ]);
   });

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-activity-group-from-events.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-activity-group-from-events.ts
@@ -173,7 +173,7 @@ export default function getActivityGroupFromEvents(
         'attempt',
       ],
       activityTaskCompletedEventAttributes: ['result'],
-      activityTaskFailedEventAttributes: ['details', 'reason'],
+      activityTaskFailedEventAttributes: ['reason', 'details'],
     };
 
   const shouldShowPendingEvent = Boolean(

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -77,8 +77,8 @@ export default function getChildWorkflowExecutionGroupFromEvents(
 
   const eventToNegativeFields: HistoryGroupEventToNegativeFieldsMap<ChildWorkflowExecutionHistoryGroup> =
     {
-      childWorkflowExecutionFailedEventAttributes: ['details', 'reason'],
-      childWorkflowExecutionTimedOutEventAttributes: ['details', 'reason'],
+      childWorkflowExecutionFailedEventAttributes: ['reason', 'details'],
+      childWorkflowExecutionTimedOutEventAttributes: ['reason', 'details'],
     };
 
   const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<ChildWorkflowExecutionHistoryGroup> =
@@ -86,7 +86,7 @@ export default function getChildWorkflowExecutionGroupFromEvents(
       startChildWorkflowExecutionInitiatedEventAttributes: ['input'],
       childWorkflowExecutionStartedEventAttributes: ['workflowExecution'],
       childWorkflowExecutionCompletedEventAttributes: ['result'],
-      childWorkflowExecutionFailedEventAttributes: ['details', 'reason'],
+      childWorkflowExecutionFailedEventAttributes: ['reason', 'details'],
     };
 
   return {

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-single-event-group-from-events.ts
@@ -82,11 +82,11 @@ export default function getSingleEventGroupFromEvents(
 
   const eventToNegativeFields: HistoryGroupEventToNegativeFieldsMap<SingleEventHistoryGroup> =
     {
-      workflowExecutionFailedEventAttributes: ['details', 'reason'],
-      workflowExecutionTerminatedEventAttributes: ['details', 'reason'],
+      workflowExecutionFailedEventAttributes: ['reason', 'details'],
+      workflowExecutionTerminatedEventAttributes: ['reason', 'details'],
       workflowExecutionContinuedAsNewEventAttributes: [
-        'failureDetails',
         'failureReason',
+        'failureDetails',
       ],
     };
 
@@ -98,11 +98,11 @@ export default function getSingleEventGroupFromEvents(
         'attempt',
       ],
       workflowExecutionCompletedEventAttributes: ['result'],
-      workflowExecutionFailedEventAttributes: ['details', 'reason'],
-      workflowExecutionTerminatedEventAttributes: ['details', 'reason'],
+      workflowExecutionFailedEventAttributes: ['reason', 'details'],
+      workflowExecutionTerminatedEventAttributes: ['reason', 'details'],
       workflowExecutionContinuedAsNewEventAttributes: [
-        'failureDetails',
         'failureReason',
+        'failureDetails',
         'newExecutionRunId',
       ],
     };


### PR DESCRIPTION
## Summary
### Problem
When rendering the summarized details for a workflow history event/group, the order is determined by the order of object fields in [the formatWorkflowHistoryEvent helpers](https://github.com/cadence-workflow/cadence-web/tree/master/src/utils/data-formatters/format-workflow-history-event). This prevents fields in certain events from being ordered correctly (example: `reason` before `details` for an activity failure).

### Solution
- Re-sort summary details based on order mentioned in the `getHistoryEventsGroup` helper's `summaryDetails` array
- Fix reordering for some events accordingly

## Test plan
Updated unit tests + ran locally.

### Before
<img width="1664" height="548" alt="Screenshot 2026-06-18 at 11 37 38" src="https://github.com/user-attachments/assets/cbd25111-451d-45e5-a0fa-d30f81a0a825" />

The layout order of the failure reason and the failure details is flipped between the Activity Failed and Workflow Failed events.

### After
<img width="1636" height="573" alt="Screenshot 2026-06-18 at 11 40 16" src="https://github.com/user-attachments/assets/f22588be-8a46-4eea-957e-b6992386ecb9" />
