### PR TITLE
feat: show Cause in child workflow initiation failure event summary

### DIFF
--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -316,4 +316,18 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     );
     expect(failedEventMetadata?.summaryFields).toEqual(['reason', 'details']);
   });
+
+  it('should include summaryFields with cause for initiation failed child workflow event', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      initiateFailureChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+
+    // The initiation failed event should have summaryFields with cause
+    const initiationFailedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Initiation failed'
+    );
+    expect(initiationFailedEventMetadata?.summaryFields).toEqual(['cause']);
+  });
 });

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -277,6 +277,20 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     });
   });
 
+  it('should include negativeFields with cause for initiation failed child workflow event', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      initiateFailureChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+
+    // The initiation failed event should have negativeFields with cause
+    const initiationFailedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Initiation failed'
+    );
+    expect(initiationFailedEventMetadata?.negativeFields).toEqual(['cause']);
+  });
+
   it('should include summaryFields for child workflow events', () => {
     const events: ChildWorkflowExecutionHistoryEvent[] = [
       initiateChildWorkflowEvent,

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -84,6 +84,7 @@ export default function getChildWorkflowExecutionGroupFromEvents(
   const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<ChildWorkflowExecutionHistoryGroup> =
     {
       startChildWorkflowExecutionInitiatedEventAttributes: ['input'],
+      startChildWorkflowExecutionFailedEventAttributes: ['cause'],
       childWorkflowExecutionStartedEventAttributes: ['workflowExecution'],
       childWorkflowExecutionCompletedEventAttributes: ['result'],
       childWorkflowExecutionFailedEventAttributes: ['reason', 'details'],

--- a/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history-v2/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -77,6 +77,7 @@ export default function getChildWorkflowExecutionGroupFromEvents(
 
   const eventToNegativeFields: HistoryGroupEventToNegativeFieldsMap<ChildWorkflowExecutionHistoryGroup> =
     {
+      startChildWorkflowExecutionFailedEventAttributes: ['cause'],
       childWorkflowExecutionFailedEventAttributes: ['reason', 'details'],
       childWorkflowExecutionTimedOutEventAttributes: ['reason', 'details'],
     };

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -317,4 +317,18 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     );
     expect(failedEventMetadata?.summaryFields).toEqual(['details', 'reason']);
   });
+
+  it('should include summaryFields with cause for initiation failed child workflow event', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      initiateFailureChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+
+    // The initiation failed event should have summaryFields with cause
+    const initiationFailedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Initiation failed'
+    );
+    expect(initiationFailedEventMetadata?.summaryFields).toEqual(['cause']);
+  });
 });

--- a/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/__tests__/get-child-workflow-execution-group-from-events.test.ts
@@ -278,6 +278,20 @@ describe('getChildWorkflowExecutionGroupFromEvents', () => {
     });
   });
 
+  it('should include negativeFields with cause for initiation failed child workflow event', () => {
+    const events: ChildWorkflowExecutionHistoryEvent[] = [
+      initiateChildWorkflowEvent,
+      initiateFailureChildWorkflowEvent,
+    ];
+    const group = getChildWorkflowExecutionGroupFromEvents(events);
+
+    // The initiation failed event should have negativeFields with cause
+    const initiationFailedEventMetadata = group.eventsMetadata.find(
+      (metadata) => metadata.label === 'Initiation failed'
+    );
+    expect(initiationFailedEventMetadata?.negativeFields).toEqual(['cause']);
+  });
+
   it('should include summaryFields for child workflow events', () => {
     const events: ChildWorkflowExecutionHistoryEvent[] = [
       initiateChildWorkflowEvent,

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -84,6 +84,7 @@ export default function getChildWorkflowExecutionGroupFromEvents(
   const eventToSummaryFields: HistoryGroupEventToSummaryFieldsMap<ChildWorkflowExecutionHistoryGroup> =
     {
       startChildWorkflowExecutionInitiatedEventAttributes: ['input'],
+      startChildWorkflowExecutionFailedEventAttributes: ['cause'],
       childWorkflowExecutionStartedEventAttributes: ['workflowExecution'],
       childWorkflowExecutionCompletedEventAttributes: ['result'],
       childWorkflowExecutionFailedEventAttributes: ['details', 'reason'],

--- a/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
+++ b/src/views/workflow-history/helpers/get-history-group-from-events/get-child-workflow-execution-group-from-events.ts
@@ -77,6 +77,7 @@ export default function getChildWorkflowExecutionGroupFromEvents(
 
   const eventToNegativeFields: HistoryGroupEventToNegativeFieldsMap<ChildWorkflowExecutionHistoryGroup> =
     {
+      startChildWorkflowExecutionFailedEventAttributes: ['cause'],
       childWorkflowExecutionFailedEventAttributes: ['details', 'reason'],
       childWorkflowExecutionTimedOutEventAttributes: ['details', 'reason'],
     };


### PR DESCRIPTION
## What changed

Child workflow **initiation failures** (`StartChildWorkflowExecutionFailed` events) previously showed no details in the event summary, because the `eventToSummaryFields` map had no entry for that event type.

This adds `cause` to the summary fields for `startChildWorkflowExecutionFailedEventAttributes`, so the initiation failure reason (e.g. `CHILD_WORKFLOW_EXECUTION_FAILED_CAUSE_WORKFLOW_ALREADY_RUNNING`) is surfaced directly in the event summary.

The change is applied to both the v1 (`workflow-history`) and v2 (`workflow-history-v2`) history views to keep them in sync.

<img width="1454" height="310" alt="image" src="https://github.com/user-attachments/assets/10359fb9-06ae-42df-b18e-914374be0658" />
<img width="1052" height="279" alt="image" src="https://github.com/user-attachments/assets/1d972137-004a-4bfd-b201-0d1ae44b99ca" />

