### PR TITLE
feat(schedule-details): render schedule policies detail section

### DIFF
--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -53,6 +53,74 @@ describe(ScheduleDetails.name, () => {
     expect(describeResolver).toHaveBeenCalledTimes(1);
   });
 
+  it('renders schedule specifications section rows', async () => {
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(
+          getMockRunningDescribeScheduleResponse({
+            info: {
+              createTime: { seconds: '1745490629', nanos: 850000000 },
+              nextRunTime: { seconds: '1745490629', nanos: 850000000 },
+              lastRunTime: { seconds: '1745490629', nanos: 850000000 },
+              totalRuns: '32',
+              lastUpdateTime: null,
+              ongoingBackfills: [],
+              missedRuns: '0',
+              skippedRuns: '0',
+            },
+            spec: {
+              cronExpression: '0 * * * *',
+              startTime: { seconds: '1735689600', nanos: 0 },
+              endTime: null,
+              jitter: { seconds: '300', nanos: 0 },
+            },
+          })
+        ),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Schedule specifications' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('rowheader', { name: 'Schedule Id' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('my-schedule')).toBeInTheDocument();
+    expect(
+      screen.getByRole('rowheader', { name: 'Cron execution' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Every hour (0 * * * *)')).toBeInTheDocument();
+    expect(screen.getByText('5m')).toBeInTheDocument();
+  });
+
+  it('hides optional specification rows when schedule fields are missing', async () => {
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(
+          getMockRunningDescribeScheduleResponse({
+            spec: {
+              cronExpression: '*/10 * * * *',
+              startTime: null,
+              endTime: null,
+              jitter: null,
+            },
+          })
+        ),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Schedule specifications' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Start time' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Creation time' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Jitter duration' })
+    ).not.toBeInTheDocument();
+  });
+
   it('hides conditional policy rows when overlap policy does not apply', async () => {
     setup({
       describeResolver: () =>

--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { HttpResponse, type HttpResponseResolver } from 'msw';
+import { HttpResponse, delay, type HttpResponseResolver } from 'msw';
 
 import {
   act,
@@ -23,29 +23,70 @@ jest.mock('next/navigation', () => ({
 }));
 
 describe(ScheduleDetails.name, () => {
-  it('shows loading first then renders details placeholder after describe succeeds', async () => {
-    // Success resolver for describe request
-    const { promise: resolveResponsePromise, resolve: resolveResponse } =
-      getDeferredPromise();
-
+  it('shows loading first then renders schedule policies section', async () => {
     const describeResolver = jest.fn(async () => {
-      await resolveResponsePromise;
-      return HttpResponse.json(getMockRunningDescribeScheduleResponse());
+      await delay(100);
+      return HttpResponse.json(
+        getMockRunningDescribeScheduleResponse({
+          policies: {
+            overlapPolicy: 'SCHEDULE_OVERLAP_POLICY_BUFFER',
+            catchUpPolicy: 'SCHEDULE_CATCH_UP_POLICY_ONE',
+            catchUpWindow: { seconds: '3600', nanos: 0 },
+            pauseOnFailure: true,
+            bufferLimit: 10,
+            concurrencyLimit: 2,
+          },
+        })
+      );
     });
 
     setup({ describeResolver });
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
-    // Resolve the promise to simulate the describe request succeeding
-    resolveResponse();
 
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
-    expect(screen.getByText('Details — coming soon')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Schedule policies' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Buffer')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
     expect(describeResolver).toHaveBeenCalledTimes(1);
   });
 
+  it('hides conditional policy rows when overlap policy does not apply', async () => {
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(
+          getMockRunningDescribeScheduleResponse({
+            policies: {
+              overlapPolicy: 'SCHEDULE_OVERLAP_POLICY_INVALID',
+              catchUpPolicy: 'SCHEDULE_CATCH_UP_POLICY_INVALID',
+              catchUpWindow: null,
+              pauseOnFailure: false,
+              bufferLimit: 0,
+              concurrencyLimit: 0,
+            },
+          })
+        ),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Schedule policies' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('rowheader', { name: 'Overlap policy' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Default (SkipNew)')).toBeInTheDocument();
+    expect(screen.getByText('Default (Skip)')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Buffer limit' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Concurrency limit' })
+    ).not.toBeInTheDocument();
+  });
+
   it('throws into error boundary when describe fails', async () => {
-    // Error resolver for describe request
     const describeResolver = jest.fn(() =>
       HttpResponse.json(
         { message: 'Failed to describe schedule' },
@@ -90,16 +131,4 @@ function setup({
       ],
     }
   );
-}
-
-function getDeferredPromise(): {
-  promise: Promise<void>;
-  resolve: () => void;
-} {
-  let resolve = () => {};
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-
-  return { promise, resolve };
 }

--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -6,6 +6,7 @@ import {
   act,
   render,
   screen,
+  userEvent,
   waitForElementToBeRemoved,
 } from '@/test-utils/rtl';
 
@@ -23,11 +24,28 @@ jest.mock('next/navigation', () => ({
 }));
 
 describe(ScheduleDetails.name, () => {
-  it('shows loading first then renders schedule policies section', async () => {
+  it('shows loading first then renders detail sections with representative values', async () => {
+    const user = userEvent.setup();
     const describeResolver = jest.fn(async () => {
       await delay(100);
       return HttpResponse.json(
         getMockRunningDescribeScheduleResponse({
+          info: {
+            createTime: { seconds: '1745490629', nanos: 850000000 },
+            nextRunTime: { seconds: '1745490629', nanos: 850000000 },
+            lastRunTime: { seconds: '1745490629', nanos: 850000000 },
+            totalRuns: '32',
+            lastUpdateTime: null,
+            ongoingBackfills: [],
+            missedRuns: '0',
+            skippedRuns: '0',
+          },
+          spec: {
+            cronExpression: '0 * * * *',
+            startTime: { seconds: '1735689600', nanos: 0 },
+            endTime: null,
+            jitter: { seconds: '300', nanos: 0 },
+          },
           policies: {
             overlapPolicy: 'SCHEDULE_OVERLAP_POLICY_BUFFER',
             catchUpPolicy: 'SCHEDULE_CATCH_UP_POLICY_ONE',
@@ -35,6 +53,23 @@ describe(ScheduleDetails.name, () => {
             pauseOnFailure: true,
             bufferLimit: 10,
             concurrencyLimit: 2,
+          },
+          action: {
+            startWorkflow: {
+              workflowType: { name: 'ScheduleWorker' },
+              taskList: {
+                name: 'schedule-task-list',
+                kind: 'TASK_LIST_KIND_NORMAL',
+                baseName: 'schedule-task-list',
+              },
+              input: null,
+              workflowIdPrefix: 'schedule-prefix',
+              executionStartToCloseTimeout: { seconds: '1800', nanos: 0 },
+              taskStartToCloseTimeout: null,
+              retryPolicy: null,
+              memo: null,
+              searchAttributes: null,
+            },
           },
         })
       );
@@ -46,53 +81,39 @@ describe(ScheduleDetails.name, () => {
 
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
     expect(
+      screen.getByRole('heading', { name: 'Schedule specifications' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Schedule action' })
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole('heading', { name: 'Schedule policies' })
     ).toBeInTheDocument();
-    expect(screen.getByText('Buffer')).toBeInTheDocument();
-    expect(screen.getByText('Yes')).toBeInTheDocument();
-    expect(describeResolver).toHaveBeenCalledTimes(1);
-  });
 
-  it('renders schedule specifications section rows', async () => {
-    setup({
-      describeResolver: () =>
-        HttpResponse.json(
-          getMockRunningDescribeScheduleResponse({
-            info: {
-              createTime: { seconds: '1745490629', nanos: 850000000 },
-              nextRunTime: { seconds: '1745490629', nanos: 850000000 },
-              lastRunTime: { seconds: '1745490629', nanos: 850000000 },
-              totalRuns: '32',
-              lastUpdateTime: null,
-              ongoingBackfills: [],
-              missedRuns: '0',
-              skippedRuns: '0',
-            },
-            spec: {
-              cronExpression: '0 * * * *',
-              startTime: { seconds: '1735689600', nanos: 0 },
-              endTime: null,
-              jitter: { seconds: '300', nanos: 0 },
-            },
-          })
-        ),
-    });
-
-    expect(
-      await screen.findByRole('heading', { name: 'Schedule specifications' })
-    ).toBeInTheDocument();
     expect(
       screen.getByRole('rowheader', { name: 'Schedule Id' })
     ).toBeInTheDocument();
     expect(screen.getByText('my-schedule')).toBeInTheDocument();
-    expect(
-      screen.getByRole('rowheader', { name: 'Cron execution' })
-    ).toBeInTheDocument();
     expect(screen.getByText('Every hour (0 * * * *)')).toBeInTheDocument();
     expect(screen.getByText('5m')).toBeInTheDocument();
+    expect(screen.getByText('Buffer')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+    expect(screen.getByText('ScheduleWorker')).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Collapse Schedule action details' })
+    );
+    expect(
+      screen.queryByRole('rowheader', { name: 'Workflow type' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Expand Schedule action details' })
+    ).toBeInTheDocument();
+
+    expect(describeResolver).toHaveBeenCalledTimes(1);
   });
 
-  it('hides optional specification rows when schedule fields are missing', async () => {
+  it('hides optional detail rows when schedule fields are missing', async () => {
     setup({
       describeResolver: () =>
         HttpResponse.json(
@@ -103,6 +124,15 @@ describe(ScheduleDetails.name, () => {
               endTime: null,
               jitter: null,
             },
+            policies: {
+              overlapPolicy: 'SCHEDULE_OVERLAP_POLICY_INVALID',
+              catchUpPolicy: 'SCHEDULE_CATCH_UP_POLICY_INVALID',
+              catchUpWindow: null,
+              pauseOnFailure: false,
+              bufferLimit: 0,
+              concurrencyLimit: 0,
+            },
+            action: { startWorkflow: null },
           })
         ),
     });
@@ -114,44 +144,17 @@ describe(ScheduleDetails.name, () => {
       screen.queryByRole('rowheader', { name: 'Start time' })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('rowheader', { name: 'Creation time' })
+      screen.queryByRole('rowheader', { name: 'Workflow Id Prefix' })
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('rowheader', { name: 'Jitter duration' })
+      screen.queryByRole('rowheader', { name: 'Schedule Search attributes' })
     ).not.toBeInTheDocument();
-  });
-
-  it('hides conditional policy rows when overlap policy does not apply', async () => {
-    setup({
-      describeResolver: () =>
-        HttpResponse.json(
-          getMockRunningDescribeScheduleResponse({
-            policies: {
-              overlapPolicy: 'SCHEDULE_OVERLAP_POLICY_INVALID',
-              catchUpPolicy: 'SCHEDULE_CATCH_UP_POLICY_INVALID',
-              catchUpWindow: null,
-              pauseOnFailure: false,
-              bufferLimit: 0,
-              concurrencyLimit: 0,
-            },
-          })
-        ),
-    });
-
-    expect(
-      await screen.findByRole('heading', { name: 'Schedule policies' })
-    ).toBeInTheDocument();
     expect(
       screen.getByRole('rowheader', { name: 'Overlap policy' })
     ).toBeInTheDocument();
-    expect(screen.getByText('Default (SkipNew)')).toBeInTheDocument();
-    expect(screen.getByText('Default (Skip)')).toBeInTheDocument();
     expect(
-      screen.queryByRole('rowheader', { name: 'Buffer limit' })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('rowheader', { name: 'Concurrency limit' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: 'Schedule action' })
+    ).toBeInTheDocument();
   });
 
   it('throws into error boundary when describe fails', async () => {

--- a/src/views/schedule-details/config/schedule-action-details.config.ts
+++ b/src/views/schedule-details/config/schedule-action-details.config.ts
@@ -1,0 +1,66 @@
+import { createElement } from 'react';
+
+import ScheduleDetailsBadges from '@/views/schedule-details/schedule-details-badges/schedule-details-badges';
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import { formatScheduleDuration } from '../helpers/schedule-details-formatters';
+import scheduleRetryPolicyDetailsConfig from './schedule-retry-policy-details.config';
+
+const scheduleActionDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'workflowType',
+    getLabel: () => 'Workflow type',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.workflowType?.name,
+  },
+  {
+    key: 'taskList',
+    getLabel: () => 'Tasklist',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.taskList?.name,
+  },
+  {
+    key: 'taskStartToCloseTimeout',
+    getLabel: () => 'Task start to close timeout',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.taskStartToCloseTimeout
+      ),
+  },
+  {
+    key: 'executionStartToCloseTimeout',
+    getLabel: () => 'Execution start to close timeout',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.executionStartToCloseTimeout
+      ),
+  },
+  {
+    key: 'workflowIdPrefix',
+    getLabel: () => 'Workflow Id Prefix',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.workflowIdPrefix,
+    hide: ({ describeSchedule }) =>
+      !describeSchedule.action?.startWorkflow?.workflowIdPrefix,
+  },
+  ...scheduleRetryPolicyDetailsConfig,
+  {
+    key: 'scheduleSearchAttributes',
+    getLabel: () => 'Schedule Search attributes',
+    getValue: ({ describeSchedule }) => {
+      const indexedFields =
+        describeSchedule.searchAttributes?.indexedFields ?? {};
+      if (Object.keys(indexedFields).length === 0) return null;
+      return createElement(ScheduleDetailsBadges, {
+        labels: Object.keys(indexedFields),
+      });
+    },
+    hide: ({ describeSchedule }) => {
+      return !Object.keys(
+        describeSchedule.searchAttributes?.indexedFields ?? {}
+      ).length;
+    },
+  },
+];
+
+export default scheduleActionDetailsConfig;

--- a/src/views/schedule-details/config/schedule-details-sections.config.ts
+++ b/src/views/schedule-details/config/schedule-details-sections.config.ts
@@ -1,8 +1,14 @@
 import { type ScheduleDetailsSectionConfig } from '@/views/schedule-details/schedule-details.types';
 
 import schedulePoliciesDetailsConfig from './schedule-policies-details.config';
+import scheduleSpecificationsDetailsConfig from './schedule-specifications-details.config';
 
 const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
+  {
+    key: 'specifications',
+    title: 'Schedule specifications',
+    rowsConfig: scheduleSpecificationsDetailsConfig,
+  },
   {
     key: 'policies',
     title: 'Schedule policies',

--- a/src/views/schedule-details/config/schedule-details-sections.config.ts
+++ b/src/views/schedule-details/config/schedule-details-sections.config.ts
@@ -1,5 +1,6 @@
 import { type ScheduleDetailsSectionConfig } from '@/views/schedule-details/schedule-details.types';
 
+import scheduleActionDetailsConfig from './schedule-action-details.config';
 import schedulePoliciesDetailsConfig from './schedule-policies-details.config';
 import scheduleSpecificationsDetailsConfig from './schedule-specifications-details.config';
 
@@ -8,6 +9,11 @@ const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
     key: 'specifications',
     title: 'Schedule specifications',
     rowsConfig: scheduleSpecificationsDetailsConfig,
+  },
+  {
+    key: 'action',
+    title: 'Schedule action',
+    rowsConfig: scheduleActionDetailsConfig,
   },
   {
     key: 'policies',

--- a/src/views/schedule-details/config/schedule-details-sections.config.ts
+++ b/src/views/schedule-details/config/schedule-details-sections.config.ts
@@ -1,0 +1,13 @@
+import { type ScheduleDetailsSectionConfig } from '@/views/schedule-details/schedule-details.types';
+
+import schedulePoliciesDetailsConfig from './schedule-policies-details.config';
+
+const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
+  {
+    key: 'policies',
+    title: 'Schedule policies',
+    rowsConfig: schedulePoliciesDetailsConfig,
+  },
+];
+
+export default scheduleDetailsSectionsConfig;

--- a/src/views/schedule-details/config/schedule-policies-details.config.ts
+++ b/src/views/schedule-details/config/schedule-policies-details.config.ts
@@ -1,0 +1,58 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import {
+  formatBooleanValue,
+  formatScheduleEnumWithDefault,
+  formatScheduleLimitValue,
+} from '../helpers/schedule-details-formatters';
+
+const schedulePoliciesDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'overlapPolicy',
+    getLabel: () => 'Overlap policy',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleEnumWithDefault(
+        describeSchedule.policies?.overlapPolicy,
+        'SCHEDULE_OVERLAP_POLICY',
+        ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_SKIP_NEW
+      ),
+  },
+  {
+    key: 'catchUpPolicy',
+    getLabel: () => 'Catchup policy',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleEnumWithDefault(
+        describeSchedule.policies?.catchUpPolicy,
+        'SCHEDULE_CATCH_UP_POLICY',
+        ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP
+      ),
+  },
+  {
+    key: 'pauseOnFailure',
+    getLabel: () => 'Pause on failure',
+    getValue: ({ describeSchedule }) =>
+      formatBooleanValue(describeSchedule.policies?.pauseOnFailure),
+  },
+  {
+    key: 'bufferLimit',
+    getLabel: () => 'Buffer limit',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleLimitValue(describeSchedule.policies?.bufferLimit),
+    hide: ({ describeSchedule }) =>
+      describeSchedule.policies?.overlapPolicy !==
+      ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+  },
+  {
+    key: 'concurrencyLimit',
+    getLabel: () => 'Concurrency limit',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleLimitValue(describeSchedule.policies?.concurrencyLimit),
+    hide: ({ describeSchedule }) =>
+      describeSchedule.policies?.overlapPolicy !==
+      ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+  },
+];
+
+export default schedulePoliciesDetailsConfig;

--- a/src/views/schedule-details/config/schedule-retry-policy-details.config.ts
+++ b/src/views/schedule-details/config/schedule-retry-policy-details.config.ts
@@ -1,0 +1,68 @@
+import { createElement } from 'react';
+
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import ScheduleDetailsBadges from '../schedule-details-badges/schedule-details-badges';
+import { formatScheduleDuration } from '../helpers/schedule-details-formatters';
+import { hideWithoutRetryPolicy } from '../helpers/schedule-details-row-hide';
+
+const scheduleRetryPolicyDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'retryPolicy.initialInterval',
+    getLabel: () => 'retryPolicy.initialInterval',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.retryPolicy?.initialInterval
+      ),
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.backoffCoefficient',
+    getLabel: () => 'retryPolicy.backoffCoefficient',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.retryPolicy?.backoffCoefficient,
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.maximumInterval',
+    getLabel: () => 'retryPolicy.maximumInterval',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.retryPolicy?.maximumInterval
+      ),
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.maximumAttempts',
+    getLabel: () => 'retryPolicy.maximumAttempts',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.retryPolicy?.maximumAttempts,
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.expirationInterval',
+    getLabel: () => 'retryPolicy.expirationInterval',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.retryPolicy?.expirationInterval
+      ),
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.nonRetryableErrorReasons',
+    getLabel: () => 'retryPolicy.nonRetryableErrorReasons',
+    getValue: ({ describeSchedule }) => {
+      const reasons =
+        describeSchedule.action?.startWorkflow?.retryPolicy
+          ?.nonRetryableErrorReasons;
+      if (!reasons?.length) {
+        return null;
+      }
+
+      return createElement(ScheduleDetailsBadges, { labels: reasons });
+    },
+    hide: hideWithoutRetryPolicy,
+  },
+];
+
+export default scheduleRetryPolicyDetailsConfig;

--- a/src/views/schedule-details/config/schedule-specifications-details.config.ts
+++ b/src/views/schedule-details/config/schedule-specifications-details.config.ts
@@ -1,0 +1,84 @@
+import { createElement } from 'react';
+
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import ScheduleDetailsBadges from '../schedule-details-badges/schedule-details-badges';
+import ScheduleDetailsMemo from '../schedule-details-memo/schedule-details-memo';
+import {
+  formatScheduleCronExpression,
+  formatScheduleDuration,
+  formatScheduleTimestamp,
+} from '../helpers/schedule-details-formatters';
+
+const scheduleSpecificationsDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'scheduleId',
+    getLabel: () => 'Schedule Id',
+    getValue: ({ scheduleId }) => scheduleId,
+  },
+  {
+    key: 'cronExpression',
+    getLabel: () => 'Cron execution',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleCronExpression(describeSchedule.spec?.cronExpression),
+  },
+  {
+    key: 'nextRunTime',
+    getLabel: () => 'Next run',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.info?.nextRunTime),
+  },
+  {
+    key: 'lastRunTime',
+    getLabel: () => 'Last run',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.info?.lastRunTime),
+  },
+  {
+    key: 'totalRuns',
+    getLabel: () => 'Total runs',
+    getValue: ({ describeSchedule }) => {
+      const total = describeSchedule.info?.totalRuns;
+      if (!total) return null;
+      return createElement(ScheduleDetailsBadges, { labels: [`${total} runs`] });
+    },
+  },
+  {
+    key: 'createTime',
+    getLabel: () => 'Creation time',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.info?.createTime),
+    hide: ({ describeSchedule }) => !describeSchedule.info?.createTime,
+  },
+  {
+    key: 'startTime',
+    getLabel: () => 'Start time',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.spec?.startTime),
+    hide: ({ describeSchedule }) => !describeSchedule.spec?.startTime,
+  },
+  {
+    key: 'endTime',
+    getLabel: () => 'End time',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.spec?.endTime),
+    hide: ({ describeSchedule }) => !describeSchedule.spec?.endTime,
+  },
+  {
+    key: 'memo',
+    getLabel: () => 'Memo',
+    getValue: ({ describeSchedule }) =>
+      createElement(ScheduleDetailsMemo, { memo: describeSchedule.memo }),
+    hide: ({ describeSchedule }) => !describeSchedule.memo?.fields,
+  },
+
+  {
+    key: 'jitter',
+    getLabel: () => 'Jitter duration',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(describeSchedule.spec?.jitter),
+    hide: ({ describeSchedule }) => !describeSchedule.spec?.jitter,
+  },
+];
+
+export default scheduleSpecificationsDetailsConfig;

--- a/src/views/schedule-details/helpers/__tests__/format-schedule-limit-value.test.ts
+++ b/src/views/schedule-details/helpers/__tests__/format-schedule-limit-value.test.ts
@@ -1,0 +1,13 @@
+import { formatScheduleLimitValue } from '../schedule-details-formatters';
+
+describe(formatScheduleLimitValue.name, () => {
+  it('returns unlimited label when limit is unset or zero', () => {
+    expect(formatScheduleLimitValue(undefined)).toBe('0 (Unlimited)');
+    expect(formatScheduleLimitValue(null)).toBe('0 (Unlimited)');
+    expect(formatScheduleLimitValue(0)).toBe('0 (Unlimited)');
+  });
+
+  it('returns the limit as a string when set', () => {
+    expect(formatScheduleLimitValue(10)).toBe('10');
+  });
+});

--- a/src/views/schedule-details/helpers/schedule-details-formatters.ts
+++ b/src/views/schedule-details/helpers/schedule-details-formatters.ts
@@ -1,4 +1,35 @@
+import formatDate from '@/utils/data-formatters/format-date';
+import formatDuration from '@/utils/data-formatters/format-duration';
 import formatEnum from '@/utils/data-formatters/format-enum';
+import formatTimestampToDatetime from '@/utils/data-formatters/format-timestamp-to-datetime';
+import { toString as cronToString } from 'cronstrue';
+
+export function formatScheduleTimestamp(
+  timestamp:
+    | { seconds: number | string; nanos: number | string }
+    | null
+    | undefined
+) {
+  const datetime = formatTimestampToDatetime(timestamp);
+  if (!datetime) {
+    return null;
+  }
+
+  return formatDate(datetime.valueOf());
+}
+
+export function formatScheduleDuration(
+  duration: { seconds: number | string; nanos: number } | null | undefined
+) {
+  if (!duration) {
+    return null;
+  }
+
+  return formatDuration({
+    seconds: String(duration.seconds),
+    nanos: duration.nanos,
+  });
+}
 
 export function formatScheduleEnum(
   value: string | null | undefined,
@@ -41,4 +72,18 @@ export function formatScheduleLimitValue(
   }
 
   return String(limit);
+}
+
+export function formatScheduleCronExpression(
+  cronExpression: string | null | undefined
+) {
+  if (!cronExpression) {
+    return null;
+  }
+
+  try {
+    return `${cronToString(cronExpression)} (${cronExpression})`;
+  } catch {
+    return cronExpression;
+  }
 }

--- a/src/views/schedule-details/helpers/schedule-details-formatters.ts
+++ b/src/views/schedule-details/helpers/schedule-details-formatters.ts
@@ -1,0 +1,44 @@
+import formatEnum from '@/utils/data-formatters/format-enum';
+
+export function formatScheduleEnum(
+  value: string | null | undefined,
+  prefix: string
+) {
+  return formatEnum(value, prefix, 'pascal');
+}
+
+export function formatScheduleEnumWithDefault(
+  value: string | null | undefined,
+  prefix: string,
+  defaultValue: string
+) {
+  const isEmpty = !value || value.includes('INVALID');
+  const formatted = formatScheduleEnum(
+    isEmpty ? defaultValue : value,
+    prefix
+  );
+
+  if (!formatted) {
+    return null;
+  }
+
+  return isEmpty ? `Default (${formatted})` : formatted;
+}
+
+export function formatBooleanValue(value: boolean | null | undefined) {
+  if (value === null || value === undefined) {
+    return null;
+  }
+
+  return value ? 'Yes' : 'No';
+}
+
+export function formatScheduleLimitValue(
+  limit: number | null | undefined
+): string {
+  if (limit === null || limit === undefined || limit === 0) {
+    return '0 (Unlimited)';
+  }
+
+  return String(limit);
+}

--- a/src/views/schedule-details/helpers/schedule-details-row-hide.ts
+++ b/src/views/schedule-details/helpers/schedule-details-row-hide.ts
@@ -1,0 +1,5 @@
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+export const hideWithoutRetryPolicy: ScheduleDetailRowConfig['hide'] = ({
+  describeSchedule,
+}) => !describeSchedule.action?.startWorkflow?.retryPolicy;

--- a/src/views/schedule-details/schedule-details-badges/__tests__/schedule-details-badges.test.tsx
+++ b/src/views/schedule-details/schedule-details-badges/__tests__/schedule-details-badges.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import ScheduleDetailsBadges from '../schedule-details-badges';
+
+describe(ScheduleDetailsBadges.name, () => {
+  it('renders each label as a badge', () => {
+    setup({ labels: ['32 runs', 'region'] });
+
+    expect(screen.getByText('32 runs')).toBeInTheDocument();
+    expect(screen.getByText('region')).toBeInTheDocument();
+  });
+
+  it('renders nothing when labels are empty', () => {
+    setup({ labels: [] });
+    expect(screen.queryByText('32 runs')).not.toBeInTheDocument();
+  });
+});
+
+function setup({ labels }: { labels: string[] }) {
+  render(<ScheduleDetailsBadges labels={labels} />);
+}

--- a/src/views/schedule-details/schedule-details-badges/schedule-details-badges.styles.ts
+++ b/src/views/schedule-details/schedule-details-badges/schedule-details-badges.styles.ts
@@ -1,0 +1,37 @@
+import { type Theme } from 'baseui';
+import { type BadgeOverrides } from 'baseui/badge';
+import { type StyleObject } from 'styletron-react';
+
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  container: (theme) => ({
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    gap: theme.sizing.scale100,
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> = cssStylesObj;
+
+export const overrides = {
+  badge: {
+    Badge: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        backgroundColor: $theme.colors.backgroundSecondary,
+        color: $theme.colors.contentSecondary,
+        borderRadius: $theme.borders.radius200,
+        paddingTop: $theme.sizing.scale0,
+        paddingBottom: $theme.sizing.scale0,
+        paddingLeft: $theme.sizing.scale300,
+        paddingRight: $theme.sizing.scale300,
+        height: 'auto',
+        ...$theme.typography.LabelXSmall,
+        whiteSpace: 'nowrap',
+      }),
+    },
+  } satisfies BadgeOverrides,
+};

--- a/src/views/schedule-details/schedule-details-badges/schedule-details-badges.tsx
+++ b/src/views/schedule-details/schedule-details-badges/schedule-details-badges.tsx
@@ -1,0 +1,31 @@
+'use client';
+import React from 'react';
+
+import { Badge } from 'baseui/badge';
+
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import { cssStyles, overrides } from './schedule-details-badges.styles';
+import { type Props } from './schedule-details-badges.types';
+
+export default function ScheduleDetailsBadges({ labels }: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+
+  if (labels.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cls.container}>
+      {labels.map((label) => (
+        <Badge
+          key={label}
+          content={label}
+          shape="rectangle"
+          color="primary"
+          overrides={overrides.badge}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/views/schedule-details/schedule-details-badges/schedule-details-badges.types.ts
+++ b/src/views/schedule-details/schedule-details-badges/schedule-details-badges.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  labels: string[];
+};

--- a/src/views/schedule-details/schedule-details-memo/__tests__/schedule-details-memo.test.tsx
+++ b/src/views/schedule-details/schedule-details-memo/__tests__/schedule-details-memo.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import ScheduleDetailsMemo from '../schedule-details-memo';
+import { type Props } from '../schedule-details-memo.types';
+
+describe(ScheduleDetailsMemo.name, () => {
+  it('renders tab-indented JSON for memo fields', () => {
+    setup({
+      memo: {
+        fields: {
+          team: { data: 'eyJ0ZWFtIjoiY2FkZW5jZSJ9' },
+          note: { data: 'dGVzdC1ub3Rl' },
+        },
+      },
+    });
+
+    const pre = screen.getByText((_, element) => element?.tagName === 'PRE');
+    expect(pre).toHaveTextContent('"team": "cadence"');
+    expect(pre).toHaveTextContent('"note": "test-note"');
+    expect(pre.textContent).toContain('\t');
+  });
+
+  it('renders nothing when memo fields are absent', () => {
+    setup({ memo: null });
+    expect(screen.queryByText(/team/)).not.toBeInTheDocument();
+  });
+});
+
+function setup({ memo }: Pick<Props, 'memo'>) {
+  render(<ScheduleDetailsMemo memo={memo} />);
+}

--- a/src/views/schedule-details/schedule-details-memo/schedule-details-memo.styles.ts
+++ b/src/views/schedule-details/schedule-details-memo/schedule-details-memo.styles.ts
@@ -1,0 +1,16 @@
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  pre: (theme) => ({
+    ...theme.typography.MonoLabelXSmall,
+    margin: 0,
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-word',
+    overflowWrap: 'anywhere',
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> = cssStylesObj;

--- a/src/views/schedule-details/schedule-details-memo/schedule-details-memo.tsx
+++ b/src/views/schedule-details/schedule-details-memo/schedule-details-memo.tsx
@@ -1,0 +1,40 @@
+'use client';
+import React, { useMemo } from 'react';
+
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+import formatPayload from '@/utils/data-formatters/format-payload';
+
+import { cssStyles } from './schedule-details-memo.styles';
+import { type Props } from './schedule-details-memo.types';
+
+export default function ScheduleDetailsMemo({ memo }: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+  const formattedMemo = useMemo(() => {
+    if (!memo?.fields) {
+      return null;
+    }
+
+    const entries = Object.entries(memo.fields).flatMap(([key, payload]) => {
+      const value = formatPayload(payload);
+      if (value === null || value === undefined) {
+        return [];
+      }
+
+      return [[key, value] as const];
+    });
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    return Object.fromEntries(entries);
+  }, [memo]);
+
+  if (!formattedMemo) {
+    return null;
+  }
+
+  return (
+    <pre className={cls.pre}>{JSON.stringify(formattedMemo, null, '\t')}</pre>
+  );
+}

--- a/src/views/schedule-details/schedule-details-memo/schedule-details-memo.types.ts
+++ b/src/views/schedule-details/schedule-details-memo/schedule-details-memo.types.ts
@@ -1,0 +1,5 @@
+import { type DescribeScheduleResponse } from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule.types';
+
+export type Props = {
+  memo: DescribeScheduleResponse['memo'];
+};

--- a/src/views/schedule-details/schedule-details-section-body/schedule-details-section-body.styles.ts
+++ b/src/views/schedule-details/schedule-details-section-body/schedule-details-section-body.styles.ts
@@ -1,0 +1,12 @@
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  bodyContainer: (_theme) => ({
+    width: '100%',
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> = cssStylesObj;

--- a/src/views/schedule-details/schedule-details-section-body/schedule-details-section-body.tsx
+++ b/src/views/schedule-details/schedule-details-section-body/schedule-details-section-body.tsx
@@ -1,0 +1,19 @@
+'use client';
+import React from 'react';
+
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import ScheduleDetailsTable from '../schedule-details-table/schedule-details-table';
+
+import { cssStyles } from './schedule-details-section-body.styles';
+import { type Props } from './schedule-details-section-body.types';
+
+export default function ScheduleDetailsSectionBody({ title, rows }: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+
+  return (
+    <div className={cls.bodyContainer}>
+      <ScheduleDetailsTable rows={rows} ariaLabel={`${title} details`} />
+    </div>
+  );
+}

--- a/src/views/schedule-details/schedule-details-section-body/schedule-details-section-body.types.ts
+++ b/src/views/schedule-details/schedule-details-section-body/schedule-details-section-body.types.ts
@@ -1,0 +1,6 @@
+import { type ScheduleDetailsTableRow } from '@/views/schedule-details/schedule-details-table/schedule-details-table.types';
+
+export type Props = {
+  title: string;
+  rows: ScheduleDetailsTableRow[];
+};

--- a/src/views/schedule-details/schedule-details-section-header/schedule-details-section-header.styles.ts
+++ b/src/views/schedule-details/schedule-details-section-header/schedule-details-section-header.styles.ts
@@ -1,0 +1,44 @@
+import { type Theme } from 'baseui';
+import { type ButtonOverrides } from 'baseui/button';
+import { type StyleObject } from 'styletron-react';
+
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  headerContainer: (theme) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: theme.sizing.scale400,
+  }),
+  title: (theme) => ({
+    ...theme.typography.LabelSmall,
+    marginTop: 0,
+    marginBottom: 0,
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> = cssStylesObj;
+
+export const overrides = {
+  collapseButton: {
+    BaseButton: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        width: $theme.sizing.scale850,
+        height: $theme.sizing.scale850,
+        paddingTop: 0,
+        paddingBottom: 0,
+        paddingLeft: 0,
+        paddingRight: 0,
+        flexShrink: 0,
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: $theme.borders.radius300,
+      }),
+    },
+  } satisfies ButtonOverrides,
+};

--- a/src/views/schedule-details/schedule-details-section-header/schedule-details-section-header.tsx
+++ b/src/views/schedule-details/schedule-details-section-header/schedule-details-section-header.tsx
@@ -1,0 +1,37 @@
+'use client';
+import React from 'react';
+
+import ChevronDown from 'baseui/icon/chevron-down';
+import ChevronUp from 'baseui/icon/chevron-up';
+
+import Button from '@/components/button/button';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import { cssStyles, overrides } from './schedule-details-section-header.styles';
+import { type Props } from './schedule-details-section-header.types';
+
+export default function ScheduleDetailsSectionHeader({
+  title,
+  isCollapsed,
+  onToggle,
+}: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+  const buttonActionLabel = isCollapsed ? 'Expand' : 'Collapse';
+  const CollapseIcon = isCollapsed ? ChevronDown : ChevronUp;
+
+  return (
+    <div className={cls.headerContainer}>
+      <h2 className={cls.title}>{title}</h2>
+      <Button
+        size="compact"
+        kind="secondary"
+        onClick={onToggle}
+        aria-label={`${buttonActionLabel} ${title} details`}
+        aria-expanded={!isCollapsed}
+        overrides={overrides.collapseButton}
+      >
+        <CollapseIcon size={16} />
+      </Button>
+    </div>
+  );
+}

--- a/src/views/schedule-details/schedule-details-section-header/schedule-details-section-header.types.ts
+++ b/src/views/schedule-details/schedule-details-section-header/schedule-details-section-header.types.ts
@@ -1,0 +1,5 @@
+export type Props = {
+  title: string;
+  isCollapsed: boolean;
+  onToggle: () => void;
+};

--- a/src/views/schedule-details/schedule-details-section/schedule-details-section.styles.ts
+++ b/src/views/schedule-details/schedule-details-section/schedule-details-section.styles.ts
@@ -1,0 +1,14 @@
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  section: (theme) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.sizing.scale500,
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> = cssStylesObj;

--- a/src/views/schedule-details/schedule-details-section/schedule-details-section.tsx
+++ b/src/views/schedule-details/schedule-details-section/schedule-details-section.tsx
@@ -1,0 +1,36 @@
+'use client';
+import React from 'react';
+
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import ScheduleDetailsSectionBody from '../schedule-details-section-body/schedule-details-section-body';
+import ScheduleDetailsSectionHeader from '../schedule-details-section-header/schedule-details-section-header';
+
+import { cssStyles } from './schedule-details-section.styles';
+import { type Props } from './schedule-details-section.types';
+
+export default function ScheduleDetailsSection({
+  title,
+  rows,
+  initiallyCollapsed = false,
+}: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+  const [isCollapsed, setIsCollapsed] = React.useState(initiallyCollapsed);
+
+  const onToggle = React.useCallback(() => {
+    setIsCollapsed((currentValue) => !currentValue);
+  }, []);
+
+  return (
+    <section className={cls.section}>
+      <ScheduleDetailsSectionHeader
+        title={title}
+        isCollapsed={isCollapsed}
+        onToggle={onToggle}
+      />
+      {!isCollapsed && (
+        <ScheduleDetailsSectionBody title={title} rows={rows} />
+      )}
+    </section>
+  );
+}

--- a/src/views/schedule-details/schedule-details-section/schedule-details-section.types.ts
+++ b/src/views/schedule-details/schedule-details-section/schedule-details-section.types.ts
@@ -1,0 +1,7 @@
+import { type ScheduleDetailsTableRow } from '@/views/schedule-details/schedule-details-table/schedule-details-table.types';
+
+export type Props = {
+  title: string;
+  rows: ScheduleDetailsTableRow[];
+  initiallyCollapsed?: boolean;
+};

--- a/src/views/schedule-details/schedule-details-table/schedule-details-table.styles.ts
+++ b/src/views/schedule-details/schedule-details-table/schedule-details-table.styles.ts
@@ -4,40 +4,53 @@ import { type StyleObject } from 'styletron-react';
 import { LABEL_COLUMN_WIDTH_PX } from './schedule-details-table.constants';
 
 export const styled = {
-  Container: createStyled('div', (): StyleObject => ({
-    width: '100%',
-  })),
-  Row: createStyled(
-    'div',
+  Table: createStyled(
+    'table',
     ({ $theme }: { $theme: Theme }): StyleObject => ({
-      display: 'flex',
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: $theme.sizing.scale300,
-      paddingTop: $theme.sizing.scale400,
-      paddingBottom: $theme.sizing.scale400,
-      wordBreak: 'break-word',
+      width: '100%',
+      borderCollapse: 'collapse',
+      borderSpacing: 0,
+      ...$theme.typography.ParagraphXSmall,
+    })
+  ),
+  Row: createStyled(
+    'tr',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
       ':not(:last-child)': {
         borderBottom: `1px solid ${$theme.colors.borderOpaque}`,
       },
     })
   ),
-  Label: createStyled(
-    'div',
+  LabelCell: createStyled(
+    'th',
     ({ $theme }: { $theme: Theme }): StyleObject => ({
+      ...$theme.typography.LabelXSmall,
+      width: `${LABEL_COLUMN_WIDTH_PX}px`,
       minWidth: `${LABEL_COLUMN_WIDTH_PX}px`,
       maxWidth: `${LABEL_COLUMN_WIDTH_PX}px`,
-      display: 'flex',
-      ...$theme.typography.LabelSmall,
-      lineHeight: $theme.typography.ParagraphSmall.lineHeight,
+      textAlign: 'left',
+      verticalAlign: 'top',
+      paddingTop: $theme.sizing.scale400,
+      paddingBottom: $theme.sizing.scale400,
+      paddingLeft: 0,
+      paddingRight: $theme.sizing.scale300,
+      lineHeight: $theme.typography.ParagraphXSmall.lineHeight,
+      wordBreak: 'break-word',
+      overflowWrap: 'anywhere',
     })
   ),
-  Value: createStyled(
-    'div',
+  ValueCell: createStyled(
+    'td',
     ({ $theme }: { $theme: Theme }): StyleObject => ({
-      display: 'flex',
-      flex: '1 0 300px',
-      ...$theme.typography.ParagraphSmall,
+      ...$theme.typography.ParagraphXSmall,
+      verticalAlign: 'top',
+      paddingTop: $theme.sizing.scale400,
+      paddingBottom: $theme.sizing.scale400,
+      paddingLeft: $theme.sizing.scale300,
+      paddingRight: 0,
+      wordBreak: 'break-word',
+      overflowWrap: 'anywhere',
+      whiteSpace: 'normal',
     })
   ),
 };

--- a/src/views/schedule-details/schedule-details-table/schedule-details-table.tsx
+++ b/src/views/schedule-details/schedule-details-table/schedule-details-table.tsx
@@ -15,15 +15,17 @@ export default function ScheduleDetailsTable({
   const visibleRows = rows.filter((row) => !row.hide);
 
   return (
-    <styled.Container aria-label={ariaLabel} role="table">
-      {visibleRows.map((row, index) => (
-        <styled.Row key={row.key ?? getRowKey(row, index)} role="row">
-          <styled.Label role="rowheader">{row.label}</styled.Label>
-          <styled.Value role="cell">
-            {getDisplayValue(row.value, emptyValue)}
-          </styled.Value>
-        </styled.Row>
-      ))}
-    </styled.Container>
+    <styled.Table aria-label={ariaLabel}>
+      <tbody>
+        {visibleRows.map((row, index) => (
+          <styled.Row key={row.key ?? getRowKey(row, index)}>
+            <styled.LabelCell scope="row">{row.label}</styled.LabelCell>
+            <styled.ValueCell>
+              {getDisplayValue(row.value, emptyValue)}
+            </styled.ValueCell>
+          </styled.Row>
+        ))}
+      </tbody>
+    </styled.Table>
   );
 }

--- a/src/views/schedule-details/schedule-details.styles.ts
+++ b/src/views/schedule-details/schedule-details.styles.ts
@@ -1,0 +1,15 @@
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  detailsSectionsContainer: (theme) => ({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.sizing.scale900,
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =
+  cssStylesObj;

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -3,11 +3,18 @@ import React from 'react';
 
 import PageSection from '@/components/page-section/page-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+import { type ScheduleDetailsTableRow } from '@/views/schedule-details/schedule-details-table/schedule-details-table.types';
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
 
-import { type Props } from './schedule-details.types';
+import scheduleDetailsSectionsConfig from './config/schedule-details-sections.config';
+import ScheduleDetailsSection from './schedule-details-section/schedule-details-section';
+
+import { cssStyles } from './schedule-details.styles';
+import { type Props, type ScheduleDetailRowConfig } from './schedule-details.types';
 
 export default function ScheduleDetails({ params }: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
   const { data, isLoading, isPending } = useDescribeSchedule({
     domain: params.domain,
     cluster: params.cluster,
@@ -18,6 +25,7 @@ export default function ScheduleDetails({ params }: Props) {
   if (isLoading || isPending) {
     return <SectionLoadingIndicator />;
   }
+
   // Should never happen as we have throwOnError set to true but it is for better type safety below
   if (!data) {
     throw new Error('Schedule data is unavailable');
@@ -25,7 +33,44 @@ export default function ScheduleDetails({ params }: Props) {
 
   return (
     <PageSection>
-      <div>Details — coming soon</div>
+      <div className={cls.detailsSectionsContainer}>
+        {scheduleDetailsSectionsConfig.map((section) => {
+          const rows = getRowsFromConfig(
+            section.rowsConfig,
+            data,
+            params.scheduleId
+          );
+          if (!rows.length) {
+            return null;
+          }
+
+          return (
+            <ScheduleDetailsSection
+              key={section.key}
+              title={section.title}
+              rows={rows}
+            />
+          );
+        })}
+      </div>
     </PageSection>
   );
+}
+
+function getRowsFromConfig(
+  config: ScheduleDetailRowConfig[],
+  data: NonNullable<ReturnType<typeof useDescribeSchedule>['data']>,
+  scheduleId: string
+): ScheduleDetailsTableRow[] {
+  const args = { describeSchedule: data, scheduleId };
+  return config
+    .filter(
+      (rowConfig) =>
+        !rowConfig.hide || !rowConfig.hide({ describeSchedule: data, scheduleId })
+    )
+    .map((rowConfig) => ({
+      key: rowConfig.key,
+      label: rowConfig.getLabel(),
+      value: rowConfig.getValue(args),
+    }));
 }

--- a/src/views/schedule-details/schedule-details.types.ts
+++ b/src/views/schedule-details/schedule-details.types.ts
@@ -1,5 +1,25 @@
-import type { SchedulePageTabsParams } from '@/views/schedule-page/schedule-page-tabs/schedule-page-tabs.types';
+import { type ScheduleDetailsTableRow } from '@/views/schedule-details/schedule-details-table/schedule-details-table.types';
+import { type SchedulePageTabsParams } from '@/views/schedule-page/schedule-page-tabs/schedule-page-tabs.types';
+import { type DescribeScheduleResponse } from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule.types';
 
 export type Props = {
   params: SchedulePageTabsParams;
+};
+
+export type ScheduleDetailRowArgs = {
+  describeSchedule: DescribeScheduleResponse;
+  scheduleId: string;
+};
+
+export type ScheduleDetailRowConfig = {
+  key: string;
+  getLabel: () => string;
+  getValue: (args: ScheduleDetailRowArgs) => ScheduleDetailsTableRow['value'];
+  hide?: (args: ScheduleDetailRowArgs) => boolean;
+};
+
+export type ScheduleDetailsSectionConfig = {
+  key: string;
+  title: string;
+  rowsConfig: ScheduleDetailRowConfig[];
 };


### PR DESCRIPTION
## Summary
- First vertical slice: working policies section on the Details tab with only the helpers and section shell needed for that group.

## Changes
- Config-driven section rendering wired in `ScheduleDetails`.
- Policies row config (overlap, catchup, pause-on-failure, limits).
- Enum/boolean formatters and collapsible section chrome.

## Testing
- [x] `npm run test:unit:browser schedule-details`