### PR TITLE
feat(schedule-details): add schedule input JSON section

### DIFF
--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -71,6 +71,49 @@ describe(ScheduleDetails.name, () => {
     expect(describeResolver).toHaveBeenCalledTimes(1);
   });
 
+  it('renders schedule input JSON section when workflow input is present', async () => {
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(
+          getMockRunningDescribeScheduleResponse({
+            action: {
+              startWorkflow: {
+                workflowType: { name: 'ScheduleWorker' },
+                taskList: {
+                  name: 'schedule-task-list',
+                  kind: 'TASK_LIST_KIND_NORMAL',
+                  baseName: 'schedule-task-list',
+                },
+                input: {
+                  data: 'eyJ3b3JrZmxvd0FyZyI6InRlc3QtdmFsdWUifQ==',
+                },
+                workflowIdPrefix: 'schedule-prefix',
+                executionStartToCloseTimeout: null,
+                taskStartToCloseTimeout: null,
+                retryPolicy: null,
+                memo: null,
+                searchAttributes: null,
+              },
+            },
+          })
+        ),
+    });
+
+    expect(await screen.findByText('Input')).toBeInTheDocument();
+  });
+
+  it('hides schedule input JSON section when workflow input is absent', async () => {
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(getMockRunningDescribeScheduleResponse()),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Mock policies section' })
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Input')).not.toBeInTheDocument();
+  });
+
   it('hides conditional rows when hide predicate returns true', async () => {
     const describeResponse = getMockRunningDescribeScheduleResponse({
       policies: {

--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -102,7 +102,7 @@ describe(ScheduleDetails.name, () => {
     expect(await screen.findByText('Input')).toBeInTheDocument();
   });
 
-  it('hides schedule input JSON section when workflow input is absent', async () => {
+  it('renders schedule input JSON section when workflow input is absent', async () => {
     setup({
       describeResolver: () =>
         HttpResponse.json(getMockRunningDescribeScheduleResponse()),
@@ -111,7 +111,7 @@ describe(ScheduleDetails.name, () => {
     expect(
       await screen.findByRole('heading', { name: 'Mock policies section' })
     ).toBeInTheDocument();
-    expect(screen.queryByText('Input')).not.toBeInTheDocument();
+    expect(screen.getByText('Input')).toBeInTheDocument();
   });
 
   it('hides conditional rows when hide predicate returns true', async () => {

--- a/src/views/schedule-details/helpers/format-schedule-input.ts
+++ b/src/views/schedule-details/helpers/format-schedule-input.ts
@@ -1,0 +1,7 @@
+import formatPayload from '@/utils/data-formatters/format-payload';
+
+export function formatScheduleInput(
+  input: { data?: string | null } | null | undefined
+) {
+  return formatPayload(input);
+}

--- a/src/views/schedule-details/helpers/format-schedule-input.ts
+++ b/src/views/schedule-details/helpers/format-schedule-input.ts
@@ -1,7 +1,0 @@
-import formatPayload from '@/utils/data-formatters/format-payload';
-
-export function formatScheduleInput(
-  input: { data?: string | null } | null | undefined
-) {
-  return formatPayload(input);
-}

--- a/src/views/schedule-details/schedule-details-input-json/__tests__/schedule-details-input-json.test.tsx
+++ b/src/views/schedule-details/schedule-details-input-json/__tests__/schedule-details-input-json.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import ScheduleDetailsInputJson from '../schedule-details-input-json';
+
+jest.mock(
+  '@/views/workflow-summary/workflow-summary-json-view/workflow-summary-json-view',
+  () =>
+    jest.fn(({ inputJson, hideTabToggle }) => (
+      <div>
+        WorkflowSummaryJsonView Mock
+        {hideTabToggle ? ' hideTabToggle' : ''}
+        {JSON.stringify(inputJson)}
+      </div>
+    ))
+);
+
+const mockInputPayload = {
+  data: 'eyJ3b3JrZmxvd0FyZyI6InRlc3QtdmFsdWUifQ==',
+};
+
+describe(ScheduleDetailsInputJson.name, () => {
+  it('renders workflow summary JSON view when input is present', () => {
+    setup({});
+    expect(
+      screen.getByText(/WorkflowSummaryJsonView Mock hideTabToggle/)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/{"workflowArg":"test-value"}/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing when input is missing', () => {
+    setup({ input: null });
+    expect(
+      screen.queryByText(/WorkflowSummaryJsonView Mock/)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when input payload has no data', () => {
+    setup({ input: { data: null } });
+    expect(
+      screen.queryByText(/WorkflowSummaryJsonView Mock/)
+    ).not.toBeInTheDocument();
+  });
+});
+
+function setup({
+  input = mockInputPayload,
+}: {
+  input?: { data?: string | null } | null;
+}) {
+  render(
+    <ScheduleDetailsInputJson
+      input={input}
+      domain="test-domain"
+      cluster="test-cluster"
+    />
+  );
+}

--- a/src/views/schedule-details/schedule-details-input-json/__tests__/schedule-details-input-json.test.tsx
+++ b/src/views/schedule-details/schedule-details-input-json/__tests__/schedule-details-input-json.test.tsx
@@ -2,18 +2,16 @@ import React from 'react';
 
 import { render, screen } from '@/test-utils/rtl';
 
+import losslessJsonStringify from '@/utils/lossless-json-stringify';
+
 import ScheduleDetailsInputJson from '../schedule-details-input-json';
 
-jest.mock(
-  '@/views/workflow-summary/workflow-summary-json-view/workflow-summary-json-view',
-  () =>
-    jest.fn(({ inputJson, hideTabToggle }) => (
-      <div>
-        WorkflowSummaryJsonView Mock
-        {hideTabToggle ? ' hideTabToggle' : ''}
-        {JSON.stringify(inputJson)}
-      </div>
-    ))
+jest.mock('@/components/copy-text-button/copy-text-button', () =>
+  jest.fn(({ textToCopy }) => <div>Copy Button: {textToCopy}</div>)
+);
+
+jest.mock('@/components/pretty-json/pretty-json', () =>
+  jest.fn(({ json }) => <div>PrettyJson Mock: {JSON.stringify(json)}</div>)
 );
 
 const mockInputPayload = {
@@ -21,28 +19,47 @@ const mockInputPayload = {
 };
 
 describe(ScheduleDetailsInputJson.name, () => {
-  it('renders workflow summary JSON view when input is present', () => {
+  it('renders input JSON when input is present', () => {
     setup({});
+    expect(screen.getByText('Input')).toBeInTheDocument();
     expect(
-      screen.getByText(/WorkflowSummaryJsonView Mock hideTabToggle/)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/{"workflowArg":"test-value"}/)
+      screen.getByText(/PrettyJson Mock: \[{"workflowArg":"test-value"}\]/)
     ).toBeInTheDocument();
   });
 
-  it('renders nothing when input is missing', () => {
+  it('passes formatted input to the copy button', () => {
+    setup({});
+    const parsedInput = [{ workflowArg: 'test-value' }];
+    const copyButton = screen.getByText(/Copy Button:/);
+    expect(copyButton).toBeInTheDocument();
+    expect(copyButton.innerHTML).toMatch(
+      losslessJsonStringify(parsedInput, null, '\t')
+    );
+  });
+
+  it('renders null when input is missing', () => {
     setup({ input: null });
-    expect(
-      screen.queryByText(/WorkflowSummaryJsonView Mock/)
-    ).not.toBeInTheDocument();
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(screen.getByText('PrettyJson Mock: null')).toBeInTheDocument();
   });
 
-  it('renders nothing when input payload has no data', () => {
+  it('renders null when input payload has no data', () => {
     setup({ input: { data: null } });
+    expect(screen.getByText('Input')).toBeInTheDocument();
+    expect(screen.getByText('PrettyJson Mock: null')).toBeInTheDocument();
+  });
+
+  it('parses multiple workflow inputs', () => {
+    setup({
+      input: {
+        data: btoa('{"name": "John", "age": 30} {"name": "Jane", "age": 25}'),
+      },
+    });
     expect(
-      screen.queryByText(/WorkflowSummaryJsonView Mock/)
-    ).not.toBeInTheDocument();
+      screen.getByText(
+        /PrettyJson Mock: \[{"name":"John","age":30},{"name":"Jane","age":25}\]/
+      )
+    ).toBeInTheDocument();
   });
 });
 
@@ -51,11 +68,5 @@ function setup({
 }: {
   input?: { data?: string | null } | null;
 }) {
-  render(
-    <ScheduleDetailsInputJson
-      input={input}
-      domain="test-domain"
-      cluster="test-cluster"
-    />
-  );
+  render(<ScheduleDetailsInputJson input={input} />);
 }

--- a/src/views/schedule-details/schedule-details-input-json/__tests__/schedule-details-input-json.test.tsx
+++ b/src/views/schedule-details/schedule-details-input-json/__tests__/schedule-details-input-json.test.tsx
@@ -44,7 +44,7 @@ describe(ScheduleDetailsInputJson.name, () => {
   });
 
   it('renders null when input payload has no data', () => {
-    setup({ input: { data: null } });
+    setup({ input: { data: '' } });
     expect(screen.getByText('Input')).toBeInTheDocument();
     expect(screen.getByText('PrettyJson Mock: null')).toBeInTheDocument();
   });
@@ -66,7 +66,7 @@ describe(ScheduleDetailsInputJson.name, () => {
 function setup({
   input = mockInputPayload,
 }: {
-  input?: { data?: string | null } | null;
+  input?: { data: string } | null;
 }) {
   render(<ScheduleDetailsInputJson input={input} />);
 }

--- a/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.styles.ts
+++ b/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.styles.ts
@@ -1,0 +1,29 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import { type ButtonOverrides } from 'baseui/button';
+
+export const styled = {
+  Container: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    padding: $theme.sizing.scale600,
+    backgroundColor: $theme.colors.backgroundSecondary,
+    borderRadius: $theme.borders.radius300,
+  })),
+  Header: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    justifyContent: 'space-between',
+    gap: $theme.sizing.scale600,
+    marginBottom: $theme.sizing.scale700,
+  })),
+  Title: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    ...$theme.typography.LabelSmall,
+  })),
+};
+
+export const overrides = {
+  copyButton: {
+    BaseButton: {
+      style: {
+        backgroundColor: 'rgba(0, 0, 0, 0)',
+      },
+    },
+  } satisfies ButtonOverrides,
+};

--- a/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.tsx
+++ b/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.tsx
@@ -1,0 +1,34 @@
+'use client';
+import React, { useMemo } from 'react';
+
+import WorkflowSummaryJsonView from '@/views/workflow-summary/workflow-summary-json-view/workflow-summary-json-view';
+
+import { type PrettyJsonValue } from '@/components/pretty-json/pretty-json.types';
+
+import { formatScheduleInput } from '../helpers/format-schedule-input';
+
+import { type Props } from './schedule-details-input-json.types';
+
+export default function ScheduleDetailsInputJson({ input, domain, cluster }: Props) {
+  const parsedInput = useMemo(() => formatScheduleInput(input), [input]);
+
+  if (parsedInput === null || parsedInput === undefined) {
+    return null;
+  }
+
+  return (
+    <WorkflowSummaryJsonView
+      inputJson={parsedInput as PrettyJsonValue}
+      resultJson={null}
+      isWorkflowRunning={false}
+      isWorkflowError={false}
+      isArchived={false}
+      domain={domain}
+      cluster={cluster}
+      workflowId=""
+      runId=""
+      defaultTab="input"
+      hideTabToggle
+    />
+  );
+}

--- a/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.tsx
+++ b/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.tsx
@@ -1,34 +1,33 @@
 'use client';
 import React, { useMemo } from 'react';
 
-import WorkflowSummaryJsonView from '@/views/workflow-summary/workflow-summary-json-view/workflow-summary-json-view';
-
+import CopyTextButton from '@/components/copy-text-button/copy-text-button';
+import PrettyJson from '@/components/pretty-json/pretty-json';
 import { type PrettyJsonValue } from '@/components/pretty-json/pretty-json.types';
+import formatInputPayload from '@/utils/data-formatters/format-input-payload';
+import losslessJsonStringify from '@/utils/lossless-json-stringify';
 
-import { formatScheduleInput } from '../helpers/format-schedule-input';
-
+import { overrides, styled } from './schedule-details-input-json.styles';
 import { type Props } from './schedule-details-input-json.types';
 
-export default function ScheduleDetailsInputJson({ input, domain, cluster }: Props) {
-  const parsedInput = useMemo(() => formatScheduleInput(input), [input]);
+export default function ScheduleDetailsInputJson({ input }: Props) {
+  const parsedInput = useMemo(() => formatInputPayload(input), [input]);
 
-  if (parsedInput === null || parsedInput === undefined) {
-    return null;
-  }
+  const textToCopy = useMemo(
+    () => losslessJsonStringify(parsedInput, null, '\t'),
+    [parsedInput]
+  );
 
   return (
-    <WorkflowSummaryJsonView
-      inputJson={parsedInput as PrettyJsonValue}
-      resultJson={null}
-      isWorkflowRunning={false}
-      isWorkflowError={false}
-      isArchived={false}
-      domain={domain}
-      cluster={cluster}
-      workflowId=""
-      runId=""
-      defaultTab="input"
-      hideTabToggle
-    />
+    <styled.Container>
+      <styled.Header>
+        <styled.Title>Input</styled.Title>
+        <CopyTextButton
+          textToCopy={textToCopy}
+          overrides={overrides.copyButton}
+        />
+      </styled.Header>
+      <PrettyJson json={parsedInput as PrettyJsonValue} />
+    </styled.Container>
   );
 }

--- a/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.types.ts
+++ b/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.types.ts
@@ -1,0 +1,5 @@
+export type Props = {
+  input: { data?: string | null } | null | undefined;
+  domain: string;
+  cluster: string;
+};

--- a/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.types.ts
+++ b/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.types.ts
@@ -1,3 +1,3 @@
 export type Props = {
-  input: { data?: string | null } | null | undefined;
+  input?: { data: string } | null;
 };

--- a/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.types.ts
+++ b/src/views/schedule-details/schedule-details-input-json/schedule-details-input-json.types.ts
@@ -1,5 +1,3 @@
 export type Props = {
   input: { data?: string | null } | null | undefined;
-  domain: string;
-  cluster: string;
 };

--- a/src/views/schedule-details/schedule-details.styles.ts
+++ b/src/views/schedule-details/schedule-details.styles.ts
@@ -1,9 +1,27 @@
-import { styled as createStyled } from 'baseui';
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
 
-export const styled = {
-  DetailsSectionsContainer: createStyled('div', ({ $theme }) => ({
+const cssStylesObj = {
+  pageContainer: (theme) => ({
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: theme.sizing.scale1000,
+    [theme.mediaQuery.medium]: {
+      gridTemplateColumns: 'repeat(2, 1fr)',
+    },
+  }),
+  mainContent: (theme) => ({
+    minWidth: 0,
     display: 'flex',
     flexDirection: 'column',
-    gap: $theme.sizing.scale900,
-  })),
-};
+    gap: theme.sizing.scale900,
+  }),
+  jsonPanel: () => ({
+    minWidth: 0,
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =
+  cssStylesObj;

--- a/src/views/schedule-details/schedule-details.styles.ts
+++ b/src/views/schedule-details/schedule-details.styles.ts
@@ -1,27 +1,24 @@
-import type {
-  StyletronCSSObject,
-  StyletronCSSObjectOf,
-} from '@/hooks/use-styletron-classes';
+import { styled as createStyled, type Theme } from 'baseui';
 
-const cssStylesObj = {
-  pageContainer: (theme) => ({
+export const styled = {
+  PageContainer: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
     display: 'grid',
     gridTemplateColumns: '1fr',
-    gap: theme.sizing.scale1000,
-    [theme.mediaQuery.medium]: {
+    gap: $theme.sizing.scale1000,
+    [$theme.mediaQuery.medium]: {
       gridTemplateColumns: 'repeat(2, 1fr)',
     },
-  }),
-  mainContent: (theme) => ({
+  })),
+  DetailsSectionsContainer: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }) => ({
+      minWidth: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: $theme.sizing.scale900,
+    })
+  ),
+  JsonPanel: createStyled('div', () => ({
     minWidth: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.sizing.scale900,
-  }),
-  jsonPanel: () => ({
-    minWidth: 0,
-  }),
-} satisfies StyletronCSSObject;
-
-export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =
-  cssStylesObj;
+  })),
+};

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -3,15 +3,18 @@ import React from 'react';
 
 import PageSection from '@/components/page-section/page-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
 
 import scheduleDetailsSectionsConfig from './config/schedule-details-sections.config';
 import { getRowsFromConfig } from './helpers/get-rows-from-config';
+import ScheduleDetailsInputJson from './schedule-details-input-json/schedule-details-input-json';
 import ScheduleDetailsSection from './schedule-details-section/schedule-details-section';
-import { styled } from './schedule-details.styles';
+import { cssStyles } from './schedule-details.styles';
 import { type Props } from './schedule-details.types';
 
 export default function ScheduleDetails({ params }: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
   const { data, isLoading, isPending } = useDescribeSchedule({
     domain: params.domain,
     cluster: params.cluster,
@@ -30,26 +33,35 @@ export default function ScheduleDetails({ params }: Props) {
 
   return (
     <PageSection>
-      <styled.DetailsSectionsContainer>
-        {scheduleDetailsSectionsConfig.map((section) => {
-          const rows = getRowsFromConfig(
-            section.rowsConfig,
-            data,
-            params.scheduleId
-          );
-          if (!rows.length) {
-            return null;
-          }
+      <div className={cls.pageContainer}>
+        <div className={cls.mainContent}>
+          {scheduleDetailsSectionsConfig.map((section) => {
+            const rows = getRowsFromConfig(
+              section.rowsConfig,
+              data,
+              params.scheduleId
+            );
+            if (!rows.length) {
+              return null;
+            }
 
-          return (
-            <ScheduleDetailsSection
-              key={section.key}
-              title={section.title}
-              rows={rows}
-            />
-          );
-        })}
-      </styled.DetailsSectionsContainer>
+            return (
+              <ScheduleDetailsSection
+                key={section.key}
+                title={section.title}
+                rows={rows}
+              />
+            );
+          })}
+        </div>
+        <div className={cls.jsonPanel}>
+          <ScheduleDetailsInputJson
+            input={data.action?.startWorkflow?.input}
+            domain={params.domain}
+            cluster={params.cluster}
+          />
+        </div>
+      </div>
     </PageSection>
   );
 }

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -3,18 +3,16 @@ import React from 'react';
 
 import PageSection from '@/components/page-section/page-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
-import useStyletronClasses from '@/hooks/use-styletron-classes';
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
 
 import scheduleDetailsSectionsConfig from './config/schedule-details-sections.config';
 import { getRowsFromConfig } from './helpers/get-rows-from-config';
 import ScheduleDetailsInputJson from './schedule-details-input-json/schedule-details-input-json';
 import ScheduleDetailsSection from './schedule-details-section/schedule-details-section';
-import { cssStyles } from './schedule-details.styles';
+import { styled } from './schedule-details.styles';
 import { type Props } from './schedule-details.types';
 
 export default function ScheduleDetails({ params }: Props) {
-  const { cls } = useStyletronClasses(cssStyles);
   const { data, isLoading, isPending } = useDescribeSchedule({
     domain: params.domain,
     cluster: params.cluster,
@@ -33,8 +31,8 @@ export default function ScheduleDetails({ params }: Props) {
 
   return (
     <PageSection>
-      <div className={cls.pageContainer}>
-        <div className={cls.mainContent}>
+      <styled.PageContainer>
+        <styled.DetailsSectionsContainer>
           {scheduleDetailsSectionsConfig.map((section) => {
             const rows = getRowsFromConfig(
               section.rowsConfig,
@@ -53,11 +51,11 @@ export default function ScheduleDetails({ params }: Props) {
               />
             );
           })}
-        </div>
-        <div className={cls.jsonPanel}>
+        </styled.DetailsSectionsContainer>
+        <styled.JsonPanel>
           <ScheduleDetailsInputJson input={data.action?.startWorkflow?.input} />
-        </div>
-      </div>
+        </styled.JsonPanel>
+      </styled.PageContainer>
     </PageSection>
   );
 }

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -55,11 +55,7 @@ export default function ScheduleDetails({ params }: Props) {
           })}
         </div>
         <div className={cls.jsonPanel}>
-          <ScheduleDetailsInputJson
-            input={data.action?.startWorkflow?.input}
-            domain={params.domain}
-            cluster={params.cluster}
-          />
+          <ScheduleDetailsInputJson input={data.action?.startWorkflow?.input} />
         </div>
       </div>
     </PageSection>


### PR DESCRIPTION
## Summary
- Add **Schedule input** section on the schedule details tab that decodes `action.startWorkflow.input` from describe and renders it with `PrettyJson`.
- Include copy-to-clipboard support

## Test plan

<img width="1671" height="478" alt="Screenshot 2026-06-26 at 02 45 52" src="https://github.com/user-attachments/assets/d3400dee-ff36-4977-a018-36d8bd7d7b6d" />
<img width="1676" height="565" alt="Screenshot 2026-06-26 at 02 46 07" src="https://github.com/user-attachments/assets/a6376b3a-87a6-4652-a53c-37663962f521" />
<img width="564" height="586" alt="Screenshot 2026-06-26 at 17 42 02" src="https://github.com/user-attachments/assets/cf68c6fd-fa4c-4cf7-b09b-49d18528d46e" />

## Feature plans
- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- [x] Schedules Create Form
- Schedules Details
   -  #1345
   -  #1353
   - #1346
   - #1348
   - #1349
   - #1368
   - #1413
   - #1375
- Schedules Actions
