### PR TITLE
chore: Upgrade node to 24 (latest LTS version)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v2
+    env:
+      npm_config_min_release_age: '14'
 
+    steps:
+    - uses: actions/checkout@v4
     - name: Use Node.js
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '24'
 
     # Cache node_modules keyed to the exact lockfile — skips npm ci on cache hit
     - name: Cache node_modules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    env:
-      npm_config_min_release_age: '14'
-
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:18-bookworm-slim  AS base
+FROM node:24-bookworm-slim  AS base
+ENV npm_config_min_release_age=14
 
 FROM base AS dev
 # Install git + CA bundle so git https can verify TLS

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM node:24-bookworm-slim  AS base
-ENV npm_config_min_release_age=14
 
 FROM base AS dev
 # Install git + CA bundle so git https can verify TLS
@@ -7,6 +6,9 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
+# Supply-chain cooldown: only effective where the lockfile is generated
+# (npm install), i.e. local dev inside this container. No-op for npm ci.
+ENV npm_config_min_release_age=14
 COPY . .
 
 
@@ -17,7 +19,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --maxsockets 1000
 RUN npm run install-idl
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends git ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 COPY package.json package-lock.json ./
-RUN npm ci --maxsockets 1000
+RUN npm ci
 RUN npm run install-idl
 COPY . .
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "@types/eslint__js": "^8.42.3",
         "@types/jest": "^29.5.14",
         "@types/lodash": "^4.14.202",
-        "@types/node": "^20.11.17",
+        "@types/node": "^24.13.2",
         "@types/react": "^18.2.57",
         "@types/react-dom": "^18.2.19",
         "@typescript-eslint/parser": "^7.18.0",
@@ -93,8 +93,8 @@
         "undici": "^6.24.0"
       },
       "engines": {
-        "node": ">=18.19.0",
-        "npm": ">=9.6.7"
+        "node": ">=24.0.0",
+        "npm": ">=11.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3624,11 +3624,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.10.tgz",
-      "integrity": "sha512-MdiXf+nDuMvY0gJKxyfZ7/6UFsETO7mGKF54MVD/ekJS6HdFtpZFBgrh6Pseu64XTb2MLyFPlbW6hj8HYRQNOQ==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -7751,6 +7752,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8176,6 +8178,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -14356,9 +14359,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test:types": "tstyche"
   },
   "engines": {
-    "node": ">=18.19.0",
-    "npm": ">=9.6.7"
+    "node": ">=24.0.0",
+    "npm": ">=11.10.0"
   },
   "dependencies": {
     "@grpc/grpc-js": "^1.14.4",
@@ -85,7 +85,7 @@
     "@types/eslint__js": "^8.42.3",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.14.202",
-    "@types/node": "^20.11.17",
+    "@types/node": "^24.13.2",
     "@types/react": "^18.2.57",
     "@types/react-dom": "^18.2.19",
     "@typescript-eslint/parser": "^7.18.0",


### PR DESCRIPTION
## Summary
- Upgrade node to 24 ([latest LTS](https://nodejs.org/en/about/previous-releases))
- Upgrade npm to 11.10.0, which adds support for configuring `min-release-age`
- Set `npm_config_min_release_age` inside dev Docker container so that new package installs do not add packages newer than 14 days

## Test plan
`npm run dev` + created and ran a prod Docker build.
```
> docker build -t cadence-web .

> docker-compose -f docker-compose-backend-services.yml up

> docker run -d --name cadence-web -p 8088:8088 \
  --network web-fork_default \
  -e CADENCE_GRPC_PEERS=cadence:7833 \
  cadence-web
```