### PR TITLE
feat(batch-actions): deep-link to a batch action not in the loaded list

### DIFF
--- a/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
+++ b/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
@@ -29,7 +29,13 @@ export const mockDescribeBatchOperationWorkflowRunning: DescribeWorkflowExecutio
       parentExecutionInfo: null,
       executionTime: { seconds: '1717408150', nanos: 0 },
       memo: null,
-      searchAttributes: null,
+      searchAttributes: {
+        indexedFields: {
+          CustomDomain: {
+            data: Buffer.from(JSON.stringify('mock-domain')).toString('base64'),
+          },
+        },
+      },
       autoResetPoints: null,
       taskList: 'cadence-sys-batcher-tasklist',
       isCron: false,
@@ -89,6 +95,25 @@ export const mockDescribeNonBatchWorkflow: DescribeWorkflowExecutionResponse = {
     type: { name: 'some-other-workflow-type' },
   },
 };
+
+// A batch action that belongs to a different domain than the request — should be
+// treated as not found so one domain can't view another's batch actions.
+export const mockDescribeBatchOperationWorkflowOtherDomain: DescribeWorkflowExecutionResponse =
+  {
+    ...mockDescribeBatchOperationWorkflowRunning,
+    workflowExecutionInfo: {
+      ...mockDescribeBatchOperationWorkflowRunning.workflowExecutionInfo!,
+      searchAttributes: {
+        indexedFields: {
+          CustomDomain: {
+            data: Buffer.from(JSON.stringify('other-domain')).toString(
+              'base64'
+            ),
+          },
+        },
+      },
+    },
+  };
 
 const encodedBatcherInput = (params: Record<string, unknown>) =>
   Buffer.from(JSON.stringify(params)).toString('base64');

--- a/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
+++ b/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
@@ -80,6 +80,16 @@ export const mockDescribeBatchOperationWorkflowFailed: DescribeWorkflowExecution
     },
   };
 
+// A workflow that exists but is not a batch action (e.g. a deep link to some
+// other workflow's runId) — the describe handler should treat it as not found.
+export const mockDescribeNonBatchWorkflow: DescribeWorkflowExecutionResponse = {
+  ...mockDescribeBatchOperationWorkflowRunning,
+  workflowExecutionInfo: {
+    ...mockDescribeBatchOperationWorkflowRunning.workflowExecutionInfo!,
+    type: { name: 'some-other-workflow-type' },
+  },
+};
+
 const encodedBatcherInput = (params: Record<string, unknown>) =>
   Buffer.from(JSON.stringify(params)).toString('base64');
 

--- a/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
+++ b/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
@@ -16,6 +16,7 @@ import {
   mockDescribeBatchOperationWorkflowFailedWithPendingProgress,
   mockDescribeBatchOperationWorkflowRunning,
   mockDescribeBatchOperationWorkflowTerminated,
+  mockDescribeBatchOperationWorkflowOtherDomain,
   mockDescribeNonBatchWorkflow,
   MOCK_BATCH_PROGRESS,
 } from '../__fixtures__/mock-describe-batch-operation-workflow';
@@ -274,6 +275,17 @@ describe(describeBatchAction.name, () => {
   it('returns 404 when the workflow is not a batch action', async () => {
     const { res } = await setup({
       describeResponse: mockDescribeNonBatchWorkflow,
+    });
+
+    expect(res.status).toEqual(404);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({ message: 'Batch action not found' })
+    );
+  });
+
+  it('returns 404 when the batch action belongs to a different domain', async () => {
+    const { res } = await setup({
+      describeResponse: mockDescribeBatchOperationWorkflowOtherDomain,
     });
 
     expect(res.status).toEqual(404);

--- a/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
+++ b/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
@@ -16,6 +16,7 @@ import {
   mockDescribeBatchOperationWorkflowFailedWithPendingProgress,
   mockDescribeBatchOperationWorkflowRunning,
   mockDescribeBatchOperationWorkflowTerminated,
+  mockDescribeNonBatchWorkflow,
   MOCK_BATCH_PROGRESS,
 } from '../__fixtures__/mock-describe-batch-operation-workflow';
 import { describeBatchAction } from '../describe-batch-action';
@@ -267,6 +268,17 @@ describe(describeBatchAction.name, () => {
         error: expect.any(Error),
       }),
       'Error fetching batch action'
+    );
+  });
+
+  it('returns 404 when the workflow is not a batch action', async () => {
+    const { res } = await setup({
+      describeResponse: mockDescribeNonBatchWorkflow,
+    });
+
+    expect(res.status).toEqual(404);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({ message: 'Batch action not found' })
     );
   });
 

--- a/src/route-handlers/describe-batch-action/describe-batch-action.ts
+++ b/src/route-handlers/describe-batch-action/describe-batch-action.ts
@@ -42,7 +42,10 @@ export async function describeBatchAction(
       }),
     ]);
 
-    const detail = getBatchActionDetailFromWorkflow(describeResponse);
+    const detail = getBatchActionDetailFromWorkflow(
+      describeResponse,
+      params.domain
+    );
     if (!detail) {
       return NextResponse.json(
         { message: 'Batch action not found' },

--- a/src/route-handlers/describe-batch-action/helpers/get-batch-action-detail-from-workflow.ts
+++ b/src/route-handlers/describe-batch-action/helpers/get-batch-action-detail-from-workflow.ts
@@ -1,21 +1,30 @@
 import { type DescribeWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeWorkflowExecutionResponse';
 import {
+  BATCH_ACTION_DOMAIN_SEARCH_ATTRIBUTE,
   BATCH_ACTION_STATUS_BY_CLOSE_STATUS,
   BATCH_ACTION_WORKFLOW_TYPE,
 } from '@/route-handlers/list-batch-actions/list-batch-actions.constants';
+import formatPayload from '@/utils/data-formatters/format-payload';
 import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 import { type BatchAction } from '@/views/domain-batch-actions/domain-batch-actions.types';
 
 export default function getBatchActionDetailFromWorkflow(
-  response: DescribeWorkflowExecutionResponse
+  response: DescribeWorkflowExecutionResponse,
+  expectedDomain: string
 ): BatchAction | undefined {
   const info = response.workflowExecutionInfo;
-  // Reject executions that aren't batch actions (e.g. a deep link to a random
-  // workflow's runId), so the handler surfaces a "not found" instead of
-  // rendering an unrelated workflow as a batch action.
+  // Reject anything that isn't a batch action for this domain — a deep link to a
+  // random workflow's runId, or to another domain's batch action — so the handler
+  // surfaces a "not found".
+  const customDomain = formatPayload(
+    info?.searchAttributes?.indexedFields?.[
+      BATCH_ACTION_DOMAIN_SEARCH_ATTRIBUTE
+    ]
+  );
   if (
     !info?.workflowExecution?.runId ||
-    info.type?.name !== BATCH_ACTION_WORKFLOW_TYPE
+    info.type?.name !== BATCH_ACTION_WORKFLOW_TYPE ||
+    customDomain !== expectedDomain
   ) {
     return undefined;
   }

--- a/src/route-handlers/describe-batch-action/helpers/get-batch-action-detail-from-workflow.ts
+++ b/src/route-handlers/describe-batch-action/helpers/get-batch-action-detail-from-workflow.ts
@@ -1,5 +1,8 @@
 import { type DescribeWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeWorkflowExecutionResponse';
-import { BATCH_ACTION_STATUS_BY_CLOSE_STATUS } from '@/route-handlers/list-batch-actions/list-batch-actions.constants';
+import {
+  BATCH_ACTION_STATUS_BY_CLOSE_STATUS,
+  BATCH_ACTION_WORKFLOW_TYPE,
+} from '@/route-handlers/list-batch-actions/list-batch-actions.constants';
 import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 import { type BatchAction } from '@/views/domain-batch-actions/domain-batch-actions.types';
 
@@ -7,7 +10,13 @@ export default function getBatchActionDetailFromWorkflow(
   response: DescribeWorkflowExecutionResponse
 ): BatchAction | undefined {
   const info = response.workflowExecutionInfo;
-  if (!info?.workflowExecution?.runId) {
+  // Reject executions that aren't batch actions (e.g. a deep link to a random
+  // workflow's runId), so the handler surfaces a "not found" instead of
+  // rendering an unrelated workflow as a batch action.
+  if (
+    !info?.workflowExecution?.runId ||
+    info.type?.name !== BATCH_ACTION_WORKFLOW_TYPE
+  ) {
     return undefined;
   }
 

--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -75,7 +75,7 @@ jest.mock(
         <button onClick={onSelectDraft}>mock-select-draft</button>
         <button onClick={fetchNextPage}>mock-fetch-next-page</button>
         {batchActions.map((a) => (
-          <button key={a.runId} onClick={() => onSelectAction(a.runId)}>
+          <button key={a.runId} onClick={() => onSelectAction(a)}>
             mock-select-{a.runId}
           </button>
         ))}
@@ -120,7 +120,10 @@ describe(DomainBatchActions.name, () => {
 
     await user.click(await screen.findByText('mock-select-4'));
 
-    expect(mockSetQueryParams).toHaveBeenCalledWith({ batchActionId: '4' });
+    expect(mockSetQueryParams).toHaveBeenCalledWith({
+      batchActionId: '4',
+      batchActionWorkflowId: 'wf-4',
+    });
   });
 
   it('resets all batch draft params and prefills the query when "New batch action" is clicked', async () => {
@@ -191,6 +194,77 @@ describe(DomainBatchActions.name, () => {
     expect(
       screen.queryByText('mock-batch-action-detail-5')
     ).not.toBeInTheDocument();
+  });
+
+  it('loads the detail for a deep-linked action that is not in the sidebar list', async () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        batchActionId: 'run-999',
+        batchActionWorkflowId: 'wf-999',
+        batchQuery: '',
+      },
+      mockSetQueryParams,
+    ]);
+
+    setup();
+
+    // run-999 is not among the loaded sidebar items (5, 4) but the detail still
+    // loads, because the workflowId comes from the URL, not the list.
+    expect(
+      await screen.findByText('mock-batch-action-detail-run-999')
+    ).toBeInTheDocument();
+  });
+
+  it('shows a not-found panel and clears the selection when describe returns 404', async () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        batchActionId: 'run-999',
+        batchActionWorkflowId: 'wf-999',
+        batchQuery: '',
+      },
+      mockSetQueryParams,
+    ]);
+
+    const user = userEvent.setup();
+
+    setup({
+      detailResolver: () =>
+        HttpResponse.json(
+          { message: 'Batch action not found' },
+          { status: 404 }
+        ),
+    });
+
+    expect(
+      await screen.findByText('mock-error-panel-Batch action not found')
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByText('View batch actions'));
+
+    expect(mockSetQueryParams).toHaveBeenCalledWith({
+      batchActionId: undefined,
+      batchActionWorkflowId: undefined,
+    });
+  });
+
+  it('shows a not-found panel when the URL has a runId with no workflowId and it is not in the list', async () => {
+    mockUsePageQueryParams.mockReturnValue([
+      {
+        ...mockDomainPageQueryParamsValues,
+        batchActionId: 'run-999',
+        batchActionWorkflowId: undefined,
+        batchQuery: '',
+      },
+      mockSetQueryParams,
+    ]);
+
+    setup();
+
+    expect(
+      await screen.findByText('mock-error-panel-Batch action not found')
+    ).toBeInTheDocument();
   });
 
   it('sets batchActionId to draft when selecting the draft sidebar item', async () => {

--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -181,6 +181,7 @@ describe(DomainBatchActions.name, () => {
       {
         ...mockDomainPageQueryParamsValues,
         batchActionId: '4',
+        batchActionWorkflowId: 'wf-4',
         batchQuery: '',
       },
       mockSetQueryParams,
@@ -249,7 +250,7 @@ describe(DomainBatchActions.name, () => {
     });
   });
 
-  it('shows a not-found panel when the URL has a runId with no workflowId and it is not in the list', async () => {
+  it('shows a not-found panel when the URL has only one of runId / workflowId', async () => {
     mockUsePageQueryParams.mockReturnValue([
       {
         ...mockDomainPageQueryParamsValues,

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/__tests__/domain-batch-actions-sidebar.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/__tests__/domain-batch-actions-sidebar.test.tsx
@@ -54,7 +54,7 @@ function setup({
   isDraftOpen?: boolean;
   isDraftSelected?: boolean;
   selectedActionId?: string | null;
-  onSelectAction?: (id: string) => void;
+  onSelectAction?: (action: BatchActionListItem) => void;
   onSelectDraft?: () => void;
   onCreateNew?: () => void;
   fetchNextPage?: () => void;
@@ -116,12 +116,16 @@ describe(DomainBatchActionsSidebar.name, () => {
     expect(screen.getByText('Warning Icon')).toBeInTheDocument();
   });
 
-  it('calls onSelectAction with the action id when a batch action is clicked', async () => {
+  it('calls onSelectAction with the action when a batch action is clicked', async () => {
     const { user, onSelectAction } = setup();
 
     await user.click(screen.getByText('2'));
 
-    expect(onSelectAction).toHaveBeenCalledWith('2');
+    expect(onSelectAction).toHaveBeenCalledWith({
+      workflowId: 'wf-2',
+      runId: '2',
+      status: 'ABORTED',
+    });
   });
 
   it('calls onCreateNew when the new batch action button is clicked', async () => {

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
@@ -62,7 +62,7 @@ export default function DomainBatchActionsSidebar({
               icon={<StatusIcon action={action} />}
               isSelected={isSelected}
               isActive={action.status === 'RUNNING' || isSelected}
-              onSelect={() => onSelectAction(action.runId)}
+              onSelect={() => onSelectAction(action)}
             />
           );
         })}

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.types.ts
@@ -5,7 +5,7 @@ export type Props = {
   isDraftOpen: boolean;
   isDraftSelected: boolean;
   selectedActionId: string | null;
-  onSelectAction: (id: string) => void;
+  onSelectAction: (action: BatchActionListItem) => void;
   onSelectDraft: () => void;
   onCreateNew: () => void;
   fetchNextPage: () => void;

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -7,6 +7,7 @@ import { MdErrorOutline } from 'react-icons/md';
 import ErrorPanel from '@/components/error-panel/error-panel';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
+import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
 import domainPageQueryParamsConfig from '@/views/domain-page/config/domain-page-query-params.config';
 import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-content/domain-page-content.types';
 import useDescribeBatchAction from '@/views/shared/hooks/use-describe-batch-action/use-describe-batch-action';
@@ -24,6 +25,7 @@ import {
   DRAFT_ACTION_ID,
 } from './domain-batch-actions.constants';
 import { styled } from './domain-batch-actions.styles';
+import resolveSelectedBatchAction from './helpers/resolve-selected-batch-action';
 
 export default function DomainBatchActions(props: DomainPageTabContentProps) {
   const [queryParams, setQueryParams] = usePageQueryParams(
@@ -67,15 +69,12 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
     [data]
   );
 
-  // Default to the first action in the list unless a real (non-draft) action is selected.
-  // selectedActionId is a runId (the URL identity); the matching list item also
-  // carries the workflowId that the describe endpoint requires.
-  const firstBatchActionId = batchActions[0]?.runId ?? null;
-  const selectedActionId = isDraftSelected
-    ? firstBatchActionId
-    : queryParams.batchActionId || firstBatchActionId;
-  const selectedAction =
-    batchActions.find((action) => action.runId === selectedActionId) ?? null;
+  const { selectedActionId, selectedWorkflowId } = resolveSelectedBatchAction({
+    batchActions,
+    batchActionId: queryParams.batchActionId,
+    batchActionWorkflowId: queryParams.batchActionWorkflowId,
+    isDraftSelected,
+  });
 
   const {
     data: batchActionDetail,
@@ -85,14 +84,22 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
   } = useDescribeBatchAction({
     domain: props.domain,
     cluster: props.cluster,
-    workflowId: selectedAction?.workflowId ?? '',
-    runId: selectedAction?.runId ?? '',
-    enabled: !isDraftSelected && !!selectedAction,
+    workflowId: selectedWorkflowId ?? '',
+    runId: selectedActionId ?? '',
+    enabled: !isDraftSelected && !!selectedActionId && !!selectedWorkflowId,
     refetchInterval: (query) =>
       query.state.data?.status === 'RUNNING'
         ? BATCH_ACTION_DETAIL_REFETCH_INTERVAL
         : false,
   });
+
+  // The selected action can't be loaded: either we have no workflowId to
+  // describe it with (deep link to a runId not in the list and no workflowId in
+  // the URL), or describe reported it isn't a batch action / doesn't exist.
+  const isSelectedActionNotFound =
+    !isDraftSelected &&
+    !!selectedActionId &&
+    (!selectedWorkflowId || batchActionDetailError?.status === 404);
 
   if (isLoading) {
     return <SectionLoadingIndicator />;
@@ -111,8 +118,18 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
     });
   };
 
-  const handleSelectAction = (id: string) => {
-    setQueryParams({ batchActionId: id });
+  const handleSelectAction = (action: BatchActionListItem) => {
+    setQueryParams({
+      batchActionId: action.runId,
+      batchActionWorkflowId: action.workflowId,
+    });
+  };
+
+  const handleClearSelectedAction = () => {
+    setQueryParams({
+      batchActionId: undefined,
+      batchActionWorkflowId: undefined,
+    });
   };
 
   const handleSelectDraft = () => {
@@ -163,7 +180,19 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
         )}
         {!isDraftSelected &&
           selectedActionId &&
-          (batchActionDetailError && !batchActionDetail ? (
+          (isSelectedActionNotFound ? (
+            <ErrorPanel
+              message="Batch action not found"
+              description="This batch action does not exist or is no longer available."
+              actions={[
+                {
+                  kind: 'callback',
+                  label: 'View batch actions',
+                  onClick: handleClearSelectedAction,
+                },
+              ]}
+            />
+          ) : batchActionDetailError && !batchActionDetail ? (
             <ErrorPanel
               error={batchActionDetailError}
               message="Failed to load batch action details"

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -93,13 +93,20 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
         : false,
   });
 
-  // The selected action can't be loaded: either we have no workflowId to
-  // describe it with (deep link to a runId not in the list and no workflowId in
-  // the URL), or describe reported it isn't a batch action / doesn't exist.
+  // The URL carries only one of the two required ids, so no action could be
+  // resolved (see resolveSelectedBatchAction).
+  const isInvalidSelection =
+    !isDraftSelected &&
+    !selectedActionId &&
+    (Boolean(queryParams.batchActionId) ||
+      Boolean(queryParams.batchActionWorkflowId));
+
+  // The selection can't be shown: it's an invalid URL pair, or describe
+  // reported the action isn't a batch action / doesn't exist.
   const isSelectedActionNotFound =
     !isDraftSelected &&
-    !!selectedActionId &&
-    (!selectedWorkflowId || batchActionDetailError?.status === 404);
+    (isInvalidSelection ||
+      (!!selectedActionId && batchActionDetailError?.status === 404));
 
   if (isLoading) {
     return <SectionLoadingIndicator />;
@@ -179,7 +186,7 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
           />
         )}
         {!isDraftSelected &&
-          selectedActionId &&
+          (selectedActionId || isInvalidSelection) &&
           (isSelectedActionNotFound ? (
             <ErrorPanel
               message="Batch action not found"

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -73,7 +73,6 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
     batchActions,
     batchActionId: queryParams.batchActionId,
     batchActionWorkflowId: queryParams.batchActionWorkflowId,
-    isDraftSelected,
   });
 
   const {

--- a/src/views/domain-batch-actions/helpers/__tests__/resolve-selected-batch-action.test.ts
+++ b/src/views/domain-batch-actions/helpers/__tests__/resolve-selected-batch-action.test.ts
@@ -1,0 +1,76 @@
+import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+
+import resolveSelectedBatchAction from '../resolve-selected-batch-action';
+
+const ACTIONS: BatchActionListItem[] = [
+  { workflowId: 'wf-1', runId: 'run-1', status: 'RUNNING' },
+  { workflowId: 'wf-2', runId: 'run-2', status: 'COMPLETED' },
+];
+
+describe(resolveSelectedBatchAction.name, () => {
+  it('defaults to the first action when nothing is selected', () => {
+    expect(
+      resolveSelectedBatchAction({
+        batchActions: ACTIONS,
+        batchActionId: undefined,
+        batchActionWorkflowId: undefined,
+        isDraftSelected: false,
+      })
+    ).toEqual({ selectedActionId: 'run-1', selectedWorkflowId: 'wf-1' });
+  });
+
+  it('selects the URL action and reads its workflowId from the list', () => {
+    expect(
+      resolveSelectedBatchAction({
+        batchActions: ACTIONS,
+        batchActionId: 'run-2',
+        batchActionWorkflowId: undefined,
+        isDraftSelected: false,
+      })
+    ).toEqual({ selectedActionId: 'run-2', selectedWorkflowId: 'wf-2' });
+  });
+
+  it('uses the workflowId from the URL for an action not in the list (deep link)', () => {
+    expect(
+      resolveSelectedBatchAction({
+        batchActions: ACTIONS,
+        batchActionId: 'run-999',
+        batchActionWorkflowId: 'wf-999',
+        isDraftSelected: false,
+      })
+    ).toEqual({ selectedActionId: 'run-999', selectedWorkflowId: 'wf-999' });
+  });
+
+  it('returns a null workflowId when the action is not in the list and the URL omits it', () => {
+    expect(
+      resolveSelectedBatchAction({
+        batchActions: ACTIONS,
+        batchActionId: 'run-999',
+        batchActionWorkflowId: undefined,
+        isDraftSelected: false,
+      })
+    ).toEqual({ selectedActionId: 'run-999', selectedWorkflowId: null });
+  });
+
+  it('tracks the first action while a draft is selected', () => {
+    expect(
+      resolveSelectedBatchAction({
+        batchActions: ACTIONS,
+        batchActionId: 'draft',
+        batchActionWorkflowId: undefined,
+        isDraftSelected: true,
+      })
+    ).toEqual({ selectedActionId: 'run-1', selectedWorkflowId: 'wf-1' });
+  });
+
+  it('returns nulls for an empty list', () => {
+    expect(
+      resolveSelectedBatchAction({
+        batchActions: [],
+        batchActionId: undefined,
+        batchActionWorkflowId: undefined,
+        isDraftSelected: false,
+      })
+    ).toEqual({ selectedActionId: null, selectedWorkflowId: null });
+  });
+});

--- a/src/views/domain-batch-actions/helpers/__tests__/resolve-selected-batch-action.test.ts
+++ b/src/views/domain-batch-actions/helpers/__tests__/resolve-selected-batch-action.test.ts
@@ -19,18 +19,7 @@ describe(resolveSelectedBatchAction.name, () => {
     ).toEqual({ selectedActionId: 'run-1', selectedWorkflowId: 'wf-1' });
   });
 
-  it('selects the URL action and reads its workflowId from the list', () => {
-    expect(
-      resolveSelectedBatchAction({
-        batchActions: ACTIONS,
-        batchActionId: 'run-2',
-        batchActionWorkflowId: undefined,
-        isDraftSelected: false,
-      })
-    ).toEqual({ selectedActionId: 'run-2', selectedWorkflowId: 'wf-2' });
-  });
-
-  it('uses the workflowId from the URL for an action not in the list (deep link)', () => {
+  it('selects the runId + workflowId pair from the URL (deep link)', () => {
     expect(
       resolveSelectedBatchAction({
         batchActions: ACTIONS,
@@ -41,15 +30,26 @@ describe(resolveSelectedBatchAction.name, () => {
     ).toEqual({ selectedActionId: 'run-999', selectedWorkflowId: 'wf-999' });
   });
 
-  it('returns a null workflowId when the action is not in the list and the URL omits it', () => {
+  it('resolves to nothing when the URL has a runId but no workflowId', () => {
     expect(
       resolveSelectedBatchAction({
         batchActions: ACTIONS,
-        batchActionId: 'run-999',
+        batchActionId: 'run-2',
         batchActionWorkflowId: undefined,
         isDraftSelected: false,
       })
-    ).toEqual({ selectedActionId: 'run-999', selectedWorkflowId: null });
+    ).toEqual({ selectedActionId: null, selectedWorkflowId: null });
+  });
+
+  it('resolves to nothing when the URL has a workflowId but no runId', () => {
+    expect(
+      resolveSelectedBatchAction({
+        batchActions: ACTIONS,
+        batchActionId: undefined,
+        batchActionWorkflowId: 'wf-999',
+        isDraftSelected: false,
+      })
+    ).toEqual({ selectedActionId: null, selectedWorkflowId: null });
   });
 
   it('tracks the first action while a draft is selected', () => {

--- a/src/views/domain-batch-actions/helpers/__tests__/resolve-selected-batch-action.test.ts
+++ b/src/views/domain-batch-actions/helpers/__tests__/resolve-selected-batch-action.test.ts
@@ -14,7 +14,6 @@ describe(resolveSelectedBatchAction.name, () => {
         batchActions: ACTIONS,
         batchActionId: undefined,
         batchActionWorkflowId: undefined,
-        isDraftSelected: false,
       })
     ).toEqual({ selectedActionId: 'run-1', selectedWorkflowId: 'wf-1' });
   });
@@ -25,7 +24,6 @@ describe(resolveSelectedBatchAction.name, () => {
         batchActions: ACTIONS,
         batchActionId: 'run-999',
         batchActionWorkflowId: 'wf-999',
-        isDraftSelected: false,
       })
     ).toEqual({ selectedActionId: 'run-999', selectedWorkflowId: 'wf-999' });
   });
@@ -36,7 +34,6 @@ describe(resolveSelectedBatchAction.name, () => {
         batchActions: ACTIONS,
         batchActionId: 'run-2',
         batchActionWorkflowId: undefined,
-        isDraftSelected: false,
       })
     ).toEqual({ selectedActionId: null, selectedWorkflowId: null });
   });
@@ -47,20 +44,8 @@ describe(resolveSelectedBatchAction.name, () => {
         batchActions: ACTIONS,
         batchActionId: undefined,
         batchActionWorkflowId: 'wf-999',
-        isDraftSelected: false,
       })
     ).toEqual({ selectedActionId: null, selectedWorkflowId: null });
-  });
-
-  it('tracks the first action while a draft is selected', () => {
-    expect(
-      resolveSelectedBatchAction({
-        batchActions: ACTIONS,
-        batchActionId: 'draft',
-        batchActionWorkflowId: undefined,
-        isDraftSelected: true,
-      })
-    ).toEqual({ selectedActionId: 'run-1', selectedWorkflowId: 'wf-1' });
   });
 
   it('returns nulls for an empty list', () => {
@@ -69,7 +54,6 @@ describe(resolveSelectedBatchAction.name, () => {
         batchActions: [],
         batchActionId: undefined,
         batchActionWorkflowId: undefined,
-        isDraftSelected: false,
       })
     ).toEqual({ selectedActionId: null, selectedWorkflowId: null });
   });

--- a/src/views/domain-batch-actions/helpers/resolve-selected-batch-action.ts
+++ b/src/views/domain-batch-actions/helpers/resolve-selected-batch-action.ts
@@ -1,10 +1,13 @@
 import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
 
 /**
- * Resolves which batch action the detail panel should show, from the URL params
- * and the loaded list. The action is identified by its runId (the URL identity),
- * defaulting to the first loaded action. describe also needs the workflowId:
- * it comes from the URL (deep links carry it), or from the matching list item.
+ * Resolves which batch action the detail panel should show. A URL selection is
+ * the (runId, workflowId) pair carried together by batchActionId +
+ * batchActionWorkflowId:
+ * - both ids present → that action;
+ * - exactly one id present → invalid selection, resolves to nothing so the view
+ *   can show an error instead of the wrong action;
+ * - neither present → default to the first loaded action.
  */
 export default function resolveSelectedBatchAction({
   batchActions,
@@ -17,16 +20,18 @@ export default function resolveSelectedBatchAction({
   batchActionWorkflowId: string | undefined;
   isDraftSelected: boolean;
 }): { selectedActionId: string | null; selectedWorkflowId: string | null } {
-  const firstActionId = batchActions[0]?.runId ?? null;
-  const selectedActionId = isDraftSelected
-    ? firstActionId
-    : batchActionId || firstActionId;
+  if (!isDraftSelected && (batchActionId || batchActionWorkflowId)) {
+    return batchActionId && batchActionWorkflowId
+      ? {
+          selectedActionId: batchActionId,
+          selectedWorkflowId: batchActionWorkflowId,
+        }
+      : { selectedActionId: null, selectedWorkflowId: null };
+  }
 
-  const selectedWorkflowId =
-    batchActionWorkflowId ||
-    batchActions.find((action) => action.runId === selectedActionId)
-      ?.workflowId ||
-    null;
-
-  return { selectedActionId, selectedWorkflowId };
+  const firstAction = batchActions[0];
+  return {
+    selectedActionId: firstAction?.runId ?? null,
+    selectedWorkflowId: firstAction?.workflowId ?? null,
+  };
 }

--- a/src/views/domain-batch-actions/helpers/resolve-selected-batch-action.ts
+++ b/src/views/domain-batch-actions/helpers/resolve-selected-batch-action.ts
@@ -13,14 +13,12 @@ export default function resolveSelectedBatchAction({
   batchActions,
   batchActionId,
   batchActionWorkflowId,
-  isDraftSelected,
 }: {
   batchActions: BatchActionListItem[];
   batchActionId: string | undefined;
   batchActionWorkflowId: string | undefined;
-  isDraftSelected: boolean;
 }): { selectedActionId: string | null; selectedWorkflowId: string | null } {
-  if (!isDraftSelected && (batchActionId || batchActionWorkflowId)) {
+  if (batchActionId || batchActionWorkflowId) {
     return batchActionId && batchActionWorkflowId
       ? {
           selectedActionId: batchActionId,

--- a/src/views/domain-batch-actions/helpers/resolve-selected-batch-action.ts
+++ b/src/views/domain-batch-actions/helpers/resolve-selected-batch-action.ts
@@ -1,0 +1,32 @@
+import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+
+/**
+ * Resolves which batch action the detail panel should show, from the URL params
+ * and the loaded list. The action is identified by its runId (the URL identity),
+ * defaulting to the first loaded action. describe also needs the workflowId:
+ * it comes from the URL (deep links carry it), or from the matching list item.
+ */
+export default function resolveSelectedBatchAction({
+  batchActions,
+  batchActionId,
+  batchActionWorkflowId,
+  isDraftSelected,
+}: {
+  batchActions: BatchActionListItem[];
+  batchActionId: string | undefined;
+  batchActionWorkflowId: string | undefined;
+  isDraftSelected: boolean;
+}): { selectedActionId: string | null; selectedWorkflowId: string | null } {
+  const firstActionId = batchActions[0]?.runId ?? null;
+  const selectedActionId = isDraftSelected
+    ? firstActionId
+    : batchActionId || firstActionId;
+
+  const selectedWorkflowId =
+    batchActionWorkflowId ||
+    batchActions.find((action) => action.runId === selectedActionId)
+      ?.workflowId ||
+    null;
+
+  return { selectedActionId, selectedWorkflowId };
+}

--- a/src/views/domain-page/__fixtures__/domain-page-query-params.ts
+++ b/src/views/domain-page/__fixtures__/domain-page-query-params.ts
@@ -17,6 +17,7 @@ export const mockDomainPageQueryParamsValues = {
   batchTimeRangeStart: undefined,
   batchTimeRangeEnd: 'now',
   batchActionId: undefined,
+  batchActionWorkflowId: undefined,
   workflowId: '',
   workflowType: '',
   statusBasic: undefined,

--- a/src/views/domain-page/config/domain-page-query-params.config.ts
+++ b/src/views/domain-page/config/domain-page-query-params.config.ts
@@ -23,6 +23,7 @@ export const domainBatchActionsQueryParamsConfig: [
   PageQueryParam<'batchTimeRangeStart', DateFilterValue | undefined>,
   PageQueryParam<'batchTimeRangeEnd', DateFilterValue>,
   PageQueryParam<'batchActionId', string | undefined>,
+  PageQueryParam<'batchActionWorkflowId', string | undefined>,
 ] = [
   {
     key: 'batchInputType',
@@ -61,6 +62,10 @@ export const domainBatchActionsQueryParamsConfig: [
   {
     key: 'batchActionId',
     queryParamKey: 'bid',
+  },
+  {
+    key: 'batchActionWorkflowId',
+    queryParamKey: 'bwid',
   },
 ] as const;
 


### PR DESCRIPTION
## Context

Deep-linking or refreshing onto a batch action whose `runId` isn't on a fetched sidebar page rendered a **blank** detail panel: `describe` was gated on finding the action in the in-memory list (which supplied the `workflowId` it needs). A random / non-batch `runId` produced the same blank state with no feedback, and nothing stopped one domain's URL from describing another domain's batch action.

## Changes

- **Carry the `workflowId` in the page URL (`bwid`) alongside the `runId` (`bid`) as a pair.** The detail loads for any deep-linked batch action regardless of what the sidebar has paginated — `describe` is enabled from the URL ids, not from a list lookup.
- **Treat the two ids as a unit** in `resolveSelectedBatchAction` (a small, tested pure helper):
  - both ids present → that action;
  - exactly one id present → invalid selection → **"Batch action not found"** panel (no silent fallback to the wrong action);
  - neither present → default to the first loaded action.
- **Guard `describe` server-side** so the panel only renders genuine, in-scope batch actions; otherwise it returns 404 → "Batch action not found":
  - the workflow type must be the batch-action type (a random `runId` is rejected);
  - the workflow's `CustomDomain` search attribute must match the viewed domain (the same attribute the sidebar list already filters on), so one domain can't open another's batch actions.
- The not-found panel offers a **"View batch actions"** action that clears the selection. The sidebar shows no selection when the deep-linked action isn't in the loaded list.


<img width="1443" height="683" alt="image" src="https://github.com/user-attachments/assets/f48b8d29-b7ca-46b2-a31d-ee51c0254c8d" />

