### PR TITLE
feat(schedule-details): static metrics chart series (SLICE-9.1 / PR09d)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@tanstack/react-query": "^5.45.0",
         "@tanstack/react-query-next-experimental": "^5.45.0",
         "@visx/axis": "^3.12.0",
+        "@visx/grid": "^3.12.0",
         "@visx/group": "^3.12.0",
         "@visx/pattern": "^3.12.0",
         "@visx/responsive": "^3.12.0",
@@ -3972,6 +3973,24 @@
         "d3-path": "1"
       }
     },
+    "node_modules/@visx/grid": {
+      "version": "3.12.0",
+      "resolved": "https://unpm.uberinternal.com/artifactory/api/npm/npmjs-virtual/@visx/grid/-/grid-3.12.0.tgz",
+      "integrity": "sha512-L4ex2ooSYhwNIxJ3XFIKRhoSvEGjPc2Y3YCrtNB4TV5Ofdj4q0UMOsxfrH23Pr8HSHuQhb6VGMgYoK0LuWqDmQ==",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/curve": "3.12.0",
+        "@visx/group": "3.12.0",
+        "@visx/point": "3.12.0",
+        "@visx/scale": "3.12.0",
+        "@visx/shape": "3.12.0",
+        "classnames": "^2.3.1",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
+      }
+    },
     "node_modules/@visx/group": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/@visx/group/-/group-3.12.0.tgz",
@@ -7751,6 +7770,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -8176,6 +8196,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@tanstack/react-query": "^5.45.0",
     "@tanstack/react-query-next-experimental": "^5.45.0",
     "@visx/axis": "^3.12.0",
+    "@visx/grid": "^3.12.0",
     "@visx/group": "^3.12.0",
     "@visx/pattern": "^3.12.0",
     "@visx/responsive": "^3.12.0",

--- a/src/views/schedule-page/schedule-detail-metrics-chart/__fixtures__/schedule-detail-metrics-chart-fixture.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/__fixtures__/schedule-detail-metrics-chart-fixture.ts
@@ -1,0 +1,18 @@
+import { type ScheduleMetricsChartSeriesData } from '../schedule-detail-metrics-chart-series.types';
+
+export const SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS = new Date(
+  '2024-06-15T12:00:00.000Z'
+).getTime();
+
+export const scheduleMetricsChartFixture: ScheduleMetricsChartSeriesData = {
+  successfulRuns: [
+    { scheduledTimeMs: SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS - 6 * 60 * 60 * 1000 },
+    { scheduledTimeMs: SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS - 4 * 60 * 60 * 1000 },
+    { scheduledTimeMs: SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS - 1 * 60 * 60 * 1000 },
+  ],
+  missedExecutions: [
+    { scheduledTimeMs: SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS - 2 * 60 * 60 * 1000 },
+  ],
+  nextExecutionTimeMs:
+    SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS + 2 * 60 * 60 * 1000,
+};

--- a/src/views/schedule-page/schedule-detail-metrics-chart/__tests__/schedule-detail-metrics-chart-empty-state.test.tsx
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/__tests__/schedule-detail-metrics-chart-empty-state.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import {
+  CHART_EMPTY_STATE_MESSAGE,
+  CHART_REGION_ARIA_LABEL,
+  CHART_SVG_TEST_ID,
+} from '../schedule-detail-metrics-chart.constants';
+import ScheduleDetailMetricsChart from '../schedule-detail-metrics-chart';
+
+jest.mock('@visx/responsive', () => ({
+  ParentSize: ({
+    children,
+  }: {
+    children: (args: { width: number; height: number }) => React.ReactNode;
+  }) => <>{children({ width: 800, height: 280 })}</>,
+}));
+
+jest.mock('../__fixtures__/schedule-detail-metrics-chart-fixture', () => ({
+  SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS: new Date(
+    '2024-06-15T12:00:00.000Z'
+  ).getTime(),
+  scheduleMetricsChartFixture: {
+    successfulRuns: [],
+    missedExecutions: [],
+    nextExecutionTimeMs: null,
+  },
+}));
+
+describe(`${ScheduleDetailMetricsChart.name} empty state`, () => {
+  it('renders empty state when there is no chart data', () => {
+    render(
+      <ScheduleDetailMetricsChart
+        params={{
+          domain: 'test-domain',
+          cluster: 'test-cluster',
+          scheduleId: 'my-schedule',
+          scheduleTab: 'runs',
+        }}
+      />
+    );
+
+    expect(
+      screen.getByRole('region', { name: CHART_REGION_ARIA_LABEL })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent(
+      CHART_EMPTY_STATE_MESSAGE
+    );
+    expect(
+      screen.queryByTestId(CHART_SVG_TEST_ID)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/views/schedule-page/schedule-detail-metrics-chart/__tests__/schedule-detail-metrics-chart.test.tsx
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/__tests__/schedule-detail-metrics-chart.test.tsx
@@ -3,8 +3,9 @@ import React from 'react';
 import { render, screen, within } from '@/test-utils/rtl';
 
 import {
-  CHART_EMPTY_STATE_MESSAGE,
+  CHART_NOW_LINE_TEST_ID,
   CHART_REGION_ARIA_LABEL,
+  CHART_SVG_TEST_ID,
   CHART_TOOLBAR_ARIA_LABEL,
   CHART_TOOLBAR_BUTTON_LABELS,
 } from '../schedule-detail-metrics-chart.constants';
@@ -18,19 +19,41 @@ jest.mock('@visx/responsive', () => ({
   }) => <>{children({ width: 800, height: 280 })}</>,
 }));
 
+const mockNow = new Date('2024-06-15T12:00:00Z').getTime();
+
 describe(ScheduleDetailMetricsChart.name, () => {
-  it('renders chart region with empty state when there is no chart data', () => {
+  beforeEach(() => {
+    jest.useFakeTimers({ now: mockNow });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders chart region with svg frame', () => {
     setup();
 
     expect(
       screen.getByRole('region', { name: CHART_REGION_ARIA_LABEL })
     ).toBeInTheDocument();
-    expect(screen.getByRole('status')).toHaveTextContent(
-      CHART_EMPTY_STATE_MESSAGE
+    expect(screen.getByTestId(CHART_SVG_TEST_ID)).toBeInTheDocument();
+  });
+
+  it('renders x and y axes in the chart svg', () => {
+    setup();
+
+    const chartSvg = screen.getByTestId(CHART_SVG_TEST_ID);
+
+    expect(within(chartSvg).getAllByText(/\d{2}:\d{2}/).length).toBeGreaterThan(
+      0
     );
-    expect(
-      screen.queryByTestId('schedule-metrics-chart-canvas')
-    ).not.toBeInTheDocument();
+    expect(within(chartSvg).getAllByText(/^\d+$/).length).toBeGreaterThan(0);
+  });
+
+  it('renders vertical now line in the chart svg', () => {
+    setup();
+
+    expect(screen.getByTestId(CHART_NOW_LINE_TEST_ID)).toBeInTheDocument();
   });
 
   it('renders disabled chart toolbar controls', () => {

--- a/src/views/schedule-page/schedule-detail-metrics-chart/__tests__/schedule-detail-metrics-chart.test.tsx
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/__tests__/schedule-detail-metrics-chart.test.tsx
@@ -5,10 +5,12 @@ import { render, screen, within } from '@/test-utils/rtl';
 import {
   CHART_NOW_LINE_TEST_ID,
   CHART_REGION_ARIA_LABEL,
+  CHART_SERIES_TEST_IDS,
   CHART_SVG_TEST_ID,
   CHART_TOOLBAR_ARIA_LABEL,
   CHART_TOOLBAR_BUTTON_LABELS,
 } from '../schedule-detail-metrics-chart.constants';
+import { SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS } from '../__fixtures__/schedule-detail-metrics-chart-fixture';
 import ScheduleDetailMetricsChart from '../schedule-detail-metrics-chart';
 
 jest.mock('@visx/responsive', () => ({
@@ -19,24 +21,35 @@ jest.mock('@visx/responsive', () => ({
   }) => <>{children({ width: 800, height: 280 })}</>,
 }));
 
-const mockNow = new Date('2024-06-15T12:00:00Z').getTime();
-
 describe(ScheduleDetailMetricsChart.name, () => {
   beforeEach(() => {
-    jest.useFakeTimers({ now: mockNow });
+    jest.useFakeTimers({ now: SCHEDULE_METRICS_CHART_FIXTURE_NOW_MS });
   });
 
   afterEach(() => {
     jest.useRealTimers();
   });
 
-  it('renders chart region with svg frame', () => {
+  it('renders chart region with svg frame and static fixture series markers', () => {
     setup();
 
     expect(
       screen.getByRole('region', { name: CHART_REGION_ARIA_LABEL })
     ).toBeInTheDocument();
     expect(screen.getByTestId(CHART_SVG_TEST_ID)).toBeInTheDocument();
+    expect(
+      screen.getByTestId(CHART_SERIES_TEST_IDS.svg)
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByTestId(CHART_SERIES_TEST_IDS.successfulRunMarker)
+    ).toHaveLength(3);
+    expect(
+      screen.getByTestId(CHART_SERIES_TEST_IDS.missedExecutionMarker)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId(CHART_SERIES_TEST_IDS.nextExecutionMarker)
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 
   it('renders x and y axes in the chart svg', () => {

--- a/src/views/schedule-page/schedule-detail-metrics-chart/helpers/format-chart-time-tick.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/helpers/format-chart-time-tick.ts
@@ -1,0 +1,5 @@
+import dayjs from '@/utils/datetime/dayjs';
+
+export default function formatChartTimeTick(timestampMs: number) {
+  return dayjs(timestampMs).format('HH:mm');
+}

--- a/src/views/schedule-page/schedule-detail-metrics-chart/helpers/has-schedule-metrics-chart-data.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/helpers/has-schedule-metrics-chart-data.ts
@@ -1,0 +1,11 @@
+import { type ScheduleMetricsChartSeriesData } from '../schedule-detail-metrics-chart-series.types';
+
+export default function hasScheduleMetricsChartData(
+  data: ScheduleMetricsChartSeriesData
+) {
+  return (
+    data.successfulRuns.length > 0 ||
+    data.missedExecutions.length > 0 ||
+    data.nextExecutionTimeMs != null
+  );
+}

--- a/src/views/schedule-page/schedule-detail-metrics-chart/hooks/use-current-time-ms.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/hooks/use-current-time-ms.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+import { CURRENT_TIME_UPDATE_INTERVAL_MS } from '../schedule-detail-metrics-chart.constants';
+
+export default function useCurrentTimeMs() {
+  const [currentTimeMs, setCurrentTimeMs] = useState<number>(Date.now());
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setCurrentTimeMs(Date.now());
+    }, CURRENT_TIME_UPDATE_INTERVAL_MS);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return currentTimeMs;
+}

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart-scales.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart-scales.ts
@@ -4,11 +4,13 @@ import { type ScaleLinear } from 'd3-scale';
 import {
   CHART_DEFAULT_PAST_WINDOW_MS,
   CHART_FUTURE_GUTTER_MS,
+  CHART_MARGIN,
   CHART_MIN_DOMAIN_SPAN_MS,
   CHART_SIDE_PADDING_PX,
 } from './schedule-detail-metrics-chart.constants';
 import {
   type CreateMetricsChartXScaleParams,
+  type MetricsChartInnerDimensions,
   type MetricsChartPixelRange,
   type MetricsChartTimeDomain,
   type ResolveMetricsChartPixelRangeParams,
@@ -16,6 +18,7 @@ import {
 } from './schedule-detail-metrics-chart.types';
 
 type MetricsChartXScale = ScaleLinear<number, number, never>;
+type MetricsChartYScale = ScaleLinear<number, number, never>;
 
 export function resolveMetricsChartTimeDomain({
   timestampsMs,
@@ -86,6 +89,26 @@ export function resolveMetricsChartPixelRange({
   };
 }
 
+export function getMetricsChartInnerDimensions(
+  widthPx: number,
+  heightPx: number
+): MetricsChartInnerDimensions {
+  const innerWidth = Math.max(
+    0,
+    widthPx - CHART_MARGIN.left - CHART_MARGIN.right
+  );
+  const innerHeight = Math.max(
+    0,
+    heightPx - CHART_MARGIN.top - CHART_MARGIN.bottom
+  );
+
+  return {
+    innerWidth,
+    innerHeight,
+    margin: CHART_MARGIN,
+  };
+}
+
 export function createMetricsChartXScale({
   domain,
   range,
@@ -110,6 +133,20 @@ export function createMetricsChartXScale({
     domain: [domain.minMs, domain.maxMs],
     range: [range.startPx, range.endPx],
     clamp: true,
+  });
+}
+
+export function createMetricsChartYScale({
+  maxCount,
+  innerHeight,
+}: {
+  maxCount: number;
+  innerHeight: number;
+}): MetricsChartYScale {
+  return scaleLinear<number>({
+    domain: [0, Math.max(maxCount, 1)],
+    range: [innerHeight, 0],
+    nice: true,
   });
 }
 

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart-series.tsx
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart-series.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+
+import { Group } from '@visx/group';
+import { Circle, Line } from '@visx/shape';
+
+import {
+  CHART_SERIES_MARKER_RADIUS_PX,
+  CHART_SERIES_MISSED_MARKER_RADIUS_PX,
+  CHART_SERIES_MISSED_STROKE_WIDTH_PX,
+  CHART_SERIES_MISSED_Y_RATIO,
+  CHART_SERIES_NEXT_EXECUTION_STROKE_WIDTH_PX,
+  CHART_SERIES_SUCCESS_Y_RATIO,
+  CHART_SERIES_TEST_IDS,
+} from './schedule-detail-metrics-chart.constants';
+import { type ScheduleMetricsChartSeriesProps } from './schedule-detail-metrics-chart-series.types';
+
+export default function ScheduleDetailMetricsChartSeries({
+  width,
+  height,
+  xScale,
+  data,
+  successfulRunColor,
+  missedExecutionColor,
+  nextExecutionColor,
+}: ScheduleMetricsChartSeriesProps) {
+  const successfulRunY = height * CHART_SERIES_SUCCESS_Y_RATIO;
+  const missedExecutionY = height * CHART_SERIES_MISSED_Y_RATIO;
+
+  return (
+    <Group data-testid={CHART_SERIES_TEST_IDS.svg}>
+      {data.successfulRuns.map(({ scheduledTimeMs }) => (
+        <Circle
+          key={`successful-${scheduledTimeMs}`}
+          cx={xScale(scheduledTimeMs)}
+          cy={successfulRunY}
+          r={CHART_SERIES_MARKER_RADIUS_PX}
+          fill={successfulRunColor}
+          data-testid={CHART_SERIES_TEST_IDS.successfulRunMarker}
+        />
+      ))}
+      {data.missedExecutions.map(({ scheduledTimeMs }) => {
+        const x = xScale(scheduledTimeMs);
+
+        return (
+          <Group key={`missed-${scheduledTimeMs}`}>
+            <Line
+              from={{ x, y: successfulRunY }}
+              to={{ x, y: missedExecutionY }}
+              stroke={missedExecutionColor}
+              strokeWidth={CHART_SERIES_MISSED_STROKE_WIDTH_PX}
+              strokeDasharray="4 3"
+              pointerEvents="none"
+            />
+            <Circle
+              cx={x}
+              cy={missedExecutionY}
+              r={CHART_SERIES_MISSED_MARKER_RADIUS_PX}
+              fill="transparent"
+              stroke={missedExecutionColor}
+              strokeWidth={CHART_SERIES_MISSED_STROKE_WIDTH_PX}
+              data-testid={CHART_SERIES_TEST_IDS.missedExecutionMarker}
+            />
+          </Group>
+        );
+      })}
+      {data.nextExecutionTimeMs != null && (
+        <Line
+          from={{ x: xScale(data.nextExecutionTimeMs), y: 0 }}
+          to={{ x: xScale(data.nextExecutionTimeMs), y: height }}
+          stroke={nextExecutionColor}
+          strokeWidth={CHART_SERIES_NEXT_EXECUTION_STROKE_WIDTH_PX}
+          strokeDasharray="6 4"
+          pointerEvents="none"
+          data-testid={CHART_SERIES_TEST_IDS.nextExecutionMarker}
+        />
+      )}
+      <rect width={width} height={height} fill="transparent" pointerEvents="none" />
+    </Group>
+  );
+}

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart-series.types.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart-series.types.ts
@@ -1,0 +1,23 @@
+import { type ScaleLinear } from 'd3-scale';
+
+export type ScheduleMetricsChartExecutionPoint = {
+  scheduledTimeMs: number;
+};
+
+export type ScheduleMetricsChartSeriesData = {
+  successfulRuns: ScheduleMetricsChartExecutionPoint[];
+  missedExecutions: ScheduleMetricsChartExecutionPoint[];
+  nextExecutionTimeMs: number | null;
+};
+
+export type ScheduleMetricsChartXScale = ScaleLinear<number, number, never>;
+
+export type ScheduleMetricsChartSeriesProps = {
+  width: number;
+  height: number;
+  xScale: ScheduleMetricsChartXScale;
+  data: ScheduleMetricsChartSeriesData;
+  successfulRunColor: string;
+  missedExecutionColor: string;
+  nextExecutionColor: string;
+};

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.constants.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.constants.ts
@@ -18,6 +18,8 @@ export const CHART_TOOLBAR_BUTTON_LABELS = {
   now: 'Now',
 } as const;
 
+export const CHART_EMPTY_STATE_MESSAGE = 'No chart data available yet';
+
 export const CHART_REGION_ARIA_LABEL = 'Schedule metrics chart';
 
 export const CHART_TOOLBAR_ARIA_LABEL = 'Chart controls';
@@ -37,3 +39,17 @@ export const CHART_FUTURE_GUTTER_MS = 30 * 60_000;
 
 /** Horizontal inset applied to the chart drawable area (px). */
 export const CHART_SIDE_PADDING_PX = 24;
+
+export const CHART_SERIES_TEST_IDS = {
+  svg: 'schedule-metrics-chart-series-svg',
+  successfulRunMarker: 'schedule-metrics-chart-successful-run-marker',
+  missedExecutionMarker: 'schedule-metrics-chart-missed-execution-marker',
+  nextExecutionMarker: 'schedule-metrics-chart-next-execution-marker',
+} as const;
+
+export const CHART_SERIES_MARKER_RADIUS_PX = 5;
+export const CHART_SERIES_MISSED_MARKER_RADIUS_PX = 6;
+export const CHART_SERIES_NEXT_EXECUTION_STROKE_WIDTH_PX = 2;
+export const CHART_SERIES_MISSED_STROKE_WIDTH_PX = 2;
+export const CHART_SERIES_SUCCESS_Y_RATIO = 0.45;
+export const CHART_SERIES_MISSED_Y_RATIO = 0.65;

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.constants.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.constants.ts
@@ -1,5 +1,16 @@
 export const CHART_HEIGHT_PX = 280;
 
+export const CHART_MARGIN = {
+  top: 12,
+  right: 24,
+  bottom: 36,
+  left: 44,
+} as const;
+
+export const DEFAULT_Y_AXIS_MAX = 10;
+
+export const CURRENT_TIME_UPDATE_INTERVAL_MS = 30_000;
+
 export const CHART_TOOLBAR_BUTTON_LABELS = {
   zoomIn: 'Zoom in',
   zoomOut: 'Zoom out',
@@ -7,11 +18,13 @@ export const CHART_TOOLBAR_BUTTON_LABELS = {
   now: 'Now',
 } as const;
 
-export const CHART_EMPTY_STATE_MESSAGE = 'No chart data available yet';
-
 export const CHART_REGION_ARIA_LABEL = 'Schedule metrics chart';
 
 export const CHART_TOOLBAR_ARIA_LABEL = 'Chart controls';
+
+export const CHART_SVG_TEST_ID = 'schedule-metrics-chart-svg';
+
+export const CHART_NOW_LINE_TEST_ID = 'schedule-metrics-chart-now-line';
 
 /** Minimum time span when domain collapses to a single timestamp (ms). */
 export const CHART_MIN_DOMAIN_SPAN_MS = 5 * 60_000;

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.styles.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.styles.ts
@@ -33,6 +33,15 @@ export const styled = {
     width: '100%',
     height: '100%',
   })),
+  EmptyState: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '100%',
+    height: '100%',
+    ...$theme.typography.ParagraphSmall,
+    color: $theme.colors.contentSecondary,
+  })),
 };
 
 const toolbarButtonRootOverrides = {

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.styles.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.styles.ts
@@ -28,18 +28,10 @@ export const styled = {
     height: `${CHART_HEIGHT_PX}px`,
     backgroundColor: $theme.colors.backgroundSecondary,
   })),
-  ChartCanvas: createStyled('div', () => ({
+  ChartSvg: createStyled('svg', () => ({
+    display: 'block',
     width: '100%',
     height: '100%',
-  })),
-  EmptyState: createStyled('div', ({ $theme }: { $theme: Theme }) => ({
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '100%',
-    height: '100%',
-    ...$theme.typography.ParagraphSmall,
-    color: $theme.colors.contentSecondary,
   })),
 };
 

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.tsx
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.tsx
@@ -1,7 +1,12 @@
 'use client';
-import React from 'react';
+import React, { useMemo } from 'react';
 
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { GridColumns, GridRows } from '@visx/grid';
+import { Group } from '@visx/group';
 import { ParentSize } from '@visx/responsive';
+import { Line } from '@visx/shape';
+import { useStyletron } from 'baseui';
 import {
   MdFitScreen,
   MdGpsFixed,
@@ -11,18 +16,144 @@ import {
 
 import Button from '@/components/button/button';
 
+import formatChartTimeTick from './helpers/format-chart-time-tick';
+import useCurrentTimeMs from './hooks/use-current-time-ms';
 import {
-  CHART_EMPTY_STATE_MESSAGE,
+  CHART_NOW_LINE_TEST_ID,
   CHART_REGION_ARIA_LABEL,
+  CHART_SVG_TEST_ID,
   CHART_TOOLBAR_ARIA_LABEL,
   CHART_TOOLBAR_BUTTON_LABELS,
+  DEFAULT_Y_AXIS_MAX,
 } from './schedule-detail-metrics-chart.constants';
+import {
+  createMetricsChartXScale,
+  createMetricsChartYScale,
+  getMetricsChartInnerDimensions,
+  resolveMetricsChartTimeDomain,
+} from './schedule-detail-metrics-chart-scales';
 import { overrides, styled } from './schedule-detail-metrics-chart.styles';
 import { type Props } from './schedule-detail-metrics-chart.types';
 
-export default function ScheduleDetailMetricsChart(_props: Props) {
-  const hasChartData = false;
+type ChartSvgProps = {
+  width: number;
+  height: number;
+};
 
+function ScheduleMetricsChartSvg({ width, height }: ChartSvgProps) {
+  const [, theme] = useStyletron();
+  const currentTimeMs = useCurrentTimeMs();
+
+  const { innerWidth, innerHeight, margin } = useMemo(
+    () => getMetricsChartInnerDimensions(width, height),
+    [width, height]
+  );
+
+  const timeDomain = useMemo(
+    () =>
+      resolveMetricsChartTimeDomain({
+        timestampsMs: [],
+        nowMs: currentTimeMs,
+      }),
+    [currentTimeMs]
+  );
+
+  const xScale = useMemo(() => {
+    if (timeDomain == null || innerWidth <= 0) {
+      return null;
+    }
+
+    return createMetricsChartXScale({
+      domain: timeDomain,
+      range: { startPx: 0, endPx: innerWidth },
+    });
+  }, [timeDomain, innerWidth]);
+
+  const yScale = useMemo(
+    () =>
+      createMetricsChartYScale({
+        maxCount: DEFAULT_Y_AXIS_MAX,
+        innerHeight,
+      }),
+    [innerHeight]
+  );
+
+  const xTickCount = Math.min(8, Math.max(2, Math.floor(innerWidth / 80)));
+  const yTickCount = Math.min(6, Math.max(2, Math.floor(innerHeight / 40)));
+  const nowLineX = xScale?.(currentTimeMs);
+
+  if (innerWidth <= 0 || innerHeight <= 0 || xScale == null) {
+    return null;
+  }
+
+  const gridStroke = theme.colors.borderOpaque;
+  const tickLabelColor = theme.colors.contentSecondary;
+  const axisStroke = theme.colors.borderOpaque;
+
+  return (
+    <styled.ChartSvg
+      width={width}
+      height={height}
+      data-testid={CHART_SVG_TEST_ID}
+    >
+      <Group left={margin.left} top={margin.top}>
+        <GridRows
+          scale={yScale}
+          width={innerWidth}
+          stroke={gridStroke}
+          numTicks={yTickCount}
+        />
+        <GridColumns
+          scale={xScale}
+          height={innerHeight}
+          stroke={gridStroke}
+          numTicks={xTickCount}
+        />
+        <AxisLeft
+          scale={yScale}
+          numTicks={yTickCount}
+          stroke={axisStroke}
+          tickStroke={axisStroke}
+          tickLabelProps={() => ({
+            fill: tickLabelColor,
+            fontSize: 10,
+            fontFamily: theme.typography.LabelXSmall.fontFamily,
+            textAnchor: 'end',
+            dx: '-0.25em',
+            dy: '0.25em',
+          })}
+        />
+        <AxisBottom
+          top={innerHeight}
+          scale={xScale}
+          numTicks={xTickCount}
+          stroke={axisStroke}
+          tickStroke={axisStroke}
+          tickFormat={(value) => formatChartTimeTick(Number(value))}
+          tickLabelProps={() => ({
+            fill: tickLabelColor,
+            fontSize: 10,
+            fontFamily: theme.typography.LabelXSmall.fontFamily,
+            textAnchor: 'middle',
+            dy: '0.25em',
+          })}
+        />
+        {nowLineX != null && nowLineX >= 0 && nowLineX <= innerWidth && (
+          <Line
+            data-testid={CHART_NOW_LINE_TEST_ID}
+            from={{ x: nowLineX, y: 0 }}
+            to={{ x: nowLineX, y: innerHeight }}
+            stroke={theme.colors.contentAccent}
+            strokeWidth={2}
+            pointerEvents="none"
+          />
+        )}
+      </Group>
+    </styled.ChartSvg>
+  );
+}
+
+export default function ScheduleDetailMetricsChart(_props: Props) {
   return (
     <styled.Container>
       <styled.Toolbar role="toolbar" aria-label={CHART_TOOLBAR_ARIA_LABEL}>
@@ -73,14 +204,10 @@ export default function ScheduleDetailMetricsChart(_props: Props) {
       </styled.Toolbar>
       <styled.ChartRegion role="region" aria-label={CHART_REGION_ARIA_LABEL}>
         <ParentSize>
-          {() =>
-            hasChartData ? (
-              <styled.ChartCanvas data-testid="schedule-metrics-chart-canvas" />
-            ) : (
-              <styled.EmptyState role="status">
-                {CHART_EMPTY_STATE_MESSAGE}
-              </styled.EmptyState>
-            )
+          {({ width = 0, height = 0 }) =>
+            width > 0 && height > 0 ? (
+              <ScheduleMetricsChartSvg width={width} height={height} />
+            ) : null
           }
         </ParentSize>
       </styled.ChartRegion>

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.tsx
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.tsx
@@ -16,9 +16,12 @@ import {
 
 import Button from '@/components/button/button';
 
+import { scheduleMetricsChartFixture } from './__fixtures__/schedule-detail-metrics-chart-fixture';
 import formatChartTimeTick from './helpers/format-chart-time-tick';
+import hasScheduleMetricsChartData from './helpers/has-schedule-metrics-chart-data';
 import useCurrentTimeMs from './hooks/use-current-time-ms';
 import {
+  CHART_EMPTY_STATE_MESSAGE,
   CHART_NOW_LINE_TEST_ID,
   CHART_REGION_ARIA_LABEL,
   CHART_SVG_TEST_ID,
@@ -32,15 +35,22 @@ import {
   getMetricsChartInnerDimensions,
   resolveMetricsChartTimeDomain,
 } from './schedule-detail-metrics-chart-scales';
+import ScheduleDetailMetricsChartSeries from './schedule-detail-metrics-chart-series';
+import { type ScheduleMetricsChartSeriesData } from './schedule-detail-metrics-chart-series.types';
 import { overrides, styled } from './schedule-detail-metrics-chart.styles';
 import { type Props } from './schedule-detail-metrics-chart.types';
 
 type ChartSvgProps = {
   width: number;
   height: number;
+  chartData: ScheduleMetricsChartSeriesData;
 };
 
-function ScheduleMetricsChartSvg({ width, height }: ChartSvgProps) {
+function ScheduleMetricsChartSvg({
+  width,
+  height,
+  chartData,
+}: ChartSvgProps) {
   const [, theme] = useStyletron();
   const currentTimeMs = useCurrentTimeMs();
 
@@ -49,13 +59,26 @@ function ScheduleMetricsChartSvg({ width, height }: ChartSvgProps) {
     [width, height]
   );
 
+  const timestampsMs = useMemo(
+    () => [
+      ...chartData.successfulRuns.map(
+        ({ scheduledTimeMs }) => scheduledTimeMs
+      ),
+      ...chartData.missedExecutions.map(
+        ({ scheduledTimeMs }) => scheduledTimeMs
+      ),
+    ],
+    [chartData]
+  );
+
   const timeDomain = useMemo(
     () =>
       resolveMetricsChartTimeDomain({
-        timestampsMs: [],
+        timestampsMs,
         nowMs: currentTimeMs,
+        nextExecutionMs: chartData.nextExecutionTimeMs,
       }),
-    [currentTimeMs]
+    [timestampsMs, currentTimeMs, chartData.nextExecutionTimeMs]
   );
 
   const xScale = useMemo(() => {
@@ -138,6 +161,15 @@ function ScheduleMetricsChartSvg({ width, height }: ChartSvgProps) {
             dy: '0.25em',
           })}
         />
+        <ScheduleDetailMetricsChartSeries
+          width={innerWidth}
+          height={innerHeight}
+          xScale={xScale}
+          data={chartData}
+          successfulRunColor={theme.colors.positive400}
+          missedExecutionColor={theme.colors.warning400}
+          nextExecutionColor={theme.colors.accent400}
+        />
         {nowLineX != null && nowLineX >= 0 && nowLineX <= innerWidth && (
           <Line
             data-testid={CHART_NOW_LINE_TEST_ID}
@@ -154,6 +186,9 @@ function ScheduleMetricsChartSvg({ width, height }: ChartSvgProps) {
 }
 
 export default function ScheduleDetailMetricsChart(_props: Props) {
+  const chartData = scheduleMetricsChartFixture;
+  const hasChartData = hasScheduleMetricsChartData(chartData);
+
   return (
     <styled.Container>
       <styled.Toolbar role="toolbar" aria-label={CHART_TOOLBAR_ARIA_LABEL}>
@@ -204,11 +239,26 @@ export default function ScheduleDetailMetricsChart(_props: Props) {
       </styled.Toolbar>
       <styled.ChartRegion role="region" aria-label={CHART_REGION_ARIA_LABEL}>
         <ParentSize>
-          {({ width = 0, height = 0 }) =>
-            width > 0 && height > 0 ? (
-              <ScheduleMetricsChartSvg width={width} height={height} />
-            ) : null
-          }
+          {({ width = 0, height = 0 }) => {
+            const chartWidth = Math.max(width, 0);
+            const chartHeight = Math.max(height, 0);
+
+            if (!hasChartData || chartWidth === 0 || chartHeight === 0) {
+              return (
+                <styled.EmptyState role="status">
+                  {CHART_EMPTY_STATE_MESSAGE}
+                </styled.EmptyState>
+              );
+            }
+
+            return (
+              <ScheduleMetricsChartSvg
+                width={chartWidth}
+                height={chartHeight}
+                chartData={chartData}
+              />
+            );
+          }}
         </ParentSize>
       </styled.ChartRegion>
     </styled.Container>

--- a/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.types.ts
+++ b/src/views/schedule-page/schedule-detail-metrics-chart/schedule-detail-metrics-chart.types.ts
@@ -1,5 +1,7 @@
 import { type SchedulePageTabsParams } from '@/views/schedule-page/schedule-page-tabs/schedule-page-tabs.types';
 
+import { type CHART_MARGIN } from './schedule-detail-metrics-chart.constants';
+
 export type Props = {
   params: SchedulePageTabsParams;
 };
@@ -12,6 +14,12 @@ export type MetricsChartTimeDomain = {
 export type MetricsChartPixelRange = {
   startPx: number;
   endPx: number;
+};
+
+export type MetricsChartInnerDimensions = {
+  innerWidth: number;
+  innerHeight: number;
+  margin: typeof CHART_MARGIN;
 };
 
 export type ResolveMetricsChartTimeDomainParams = {


### PR DESCRIPTION
## Summary
- Add static fixture data for schedule metrics chart series (successful runs, missed executions, next execution from describe)
- Render `@visx/shape` markers/lines with distinct styling per series type
- Replace empty state when fixture data is present; completes operator-visible static chart for SLICE-9.1
- Integrates with PR09b `schedule-detail-metrics-chart-scales` for time-to-pixel positioning

## Notes
- Target merge base after PR09c lands: `feat/schedule-details-pr09c-metrics-chart-axes`
- Currently stacked on PR09b because PR09c is not yet on upstream

## Test plan
- [x] `npm run test:unit:browser -- schedule-detail-metrics-chart schedule-page-tab-content-runs-chart`
- [ ] Manual: Runs tab shows chart markers for successful/missed runs and next execution line


Made with [Cursor](https://cursor.com)