### PR TITLE
feat(schedules): add catch-up policy cluster to advanced create form

### DIFF
--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -33,6 +33,9 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
     expect(
       screen.getByRole('combobox', { name: /overlap policy/i })
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('radiogroup', { name: /catch-up policy/i })
+    ).toBeInTheDocument();
   });
 
   it('collapses advanced fields when the toggle is clicked again', async () => {
@@ -80,6 +83,33 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
     expect(screen.getByLabelText('Concurrency limit')).toBeInTheDocument();
     expect(screen.queryByLabelText('Buffer limit')).not.toBeInTheDocument();
   });
+
+  it('shows catch-up window only when catch-up policy is not Skip', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.queryByLabelText('Catch-up window')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'Catch-up all' }));
+    expect(screen.getByLabelText('Catch-up window')).toBeInTheDocument();
+  });
+
+  it('hides catch-up window when switching catch-up policy back to Skip', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    await user.click(screen.getByRole('radio', { name: 'Catch-up all' }));
+    expect(screen.getByLabelText('Catch-up window')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('radio', { name: 'Skip' }));
+    expect(screen.queryByLabelText('Catch-up window')).not.toBeInTheDocument();
+  });
 });
 
 function setup() {
@@ -92,6 +122,7 @@ function setup() {
     } = useForm<DomainSchedulesCreateFormData>({
       defaultValues: {},
     });
+
     return (
       <DomainSchedulesCreateAdvancedForm
         control={control}

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -1,5 +1,11 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
-import { SCHEDULE_OVERLAP_POLICIES } from '@/route-handlers/create-schedule/create-schedule.constants';
+import {
+  SCHEDULE_CATCH_UP_POLICIES,
+  SCHEDULE_OVERLAP_POLICIES,
+} from '@/route-handlers/create-schedule/create-schedule.constants';
+
+export const MAX_CATCH_UP_WINDOW_DAYS = 90;
 
 /** Stable ids for advanced create-schedule horizontal fields. */
 export const CREATE_SCHEDULE_ADVANCED_FIELD_IDS = {
@@ -44,5 +50,21 @@ export const OVERLAP_POLICY_OPTIONS = SCHEDULE_OVERLAP_POLICIES.map(
   (policy) => ({
     id: policy,
     label: overlapPolicyLabels[policy],
+  })
+);
+
+const catchUpPolicyLabels: Record<
+  (typeof SCHEDULE_CATCH_UP_POLICIES)[number],
+  string
+> = {
+  [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP]: 'Skip',
+  [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE]: 'Catch-up one',
+  [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL]: 'Catch-up all',
+};
+
+export const CATCH_UP_POLICY_OPTIONS = SCHEDULE_CATCH_UP_POLICIES.map(
+  (policy) => ({
+    id: policy,
+    label: catchUpPolicyLabels[policy],
   })
 );

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -30,6 +30,9 @@ export const CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS = {
     'Prefix text to add into started workflows. Ids are formed as `${Prefix}+{auto generated postfix}`.',
 } as const;
 
+export const DEFAULT_CATCH_UP_POLICY =
+  ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP;
+
 export const DEFAULT_OVERLAP_POLICY =
   ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT;
 

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -56,10 +56,12 @@ export const OVERLAP_POLICY_OPTIONS = SCHEDULE_OVERLAP_POLICIES.map(
   })
 );
 
-const catchUpPolicyLabels: Record<
+type ScheduleCatchUpPolicyLabelMap = Record<
   (typeof SCHEDULE_CATCH_UP_POLICIES)[number],
   string
-> = {
+>;
+
+const catchUpPolicyLabels: ScheduleCatchUpPolicyLabelMap = {
   [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP]: 'Skip',
   [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE]: 'Catch-up one',
   [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL]: 'Catch-up all',

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -6,19 +6,23 @@ import { StatefulPanel } from 'baseui/accordion';
 import { Button } from 'baseui/button';
 import { mergeOverrides } from 'baseui/helpers/overrides';
 import { Input } from 'baseui/input';
+import { Radio, RadioGroup } from 'baseui/radio';
 import { Select } from 'baseui/select';
 import { LabelXSmall } from 'baseui/typography';
 import { Controller, useWatch } from 'react-hook-form';
 import { MdExpandLess, MdExpandMore } from 'react-icons/md';
 
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import DomainSchedulesHorizontalField from '@/views/domain-schedules/domain-schedules-horizontal-field/domain-schedules-horizontal-field';
 import getFieldErrorMessage from '@/views/workflow-actions/workflow-action-start-form/helpers/get-field-error-message';
 
 import {
+  CATCH_UP_POLICY_OPTIONS,
   CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS,
   CREATE_SCHEDULE_ADVANCED_FIELD_IDS,
   DEFAULT_OVERLAP_POLICY,
+  MAX_CATCH_UP_WINDOW_DAYS,
   OVERLAP_POLICY_OPTIONS,
 } from './domain-schedules-create-advanced-form.constants';
 import {
@@ -35,6 +39,11 @@ export default function DomainSchedulesCreateAdvancedForm({
     control,
     name: 'overlapPolicy',
     defaultValue: DEFAULT_OVERLAP_POLICY,
+  });
+  const catchUpPolicy = useWatch({
+    control,
+    name: 'catchUpPolicy',
+    defaultValue: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP,
   });
 
   return (
@@ -191,6 +200,73 @@ export default function DomainSchedulesCreateAdvancedForm({
                   )}
                   size="compact"
                   placeholder="Set concurrency limit"
+                />
+              )}
+            />
+          </DomainSchedulesHorizontalField>
+        )}
+
+        <DomainSchedulesHorizontalField
+          label="Catch-up Policy"
+          description="Controls whether missed schedules should run after downtime."
+          error={getFieldErrorMessage(fieldErrors, 'catchUpPolicy')}
+        >
+          <Controller
+            name="catchUpPolicy"
+            control={control}
+            defaultValue={ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP}
+            render={({ field: { value, onChange, ref, ...field } }) => (
+              <RadioGroup
+                {...field}
+                // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
+                inputRef={ref}
+                aria-label="Catch-up Policy"
+                value={value}
+                onChange={(e) => onChange(e.currentTarget.value)}
+                error={Boolean(
+                  getFieldErrorMessage(fieldErrors, 'catchUpPolicy')
+                )}
+                align="horizontal"
+              >
+                {CATCH_UP_POLICY_OPTIONS.map((option) => (
+                  <Radio key={option.id} value={option.id}>
+                    {option.label}
+                  </Radio>
+                ))}
+              </RadioGroup>
+            )}
+          />
+        </DomainSchedulesHorizontalField>
+
+        {catchUpPolicy !==
+          ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP && (
+          <DomainSchedulesHorizontalField
+            subfield={true}
+            label="Catch-up window"
+            description="Maximum age of missed schedules that can still be started."
+            htmlFor="create-schedule-form-catch-up-window-days"
+            error={getFieldErrorMessage(fieldErrors, 'catchUpWindowDays')}
+          >
+            <Controller
+              name="catchUpWindowDays"
+              control={control}
+              render={({ field: { ref, ...field } }) => (
+                <Input
+                  {...field}
+                  id="create-schedule-form-catch-up-window-days"
+                  // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
+                  inputRef={ref}
+                  aria-label="Catch-up window"
+                  type="number"
+                  min={1}
+                  max={MAX_CATCH_UP_WINDOW_DAYS}
+                  onBlur={field.onBlur}
+                  error={Boolean(
+                    getFieldErrorMessage(fieldErrors, 'catchUpWindowDays')
+                  )}
+                  size="compact"
+                  placeholder="Set catch-up window"
+                  endEnhancer={<LabelXSmall>Days</LabelXSmall>}
                 />
               )}
             />

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -21,6 +21,7 @@ import {
   CATCH_UP_POLICY_OPTIONS,
   CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS,
   CREATE_SCHEDULE_ADVANCED_FIELD_IDS,
+  DEFAULT_CATCH_UP_POLICY,
   DEFAULT_OVERLAP_POLICY,
   MAX_CATCH_UP_WINDOW_DAYS,
   OVERLAP_POLICY_OPTIONS,
@@ -43,7 +44,7 @@ export default function DomainSchedulesCreateAdvancedForm({
   const catchUpPolicy = useWatch({
     control,
     name: 'catchUpPolicy',
-    defaultValue: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP,
+    defaultValue: DEFAULT_CATCH_UP_POLICY,
   });
 
   return (
@@ -214,7 +215,7 @@ export default function DomainSchedulesCreateAdvancedForm({
           <Controller
             name="catchUpPolicy"
             control={control}
-            defaultValue={ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP}
+            defaultValue={DEFAULT_CATCH_UP_POLICY}
             render={({ field: { value, onChange, ref, ...field } }) => (
               <RadioGroup
                 {...field}

--- a/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
@@ -1,3 +1,4 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import { DEFAULT_OVERLAP_POLICY } from '@/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants';
 
@@ -103,5 +104,55 @@ describe(transformDomainSchedulesCreateFormToBody.name, () => {
     expect(result.overlapPolicy).toBe(DEFAULT_OVERLAP_POLICY);
     expect(result.concurrencyLimit).toBe(7);
     expect(result.bufferLimit).toBeUndefined();
+  });
+
+  it('maps catch-up window days to seconds for non-skip catch-up policy', () => {
+    const result = transformDomainSchedulesCreateFormToBody({
+      ...mockDomainSchedulesCreateFormData,
+      catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE,
+      catchUpWindowDays: '14',
+    });
+
+    expect(result.catchUpPolicy).toBe(
+      ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE
+    );
+    expect(result.catchUpWindowSeconds).toBe(14 * 86400);
+  });
+
+  it('omits catch-up window seconds for skip catch-up policy', () => {
+    const result = transformDomainSchedulesCreateFormToBody({
+      ...mockDomainSchedulesCreateFormData,
+      catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP,
+      catchUpWindowDays: '14',
+    });
+
+    expect(result.catchUpPolicy).toBe(
+      ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP
+    );
+    expect(result.catchUpWindowSeconds).toBeUndefined();
+  });
+
+  it('omits catchUpPolicy when not set on form data', () => {
+    const result = transformDomainSchedulesCreateFormToBody(
+      mockDomainSchedulesCreateFormData
+    );
+
+    expect(result.catchUpPolicy).toBeUndefined();
+  });
+
+  it('omits buffer and concurrency limits when limit strings are empty', () => {
+    const bufferResult = transformDomainSchedulesCreateFormToBody({
+      ...mockDomainSchedulesCreateFormData,
+      overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+      bufferLimit: '',
+    });
+    expect(bufferResult.bufferLimit).toBeUndefined();
+
+    const concurrentResult = transformDomainSchedulesCreateFormToBody({
+      ...mockDomainSchedulesCreateFormData,
+      overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+      concurrencyLimit: '',
+    });
+    expect(concurrentResult.concurrencyLimit).toBeUndefined();
   });
 });

--- a/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
@@ -116,7 +116,7 @@ describe(transformDomainSchedulesCreateFormToBody.name, () => {
     expect(result.catchUpPolicy).toBe(
       ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE
     );
-    expect(result.catchUpWindowSeconds).toBe(14 * 86400);
+    expect(result.catchUpWindowSeconds).toBe(14 * 24 * 60 * 60);
   });
 
   it('omits catch-up window seconds for skip catch-up policy', () => {

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
@@ -1,5 +1,6 @@
 import pickBy from 'lodash/pickBy';
 
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
 import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
@@ -38,6 +39,7 @@ export default function transformDomainSchedulesCreateFormToBody(
       {
         pauseOnFailure: formData.pauseOnFailure ?? undefined,
         overlapPolicy: formData.overlapPolicy ?? undefined,
+        catchUpPolicy: formData.catchUpPolicy ?? undefined,
         bufferLimit:
           formData.overlapPolicy ===
             ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER &&
@@ -49,6 +51,13 @@ export default function transformDomainSchedulesCreateFormToBody(
             ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT &&
           formData.concurrencyLimit
             ? parseInt(formData.concurrencyLimit, 10)
+            : undefined,
+        catchUpWindowSeconds:
+          formData.catchUpPolicy !== undefined &&
+          formData.catchUpPolicy !==
+            ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP &&
+          formData.catchUpWindowDays
+            ? parseInt(formData.catchUpWindowDays, 10) * 86400
             : undefined,
         scheduleId: formData.scheduleId?.trim() || undefined,
         jitterSeconds: formData.jitterSeconds

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
@@ -57,7 +57,7 @@ export default function transformDomainSchedulesCreateFormToBody(
           formData.catchUpPolicy !==
             ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP &&
           formData.catchUpWindowDays
-            ? parseInt(formData.catchUpWindowDays, 10) * 86400
+            ? parseInt(formData.catchUpWindowDays, 10) * 24 * 60 * 60
             : undefined,
         scheduleId: formData.scheduleId?.trim() || undefined,
         jitterSeconds: formData.jitterSeconds

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -125,7 +125,9 @@ export const createScheduleFormSchema = z
       .refine(
         (v) =>
           v === '' || (Number(v) >= 1 && Number(v) <= MAX_CATCH_UP_WINDOW_DAYS),
-        { message: 'Catch-up window must be between 1 and 90 days' }
+        {
+          message: `Catch-up window must be between 1 and ${MAX_CATCH_UP_WINDOW_DAYS} days`,
+        }
       )
       .optional(),
     jitterSeconds: z

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -1,10 +1,15 @@
 import { z } from 'zod';
 
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
-import { SCHEDULE_OVERLAP_POLICIES } from '@/route-handlers/create-schedule/create-schedule.constants';
+import {
+  SCHEDULE_CATCH_UP_POLICIES,
+  SCHEDULE_OVERLAP_POLICIES,
+} from '@/route-handlers/create-schedule/create-schedule.constants';
 // TODO(refactor): WORKER_SDK_LANGUAGES is imported from start-workflow — extract to shared constants once both features stabilise
 import { WORKER_SDK_LANGUAGES } from '@/route-handlers/start-workflow/start-workflow.constants';
+import { MAX_CATCH_UP_WINDOW_DAYS } from '@/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants';
 import { getCronFieldsError } from '@/views/workflow-actions/workflow-action-start-form/helpers/get-cron-fields-error';
 
 const cronExpressionFieldsSchema = z
@@ -114,6 +119,15 @@ export const createScheduleFormSchema = z
     overlapPolicy: z.enum(SCHEDULE_OVERLAP_POLICIES).optional(),
     bufferLimit: z.string().optional(),
     concurrencyLimit: z.string().optional(),
+    catchUpPolicy: z.enum(SCHEDULE_CATCH_UP_POLICIES).optional(),
+    catchUpWindowDays: z
+      .string()
+      .refine(
+        (v) =>
+          v === '' || (Number(v) >= 1 && Number(v) <= MAX_CATCH_UP_WINDOW_DAYS),
+        { message: 'Catch-up window must be between 1 and 90 days' }
+      )
+      .optional(),
     jitterSeconds: z
       .string()
       .refine((v) => v === '' || Number(v) >= 0, {
@@ -154,6 +168,19 @@ export const createScheduleFormSchema = z
         code: z.ZodIssueCode.custom,
         message: 'Concurrency limit must be a non-negative integer',
         path: ['concurrencyLimit'],
+      });
+    }
+
+    if (
+      data.catchUpPolicy !== undefined &&
+      data.catchUpPolicy !==
+        ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP &&
+      (data.catchUpWindowDays === '' || data.catchUpWindowDays === undefined)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Catch-up window is required',
+        path: ['catchUpWindowDays'],
       });
     }
   });

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -137,6 +137,7 @@ export const createScheduleFormSchema = z
     workflowIdPrefix: z.string().optional(),
   })
   .superRefine((data, ctx) => {
+    // overlap policy fields
     if (
       data.overlapPolicy ===
         ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER &&
@@ -171,6 +172,7 @@ export const createScheduleFormSchema = z
       });
     }
 
+    // catch up policy fields
     if (
       data.catchUpPolicy !== undefined &&
       data.catchUpPolicy !==


### PR DESCRIPTION
## Summary

- Add **Catch-up Policy** radio controls (Skip, Catch-up one, Catch-up all) to the create-schedule advanced accordion, placed after the overlap policy cluster.
- Show **Catch-up window** as an indented subfield when the policy is not Skip; default is 14 days, max 90 days.
- Extend the Zod schema with `catchUpPolicy` / `catchUpWindowDays` validation (window required for non-skip policies; range validated in one refine: "Catch-up window must be between 1 and 90 days").
- Wire `transformDomainSchedulesCreateFormToBody` to pass through `catchUpPolicy` when set and convert window days to `catchUpWindowSeconds` on submit (string form fields, consistent with PR09b).

Stacked on #1381 (PR09b overlap policy).

## Test plan
<img width="1060" height="889" alt="Screenshot 2026-06-25 at 02 50 33" src="https://github.com/user-attachments/assets/8e472bb8-dcd1-4c20-857d-af0c5e6ca625" />
<img width="1049" height="829" alt="Screenshot 2026-06-25 at 02 50 39" src="https://github.com/user-attachments/assets/9f52eb7b-29c4-455d-a60f-e0c5f42ac939" />
<img width="1054" height="849" alt="Screenshot 2026-06-25 at 02 50 53" src="https://github.com/user-attachments/assets/e2886ec1-46ca-4e28-ae0b-c745cedc0926" />
<img width="1049" height="850" alt="Screenshot 2026-06-25 at 02 50 57" src="https://github.com/user-attachments/assets/c87e86b4-8937-4902-9667-e7bf073f0d0c" />

## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- Schedules Create Form
  - #1302
  - #1303
  - #1305
  - #1306
  - #1307
  - #1340
  - #1342
  - #1343
  - #1381
  - #1387
- Schedules Details
- Schedules Actions