### PR TITLE
feat(schedules): add memo and search attributes to advanced create form

### DIFF
--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -7,6 +7,20 @@ import { render, screen, userEvent } from '@/test-utils/rtl';
 import { type DomainSchedulesCreateFormData } from '../../domain-schedules-create-modal/domain-schedules-create-modal.types';
 import DomainSchedulesCreateAdvancedForm from '../domain-schedules-create-advanced-form';
 
+jest.mock(
+  '@/views/shared/hooks/use-search-attributes/use-search-attributes',
+  () =>
+    jest.fn(() => ({
+      data: {
+        keys: {
+          CustomKeywordField: 'INDEXED_VALUE_TYPE_STRING',
+          CustomIntField: 'INDEXED_VALUE_TYPE_INT',
+        },
+      },
+      isLoading: false,
+    }))
+);
+
 describe(DomainSchedulesCreateAdvancedForm.name, () => {
   it('renders the accordion toggle and is collapsed by default', () => {
     setup();
@@ -32,6 +46,8 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
     expect(screen.getByLabelText('Workflow Id Prefix')).toBeInTheDocument();
     expect(screen.getByLabelText('Schedule period start')).toBeInTheDocument();
     expect(screen.getByLabelText('Schedule period end')).toBeInTheDocument();
+    expect(screen.getByLabelText('Memo')).toBeInTheDocument();
+    expect(screen.getByLabelText('Search attribute key')).toBeInTheDocument();
     expect(
       screen.getByRole('combobox', { name: /overlap policy/i })
     ).toBeInTheDocument();
@@ -150,6 +166,7 @@ function setup() {
       <DomainSchedulesCreateAdvancedForm
         control={control}
         fieldErrors={fieldErrors}
+        cluster="test-cluster"
       />
     );
   }

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -18,6 +18,10 @@ export const CREATE_SCHEDULE_ADVANCED_FIELD_IDS = {
   workflowIdPrefix: 'domain-schedules-create-form-workflow-id-prefix',
   bufferLimit: 'domain-schedules-create-form-buffer-limit',
   concurrencyLimit: 'domain-schedules-create-form-concurrency-limit',
+  catchUpWindowDays: 'domain-schedules-create-form-catch-up-window-days',
+  startTime: 'domain-schedules-create-form-start-time',
+  endTime: 'domain-schedules-create-form-end-time',
+  memo: 'domain-schedules-create-form-memo',
 } as const;
 
 export const CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS = {
@@ -28,10 +32,17 @@ export const CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS = {
     'Max number of pending workflows allowed when using Buffer overlap policy.',
   concurrencyLimit:
     'Max number of concurrently running workflows allowed for Concurrent overlap policy.',
+  catchUpPolicy: 'Controls whether missed schedules should run after downtime.',
+  catchUpWindowDays:
+    'Maximum age of missed schedules that can still be started.',
+  schedulePeriod: 'Optional time range that limits when this schedule can run.',
+  searchAttributes:
+    'Additional indexed attributes attached to each started workflow.',
   jitterSeconds:
     'Time range to distribute starting workflows across. This helps avoiding burst of workflow creations in a single point of time.',
   workflowIdPrefix:
     'Prefix text to add into started workflows. Ids are formed as `${Prefix}+{auto generated postfix}`.',
+  memo: 'JSON object that is attached to each started workflow.',
 } as const;
 
 export const DEFAULT_CATCH_UP_POLICY =

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { StatefulPanel } from 'baseui/accordion';
 import { Button } from 'baseui/button';
@@ -10,14 +10,20 @@ import { mergeOverrides } from 'baseui/helpers/overrides';
 import { Input } from 'baseui/input';
 import { Radio, RadioGroup } from 'baseui/radio';
 import { Select } from 'baseui/select';
+import { Textarea } from 'baseui/textarea';
 import { LabelXSmall } from 'baseui/typography';
 import { Controller, useWatch } from 'react-hook-form';
 import { MdExpandLess, MdExpandMore } from 'react-icons/md';
 
 import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import useSearchAttributes from '@/views/shared/hooks/use-search-attributes/use-search-attributes';
 import DomainSchedulesHorizontalField from '@/views/domain-schedules/domain-schedules-horizontal-field/domain-schedules-horizontal-field';
+// TODO(refactor): getSearchAttributesErrorMessage is imported from start-workflow helpers — extract to shared utils
 import getFieldErrorMessage from '@/views/workflow-actions/workflow-action-start-form/helpers/get-field-error-message';
+import getSearchAttributesErrorMessage from '@/views/workflow-actions/workflow-action-start-form/helpers/get-search-attributes-error-message';
+// TODO(refactor): WorkflowActionsSearchAttributes is imported from start-workflow feature — extract shared component under views/shared
+import WorkflowActionsSearchAttributes from '@/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes';
 
 import {
   CATCH_UP_POLICY_OPTIONS,
@@ -39,7 +45,23 @@ export default function DomainSchedulesCreateAdvancedForm({
   fieldErrors,
   trigger,
   isSubmitted = false,
+  cluster,
 }: Props) {
+  const { data: searchAttributesData, isLoading: isLoadingSearchAttributes } =
+    useSearchAttributes({ cluster, category: 'custom' });
+  const searchAttributesError = getSearchAttributesErrorMessage(
+    fieldErrors,
+    'searchAttributes'
+  );
+
+  const searchAttributesOptions = useMemo(() => {
+    return Object.entries(searchAttributesData?.keys || {}).map(
+      ([name, valueType]) => ({
+        name,
+        valueType,
+      })
+    );
+  }, [searchAttributesData?.keys]);
   const overlapPolicy = useWatch({
     control,
     name: 'overlapPolicy',
@@ -367,6 +389,60 @@ export default function DomainSchedulesCreateAdvancedForm({
               </FormControl>
             </styled.SchedulePeriodField>
           </styled.SchedulePeriodRow>
+        </DomainSchedulesHorizontalField>
+
+        <DomainSchedulesHorizontalField
+          label="Memo (optional)"
+          description="JSON object that is attached to each started workflow."
+          htmlFor="create-schedule-form-memo"
+          error={getFieldErrorMessage(fieldErrors, 'memo')}
+        >
+          <Controller
+            name="memo"
+            control={control}
+            render={({ field: { ref, ...field } }) => (
+              <Textarea
+                {...field}
+                value={field.value ?? ''}
+                id="create-schedule-form-memo"
+                // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
+                inputRef={ref}
+                aria-label="Memo"
+                onChange={(e) => field.onChange(e.target.value)}
+                onBlur={field.onBlur}
+                error={Boolean(getFieldErrorMessage(fieldErrors, 'memo'))}
+                size="compact"
+                placeholder='{"key":"value"}'
+                rows={3}
+              />
+            )}
+          />
+        </DomainSchedulesHorizontalField>
+
+        <DomainSchedulesHorizontalField
+          label="Search attributes (optional)"
+          description="Additional indexed attributes attached to each started workflow."
+          error={
+            typeof searchAttributesError === 'string'
+              ? searchAttributesError
+              : undefined
+          }
+        >
+          <Controller
+            name="searchAttributes"
+            control={control}
+            defaultValue={[]}
+            render={({ field }) => (
+              <WorkflowActionsSearchAttributes
+                value={field.value}
+                onChange={field.onChange}
+                searchAttributes={searchAttributesOptions}
+                isLoading={isLoadingSearchAttributes}
+                error={searchAttributesError}
+                showSectionBorder={false}
+              />
+            )}
+          />
         </DomainSchedulesHorizontalField>
 
         <DomainSchedulesHorizontalField

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -17,8 +17,8 @@ import { MdExpandLess, MdExpandMore } from 'react-icons/md';
 
 import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
-import useSearchAttributes from '@/views/shared/hooks/use-search-attributes/use-search-attributes';
 import DomainSchedulesHorizontalField from '@/views/domain-schedules/domain-schedules-horizontal-field/domain-schedules-horizontal-field';
+import useSearchAttributes from '@/views/shared/hooks/use-search-attributes/use-search-attributes';
 // TODO(refactor): getSearchAttributesErrorMessage is imported from start-workflow helpers — extract to shared utils
 import getFieldErrorMessage from '@/views/workflow-actions/workflow-action-start-form/helpers/get-field-error-message';
 import getSearchAttributesErrorMessage from '@/views/workflow-actions/workflow-action-start-form/helpers/get-search-attributes-error-message';
@@ -242,7 +242,9 @@ export default function DomainSchedulesCreateAdvancedForm({
 
         <DomainSchedulesHorizontalField
           label="Catch-up Policy"
-          description="Controls whether missed schedules should run after downtime."
+          description={
+            CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.catchUpPolicy
+          }
           error={getFieldErrorMessage(fieldErrors, 'catchUpPolicy')}
         >
           <Controller
@@ -277,8 +279,10 @@ export default function DomainSchedulesCreateAdvancedForm({
           <DomainSchedulesHorizontalField
             subfield={true}
             label="Catch-up window"
-            description="Maximum age of missed schedules that can still be started."
-            htmlFor="create-schedule-form-catch-up-window-days"
+            description={
+              CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.catchUpWindowDays
+            }
+            htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.catchUpWindowDays}
             error={getFieldErrorMessage(fieldErrors, 'catchUpWindowDays')}
           >
             <Controller
@@ -287,7 +291,7 @@ export default function DomainSchedulesCreateAdvancedForm({
               render={({ field: { ref, ...field } }) => (
                 <Input
                   {...field}
-                  id="create-schedule-form-catch-up-window-days"
+                  id={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.catchUpWindowDays}
                   // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
                   inputRef={ref}
                   aria-label="Catch-up window"
@@ -309,11 +313,15 @@ export default function DomainSchedulesCreateAdvancedForm({
 
         <DomainSchedulesHorizontalField
           label="Schedule period"
-          description="Optional time range that limits when this schedule can run."
+          description={
+            CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.schedulePeriod
+          }
         >
           <styled.SchedulePeriodRow>
             <styled.SchedulePeriodField>
-              <styled.SchedulePeriodInputLabel htmlFor="create-schedule-form-start-time">
+              <styled.SchedulePeriodInputLabel
+                htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.startTime}
+              >
                 Start date
               </styled.SchedulePeriodInputLabel>
               <FormControl
@@ -328,7 +336,7 @@ export default function DomainSchedulesCreateAdvancedForm({
                       {...field}
                       // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
                       inputRef={ref}
-                      id="create-schedule-form-start-time"
+                      id={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.startTime}
                       aria-label="Schedule period start"
                       value={value ? [new Date(value)] : []}
                       onChange={({ date }) => {
@@ -351,7 +359,9 @@ export default function DomainSchedulesCreateAdvancedForm({
               </FormControl>
             </styled.SchedulePeriodField>
             <styled.SchedulePeriodField>
-              <styled.SchedulePeriodInputLabel htmlFor="create-schedule-form-end-time">
+              <styled.SchedulePeriodInputLabel
+                htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.endTime}
+              >
                 End date
               </styled.SchedulePeriodInputLabel>
               <FormControl
@@ -366,7 +376,7 @@ export default function DomainSchedulesCreateAdvancedForm({
                       {...field}
                       // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
                       inputRef={ref}
-                      id="create-schedule-form-end-time"
+                      id={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.endTime}
                       aria-label="Schedule period end"
                       value={value ? [new Date(value)] : []}
                       onChange={({ date }) => {
@@ -392,40 +402,9 @@ export default function DomainSchedulesCreateAdvancedForm({
         </DomainSchedulesHorizontalField>
 
         <DomainSchedulesHorizontalField
-          label="Memo (optional)"
-          description="JSON object that is attached to each started workflow."
-          htmlFor="create-schedule-form-memo"
-          error={getFieldErrorMessage(fieldErrors, 'memo')}
-        >
-          <Controller
-            name="memo"
-            control={control}
-            render={({ field: { ref, ...field } }) => (
-              <Textarea
-                {...field}
-                value={field.value ?? ''}
-                id="create-schedule-form-memo"
-                // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
-                inputRef={ref}
-                aria-label="Memo"
-                onChange={(e) => field.onChange(e.target.value)}
-                onBlur={field.onBlur}
-                error={Boolean(getFieldErrorMessage(fieldErrors, 'memo'))}
-                size="compact"
-                placeholder='{"key":"value"}'
-                rows={3}
-              />
-            )}
-          />
-        </DomainSchedulesHorizontalField>
-
-        <DomainSchedulesHorizontalField
-          label="Search attributes (optional)"
-          description="Additional indexed attributes attached to each started workflow."
-          error={
-            typeof searchAttributesError === 'string'
-              ? searchAttributesError
-              : undefined
+          label="Search attributes"
+          description={
+            CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.searchAttributes
           }
         >
           <Controller
@@ -435,11 +414,44 @@ export default function DomainSchedulesCreateAdvancedForm({
             render={({ field }) => (
               <WorkflowActionsSearchAttributes
                 value={field.value}
-                onChange={field.onChange}
+                onChange={(value) => {
+                  field.onChange(value);
+                  if (isSubmitted) {
+                    trigger?.('searchAttributes');
+                  }
+                }}
                 searchAttributes={searchAttributesOptions}
                 isLoading={isLoadingSearchAttributes}
                 error={searchAttributesError}
                 showSectionBorder={false}
+              />
+            )}
+          />
+        </DomainSchedulesHorizontalField>
+
+        <DomainSchedulesHorizontalField
+          label="Memo"
+          description={CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.memo}
+          htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.memo}
+          error={getFieldErrorMessage(fieldErrors, 'memo')}
+        >
+          <Controller
+            name="memo"
+            control={control}
+            render={({ field: { ref, ...field } }) => (
+              <Textarea
+                {...field}
+                value={field.value ?? ''}
+                id={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.memo}
+                // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
+                inputRef={ref}
+                aria-label="Memo"
+                onChange={(e) => field.onChange(e.target.value)}
+                onBlur={field.onBlur}
+                error={Boolean(getFieldErrorMessage(fieldErrors, 'memo'))}
+                size="compact"
+                placeholder='{"key":"value"}'
+                rows={3}
               />
             )}
           />

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -424,6 +424,7 @@ export default function DomainSchedulesCreateAdvancedForm({
                 isLoading={isLoadingSearchAttributes}
                 error={searchAttributesError}
                 showSectionBorder={false}
+                showFieldErrorMessages
               />
             )}
           />

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
@@ -11,4 +11,5 @@ export type Props = {
   fieldErrors: FieldErrors<DomainSchedulesCreateFormData>;
   trigger?: UseFormTrigger<DomainSchedulesCreateFormData>;
   isSubmitted?: boolean;
+  cluster: string;
 };

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -168,12 +168,11 @@ function TestWrapper({
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
   injectFieldErrors?: boolean;
 }) {
-  const { control, trigger, setError } = useForm<DomainSchedulesCreateFormData>(
-    {
+  const { control, trigger, setError, clearErrors } =
+    useForm<DomainSchedulesCreateFormData>({
       defaultValues: { ...defaultValues },
       mode: 'onSubmit',
-    }
-  );
+    });
 
   useEffect(() => {
     if (!injectFieldErrors) return;
@@ -182,7 +181,14 @@ function TestWrapper({
     }
   }, [injectFieldErrors, setError]);
 
-  return <DomainSchedulesCreateForm control={control} trigger={trigger} />;
+  return (
+    <DomainSchedulesCreateForm
+      control={control}
+      trigger={trigger}
+      clearErrors={clearErrors}
+      cluster="test-cluster"
+    />
+  );
 }
 
 async function setup({

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -168,11 +168,12 @@ function TestWrapper({
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
   injectFieldErrors?: boolean;
 }) {
-  const { control, trigger, setError } =
-    useForm<DomainSchedulesCreateFormData>({
+  const { control, trigger, setError } = useForm<DomainSchedulesCreateFormData>(
+    {
       defaultValues: { ...defaultValues },
       mode: 'onSubmit',
-    });
+    }
+  );
 
   useEffect(() => {
     if (!injectFieldErrors) return;

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -168,7 +168,7 @@ function TestWrapper({
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
   injectFieldErrors?: boolean;
 }) {
-  const { control, trigger, setError, clearErrors } =
+  const { control, trigger, setError } =
     useForm<DomainSchedulesCreateFormData>({
       defaultValues: { ...defaultValues },
       mode: 'onSubmit',
@@ -185,7 +185,6 @@ function TestWrapper({
     <DomainSchedulesCreateForm
       control={control}
       trigger={trigger}
-      clearErrors={clearErrors}
       cluster="test-cluster"
     />
   );

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -30,7 +30,6 @@ import { type Props } from './domain-schedules-create-form.types';
 export default function DomainSchedulesCreateForm({
   control,
   trigger,
-  clearErrors: _clearErrors,
   cluster,
 }: Props) {
   const { errors: fieldErrors, isSubmitted } = useFormState({ control });

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -27,7 +27,12 @@ import {
 import { overrides } from './domain-schedules-create-form.styles';
 import { type Props } from './domain-schedules-create-form.types';
 
-export default function DomainSchedulesCreateForm({ control, trigger }: Props) {
+export default function DomainSchedulesCreateForm({
+  control,
+  trigger,
+  clearErrors: _clearErrors,
+  cluster,
+}: Props) {
   const { errors: fieldErrors, isSubmitted } = useFormState({ control });
   const cronExpressionError = getFieldObjectErrorMessages(
     fieldErrors,
@@ -308,6 +313,7 @@ export default function DomainSchedulesCreateForm({ control, trigger }: Props) {
         fieldErrors={fieldErrors}
         trigger={trigger}
         isSubmitted={isSubmitted}
+        cluster={cluster}
       />
     </div>
   );

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -1,14 +1,9 @@
-import {
-  type Control,
-  type UseFormClearErrors,
-  type UseFormTrigger,
-} from 'react-hook-form';
+import { type Control, type UseFormTrigger } from 'react-hook-form';
 
 import { type DomainSchedulesCreateFormData } from '../domain-schedules-create-modal/domain-schedules-create-modal.types';
 
 export type Props = {
   control: Control<DomainSchedulesCreateFormData>;
   trigger: UseFormTrigger<DomainSchedulesCreateFormData>;
-  clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   cluster: string;
 };

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -1,8 +1,10 @@
-import { type Control, type UseFormTrigger } from 'react-hook-form';
+import { type Control, type UseFormClearErrors, type UseFormTrigger } from 'react-hook-form';
 
 import { type DomainSchedulesCreateFormData } from '../domain-schedules-create-modal/domain-schedules-create-modal.types';
 
 export type Props = {
   control: Control<DomainSchedulesCreateFormData>;
   trigger: UseFormTrigger<DomainSchedulesCreateFormData>;
+  clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
+  cluster: string;
 };

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -1,4 +1,8 @@
-import { type Control, type UseFormClearErrors, type UseFormTrigger } from 'react-hook-form';
+import {
+  type Control,
+  type UseFormClearErrors,
+  type UseFormTrigger,
+} from 'react-hook-form';
 
 import { type DomainSchedulesCreateFormData } from '../domain-schedules-create-modal/domain-schedules-create-modal.types';
 

--- a/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
@@ -175,4 +175,32 @@ describe(transformDomainSchedulesCreateFormToBody.name, () => {
     expect(result.startTime).toBeUndefined();
     expect(result.endTime).toBeUndefined();
   });
+
+  it('maps memo JSON and search attributes into startWorkflow', () => {
+    const result = transformDomainSchedulesCreateFormToBody({
+      ...mockDomainSchedulesCreateFormData,
+      memo: '{"k":"v"}',
+      searchAttributes: [
+        { key: 'CustomKeywordField', value: 'value-1' },
+        { key: 'CustomIntField', value: 9 },
+      ],
+    });
+
+    expect(result.startWorkflow.memo).toEqual({ k: 'v' });
+    expect(result.startWorkflow.searchAttributes).toEqual({
+      CustomKeywordField: 'value-1',
+      CustomIntField: 9,
+    });
+  });
+
+  it('omits memo and search attributes when empty', () => {
+    const result = transformDomainSchedulesCreateFormToBody({
+      ...mockDomainSchedulesCreateFormData,
+      memo: '  ',
+      searchAttributes: [],
+    });
+
+    expect(result.startWorkflow.memo).toBeUndefined();
+    expect(result.startWorkflow.searchAttributes).toBeUndefined();
+  });
 });

--- a/src/views/domain-schedules/domain-schedules-create-modal/domain-schedules-create-modal.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-modal/domain-schedules-create-modal.tsx
@@ -107,7 +107,12 @@ export default function DomainSchedulesCreateModal({
               </Banner>
             </div>
           )}
-          <DomainSchedulesCreateForm control={control} trigger={trigger} />
+          <DomainSchedulesCreateForm
+            control={control}
+            trigger={trigger}
+            clearErrors={clearErrors}
+            cluster={cluster}
+          />
         </styled.ModalBody>
         <styled.ModalFooter>
           <ModalButton

--- a/src/views/domain-schedules/domain-schedules-create-modal/domain-schedules-create-modal.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-modal/domain-schedules-create-modal.tsx
@@ -110,7 +110,6 @@ export default function DomainSchedulesCreateModal({
           <DomainSchedulesCreateForm
             control={control}
             trigger={trigger}
-            clearErrors={clearErrors}
             cluster={cluster}
           />
         </styled.ModalBody>

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/__tests__/refine-create-schedule-form.test.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/__tests__/refine-create-schedule-form.test.ts
@@ -102,6 +102,28 @@ describe(refineCreateScheduleForm.name, () => {
       }),
     ]);
   });
+
+  it('accepts valid memo JSON object', () => {
+    expect(getIssues({ memo: '{"k":"v"}' })).toEqual([]);
+  });
+
+  it('rejects invalid memo JSON', () => {
+    expect(getIssues({ memo: 'not-json' })).toEqual([
+      expect.objectContaining({
+        path: ['memo'],
+        message: 'Memo must be valid JSON',
+      }),
+    ]);
+  });
+
+  it('rejects memo JSON that is not an object', () => {
+    expect(getIssues({ memo: '["array"]' })).toEqual([
+      expect.objectContaining({
+        path: ['memo'],
+        message: 'Memo must be a JSON object',
+      }),
+    ]);
+  });
 });
 
 function getIssues(overrides: Partial<CreateScheduleFormRefineInput> = {}) {

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form.ts
@@ -1,3 +1,4 @@
+import isPlainObject from 'lodash/isPlainObject';
 import { z } from 'zod';
 
 import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
@@ -73,11 +74,7 @@ export default function refineCreateScheduleForm(
   if (data.memo && data.memo.trim() !== '') {
     try {
       const parsedMemo = JSON.parse(data.memo);
-      const isObject =
-        typeof parsedMemo === 'object' &&
-        parsedMemo !== null &&
-        !Array.isArray(parsedMemo);
-      if (!isObject) {
+      if (!isPlainObject(parsedMemo)) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Memo must be a JSON object',

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form.ts
@@ -69,4 +69,27 @@ export default function refineCreateScheduleForm(
       path: ['startTime'],
     });
   }
+
+  if (data.memo && data.memo.trim() !== '') {
+    try {
+      const parsedMemo = JSON.parse(data.memo);
+      const isObject =
+        typeof parsedMemo === 'object' &&
+        parsedMemo !== null &&
+        !Array.isArray(parsedMemo);
+      if (!isObject) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Memo must be a JSON object',
+          path: ['memo'],
+        });
+      }
+    } catch {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Memo must be valid JSON',
+        path: ['memo'],
+      });
+    }
+  }
 }

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
@@ -18,6 +18,16 @@ export default function transformDomainSchedulesCreateFormToBody(
   const parsedInput = formData.input
     ?.filter((v) => v.trim() !== '')
     .map((v) => JSON.parse(v) as Json);
+  const parsedMemo =
+    formData.memo && formData.memo.trim() !== ''
+      ? (JSON.parse(formData.memo) as Record<string, unknown>)
+      : undefined;
+  const mappedSearchAttributes =
+    formData.searchAttributes && formData.searchAttributes.length > 0
+      ? Object.fromEntries(
+          formData.searchAttributes.map(({ key, value }) => [key, value])
+        )
+      : undefined;
 
   return {
     cronExpression: cronString,
@@ -29,6 +39,10 @@ export default function transformDomainSchedulesCreateFormToBody(
         formData.executionStartToCloseTimeoutSeconds,
       taskStartToCloseTimeoutSeconds: formData.taskStartToCloseTimeoutSeconds,
       ...(parsedInput && parsedInput.length > 0 ? { input: parsedInput } : {}),
+      ...(parsedMemo ? { memo: parsedMemo } : {}),
+      ...(mappedSearchAttributes
+        ? { searchAttributes: mappedSearchAttributes }
+        : {}),
       ...(formData.workflowIdPrefix?.trim()
         ? { workflowIdPrefix: formData.workflowIdPrefix.trim() }
         : {}),

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -140,8 +140,12 @@ export const createScheduleFormFieldsSchema = z.object({
   searchAttributes: z
     .array(
       z.object({
-        key: z.string().min(1, 'Search attribute key is required'),
-        value: z.union([z.string(), z.number(), z.boolean()]),
+        key: z.string().min(1, 'Attribute key is required'),
+        value: z.union([
+          z.string().min(1, 'Attribute value is required'),
+          z.number(),
+          z.boolean(),
+        ]),
       })
     )
     .optional(),

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -136,6 +136,15 @@ export const createScheduleFormFieldsSchema = z.object({
     .optional(),
   startTime: z.string().datetime('Start time must be valid').optional(),
   endTime: z.string().datetime('End time must be valid').optional(),
+  memo: z.string().optional(),
+  searchAttributes: z
+    .array(
+      z.object({
+        key: z.string().min(1, 'Search attribute key is required'),
+        value: z.union([z.string(), z.number(), z.boolean()]),
+      })
+    )
+    .optional(),
   workflowIdPrefix: z.string().optional(),
 });
 

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
@@ -40,8 +40,6 @@ export default function ScheduleActionsModalContent<
     handleSubmit,
     formState: { errors: validationErrors, isSubmitting },
     control,
-    clearErrors,
-    trigger,
   } = useForm<OptionalFormData>({
     resolver: action.modal.formSchema
       ? zodResolver(action.modal.formSchema)
@@ -150,9 +148,7 @@ export default function ScheduleActionsModalContent<
             {action.modal.withForm && Form && (
               <Form
                 fieldErrors={validationErrors}
-                clearErrors={clearErrors}
                 control={control}
-                trigger={trigger}
                 cluster={params.cluster}
                 domain={params.domain}
                 scheduleId={params.scheduleId}

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -5,11 +5,9 @@ import { type KIND as BANNER_KIND } from 'baseui/banner';
 import { type IconProps } from 'baseui/icon';
 import { type AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
 import {
-  type UseFormClearErrors,
   type Control,
   type FieldErrors,
   type FieldValues,
-  type UseFormTrigger,
 } from 'react-hook-form';
 import { type z } from 'zod';
 
@@ -35,8 +33,6 @@ export type ScheduleActionInput<SubmissionData> = ScheduleActionInputParams & {
 export type ScheduleActionFormProps<FormData extends FieldValues> = {
   fieldErrors: FieldErrors<FormData>;
   control: Control<FormData>;
-  clearErrors: UseFormClearErrors<FormData>;
-  trigger: UseFormTrigger<FormData>;
   cluster: string;
   domain: string;
   scheduleId: string;

--- a/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.tsx
+++ b/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.tsx
@@ -314,6 +314,7 @@ export default function WorkflowActionStartForm({
         clearErrors={clearErrors}
         formData={formData}
         fieldErrors={fieldErrors}
+        trigger={trigger}
         cluster={cluster}
         domain={domain}
       />

--- a/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.types.ts
+++ b/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.types.ts
@@ -11,7 +11,7 @@ export type Props = WorkflowActionFormProps<StartWorkflowFormData>;
 
 export type SubFormProps = Pick<
   Props,
-  'control' | 'clearErrors' | 'formData' | 'fieldErrors'
+  'control' | 'clearErrors' | 'formData' | 'fieldErrors' | 'trigger'
 >;
 
 export type StartWorkflowFormData = z.infer<typeof startWorkflowFormSchema>;

--- a/src/views/workflow-actions/workflow-action-start-optional-section/__tests__/workflow-action-start-optional-section.test.tsx
+++ b/src/views/workflow-actions/workflow-action-start-optional-section/__tests__/workflow-action-start-optional-section.test.tsx
@@ -210,6 +210,7 @@ function TestWrapper({ formData, fieldErrors }: TestProps) {
       clearErrors={methods.clearErrors}
       formData={formData}
       fieldErrors={fieldErrors}
+      trigger={methods.trigger}
       cluster="test-cluster"
       domain="test-domain"
     />

--- a/src/views/workflow-actions/workflow-action-start-optional-section/workflow-action-start-optional-section.tsx
+++ b/src/views/workflow-actions/workflow-action-start-optional-section/workflow-action-start-optional-section.tsx
@@ -33,6 +33,7 @@ export default function WorkflowActionStartOptionalSection({
   clearErrors,
   formData,
   fieldErrors,
+  trigger,
   cluster,
   domain,
 }: Props) {
@@ -146,6 +147,7 @@ export default function WorkflowActionStartOptionalSection({
           clearErrors={clearErrors}
           formData={formData}
           fieldErrors={fieldErrors}
+          trigger={trigger}
         />
 
         <FormControl label="Header (optional)">
@@ -206,7 +208,10 @@ export default function WorkflowActionStartOptionalSection({
             render={({ field }) => (
               <WorkflowActionsSearchAttributes
                 value={field.value}
-                onChange={field.onChange}
+                onChange={(value) => {
+                  field.onChange(value);
+                  trigger('searchAttributes');
+                }}
                 searchAttributes={searchAttributesOptions}
                 isLoading={isLoadingSearchAttributes}
                 error={getSearchAttributesErrorMessage(

--- a/src/views/workflow-actions/workflow-action-start-optional-section/workflow-action-start-optional-section.tsx
+++ b/src/views/workflow-actions/workflow-action-start-optional-section/workflow-action-start-optional-section.tsx
@@ -205,12 +205,12 @@ export default function WorkflowActionStartOptionalSection({
             name="searchAttributes"
             control={control}
             defaultValue={[]}
-            render={({ field }) => (
+            render={({ field, formState: { isSubmitted } }) => (
               <WorkflowActionsSearchAttributes
                 value={field.value}
                 onChange={(value) => {
                   field.onChange(value);
-                  trigger('searchAttributes');
+                  if (isSubmitted) trigger('searchAttributes');
                 }}
                 searchAttributes={searchAttributesOptions}
                 isLoading={isLoadingSearchAttributes}

--- a/src/views/workflow-actions/workflow-action-start-retry-policy/__tests__/workflow-action-start-retry-policy.test.tsx
+++ b/src/views/workflow-actions/workflow-action-start-retry-policy/__tests__/workflow-action-start-retry-policy.test.tsx
@@ -159,6 +159,7 @@ function TestWrapper({ formData, fieldErrors }: TestProps) {
       clearErrors={methods.clearErrors}
       formData={formData}
       fieldErrors={fieldErrors}
+      trigger={methods.trigger}
     />
   );
 }

--- a/src/views/workflow-actions/workflow-actions-search-attributes/__tests__/workflow-actions-search-attributes.test.tsx
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/__tests__/workflow-actions-search-attributes.test.tsx
@@ -239,6 +239,7 @@ describe(SearchAttributesInput.name, () => {
 
   it('should display field-specific error state', () => {
     setup({
+      showFieldErrorMessages: true,
       value: [
         { key: 'WorkflowType', value: 'test' },
         { key: 'StartTime', value: '' },
@@ -259,6 +260,28 @@ describe(SearchAttributesInput.name, () => {
     expect(allValueInputs[0]).not.toHaveAttribute('aria-invalid', 'true');
     expect(allValueInputs[1]).toHaveAttribute('aria-invalid', 'true');
     expect(screen.getByText('Value is required')).toBeInTheDocument();
+  });
+
+  it('shows error borders without messages by default', () => {
+    setup({
+      value: [
+        { key: 'WorkflowType', value: 'test' },
+        { key: 'StartTime', value: '' },
+      ],
+      error: [
+        undefined,
+        {
+          value: 'Value is required',
+        },
+      ],
+    });
+
+    const allValueInputs = screen.getAllByRole('textbox', {
+      name: 'Search attribute value',
+    });
+
+    expect(allValueInputs[1]).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.queryByText('Value is required')).not.toBeInTheDocument();
   });
 
   it('should be searchable in the key select dropdown', async () => {

--- a/src/views/workflow-actions/workflow-actions-search-attributes/__tests__/workflow-actions-search-attributes.test.tsx
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/__tests__/workflow-actions-search-attributes.test.tsx
@@ -224,12 +224,12 @@ describe(SearchAttributesInput.name, () => {
     expect(screen.getByLabelText('Delete attribute')).toBeDisabled();
   });
 
-  it('should display global error state on fields', () => {
+  it('applies error state to inputs when string error prop is provided', () => {
     setup({
       error: 'Global error message',
     });
 
-    // Global errors apply error state to all fields (aria-invalid="true")
+    // string error marks inputs invalid; message is shown by parent FormControl
     const valueInput = screen.getByRole('textbox', {
       name: 'Search attribute value',
     });
@@ -255,8 +255,10 @@ describe(SearchAttributesInput.name, () => {
       name: 'Search attribute value',
     });
 
-    expect(allValueInputs[0]).toHaveAttribute('aria-invalid', 'false');
+    expect(allValueInputs).toHaveLength(2);
+    expect(allValueInputs[0]).not.toHaveAttribute('aria-invalid', 'true');
     expect(allValueInputs[1]).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText('Value is required')).toBeInTheDocument();
   });
 
   it('should be searchable in the key select dropdown', async () => {

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.styles.ts
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.styles.ts
@@ -31,6 +31,8 @@ const cssStylesObj = {
     display: 'flex',
     flexDirection: 'column',
     gap: theme.sizing.scale600,
+  }),
+  containerWithBorder: (theme: Theme) => ({
     borderLeft: `2px solid ${theme.colors.borderOpaque}`,
     paddingLeft: theme.sizing.scale600,
   }),

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.styles.ts
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.styles.ts
@@ -1,4 +1,4 @@
-import { type Theme } from 'baseui';
+import { styled as createStyled, type Theme } from 'baseui';
 import { type FormControlOverrides } from 'baseui/form-control';
 import { type InputOverrides } from 'baseui/input';
 import { type SelectOverrides } from 'baseui/select';
@@ -8,6 +8,21 @@ import type {
   StyletronCSSObject,
   StyletronCSSObjectOf,
 } from '@/hooks/use-styletron-classes';
+
+export const styled = {
+  Container: createStyled<'div', { $showSectionBorder?: boolean }>(
+    'div',
+    ({ $theme, $showSectionBorder }) => ({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: $theme.sizing.scale600,
+      ...($showSectionBorder && {
+        borderLeft: `2px solid ${$theme.colors.borderOpaque}`,
+        paddingLeft: $theme.sizing.scale600,
+      }),
+    })
+  ),
+};
 
 export const overrides = {
   fieldFormControl: {
@@ -35,15 +50,6 @@ export const overrides = {
 };
 
 const cssStylesObj = {
-  container: (theme: Theme) => ({
-    display: 'flex',
-    flexDirection: 'column',
-    gap: theme.sizing.scale600,
-  }),
-  containerWithBorder: (theme: Theme) => ({
-    borderLeft: `2px solid ${theme.colors.borderOpaque}`,
-    paddingLeft: theme.sizing.scale600,
-  }),
   attributeRow: (theme: Theme) => ({
     display: 'flex',
     alignItems: 'flex-start',

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.styles.ts
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.styles.ts
@@ -1,4 +1,5 @@
 import { type Theme } from 'baseui';
+import { type FormControlOverrides } from 'baseui/form-control';
 import { type InputOverrides } from 'baseui/input';
 import { type SelectOverrides } from 'baseui/select';
 import { type StyleObject } from 'styletron-react';
@@ -9,6 +10,13 @@ import type {
 } from '@/hooks/use-styletron-classes';
 
 export const overrides = {
+  fieldFormControl: {
+    ControlContainer: {
+      style: {
+        marginBottom: 0,
+      },
+    },
+  } satisfies FormControlOverrides,
   keySelect: {
     Root: {
       style: (): StyleObject => ({

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useMemo } from 'react';
 
 import { Button } from 'baseui/button';
 import { DatePicker } from 'baseui/datepicker';
+import { FormControl } from 'baseui/form-control';
 import { Input } from 'baseui/input';
 import { Select } from 'baseui/select';
 import { MdAdd, MdDeleteOutline } from 'react-icons/md';
@@ -47,14 +48,12 @@ export default function WorkflowActionsSearchAttributes({
   }, [searchAttributes, value]);
 
   const getFieldError = useCallback(
-    (index: number, field: 'key' | 'value'): boolean => {
-      if (typeof error === 'string') return true; // Global error affects all
+    (index: number, field: 'key' | 'value'): string | true | undefined => {
+      if (typeof error === 'string') return true;
       if (Array.isArray(error)) {
-        const fieldError = error[index];
-        if (!fieldError) return false;
-        return Boolean(fieldError[field]);
+        return error[index]?.[field];
       }
-      return false;
+      return undefined;
     },
     [error]
   );
@@ -167,17 +166,17 @@ export default function WorkflowActionsSearchAttributes({
   const renderValueInput = useCallback(
     (item: SearchAttributeItem, index: number) => {
       const selectedAttribute = selectedAttributes[index];
-      const inputError = getFieldError(index, 'value');
+      const valueError = getFieldError(index, 'value');
       const inputPlaceholder =
         INPUT_PLACEHOLDERS_FOR_VALUE_TYPE[selectedAttribute?.valueType] ||
         'Enter value';
 
-      // Common input value props
       const commonInputProps = {
         'aria-label': 'Search attribute value',
         placeholder: inputPlaceholder,
         size: 'compact' as const,
-        error: inputError,
+        // FormControl shows message text; input error is still required for border/aria-invalid (see multi-json-input).
+        error: valueError !== undefined,
         overrides: overrides.valueInput,
       };
 
@@ -268,30 +267,43 @@ export default function WorkflowActionsSearchAttributes({
         const deleteButtonLabel =
           isLastItem && !isEmptyRow ? 'Clear attribute' : 'Delete attribute';
 
+        const keyError = getFieldError(index, 'key');
+        const valueError = getFieldError(index, 'value');
+
         return (
           <div key={item.key || `empty-${index}`} className={cls.attributeRow}>
             <div className={cls.keyContainer}>
-              <Select
-                aria-label="Search attribute key"
-                options={getAttributeOptionsForRow(item.key)}
-                value={item.key ? [{ id: item.key, label: item.key }] : []}
-                onChange={(params) => {
-                  const newKey = String(params.value[0]?.id || '');
-                  handleKeyChange(index, newKey);
-                }}
-                placeholder="Select attribute"
-                size="compact"
-                error={getFieldError(index, 'key')}
-                overrides={overrides.keySelect}
-                searchable
-                clearable={false}
-                disabled={isLoading}
-                isLoading={isLoading}
-              />
+              <FormControl
+                error={keyError}
+                overrides={overrides.fieldFormControl}
+              >
+                <Select
+                  aria-label="Search attribute key"
+                  options={getAttributeOptionsForRow(item.key)}
+                  value={item.key ? [{ id: item.key, label: item.key }] : []}
+                  onChange={(params) => {
+                    const newKey = String(params.value[0]?.id || '');
+                    handleKeyChange(index, newKey);
+                  }}
+                  placeholder="Select attribute"
+                  size="compact"
+                  error={keyError !== undefined}
+                  overrides={overrides.keySelect}
+                  searchable
+                  clearable={false}
+                  disabled={isLoading}
+                  isLoading={isLoading}
+                />
+              </FormControl>
             </div>
 
             <div className={cls.valueContainer}>
-              {renderValueInput(item, index)}
+              <FormControl
+                error={valueError}
+                overrides={overrides.fieldFormControl}
+              >
+                {renderValueInput(item, index)}
+              </FormControl>
             </div>
 
             <div className={cls.buttonContainer}>

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
@@ -34,6 +34,7 @@ export default function WorkflowActionsSearchAttributes({
   searchAttributes,
   addButtonText = 'Add search attribute',
   showSectionBorder = true,
+  showFieldErrorMessages = false,
 }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
 
@@ -270,7 +271,7 @@ export default function WorkflowActionsSearchAttributes({
           <div key={item.key || `empty-${index}`} className={cls.attributeRow}>
             <div className={cls.keyContainer}>
               <FormControl
-                error={keyError}
+                error={showFieldErrorMessages ? keyError : undefined}
                 overrides={overrides.fieldFormControl}
               >
                 <Select
@@ -295,7 +296,7 @@ export default function WorkflowActionsSearchAttributes({
 
             <div className={cls.valueContainer}>
               <FormControl
-                error={valueError}
+                error={showFieldErrorMessages ? valueError : undefined}
                 overrides={overrides.fieldFormControl}
               >
                 {renderValueInput(item, index)}

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
@@ -31,6 +31,7 @@ export default function WorkflowActionsSearchAttributes({
   error,
   searchAttributes,
   addButtonText = 'Add search attribute',
+  showSectionBorder = true,
 }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
 
@@ -255,7 +256,11 @@ export default function WorkflowActionsSearchAttributes({
   );
 
   return (
-    <div className={cls.container}>
+    <div
+      className={`${cls.container} ${
+        showSectionBorder ? cls.containerWithBorder : ''
+      }`}
+    >
       {displayValue.map((item: SearchAttributeItem, index: number) => {
         const isEmptyRow = !item.key && !item.value;
         const isLastItem = displayValue.length === 1;

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.tsx
@@ -18,6 +18,7 @@ import {
 import {
   cssStyles,
   overrides,
+  styled,
 } from './workflow-actions-search-attributes.styles';
 import type {
   Props,
@@ -175,7 +176,6 @@ export default function WorkflowActionsSearchAttributes({
         'aria-label': 'Search attribute value',
         placeholder: inputPlaceholder,
         size: 'compact' as const,
-        // FormControl shows message text; input error is still required for border/aria-invalid (see multi-json-input).
         error: valueError !== undefined,
         overrides: overrides.valueInput,
       };
@@ -255,11 +255,7 @@ export default function WorkflowActionsSearchAttributes({
   );
 
   return (
-    <div
-      className={`${cls.container} ${
-        showSectionBorder ? cls.containerWithBorder : ''
-      }`}
-    >
+    <styled.Container $showSectionBorder={showSectionBorder}>
       {displayValue.map((item: SearchAttributeItem, index: number) => {
         const isEmptyRow = !item.key && !item.value;
         const isLastItem = displayValue.length === 1;
@@ -338,6 +334,6 @@ export default function WorkflowActionsSearchAttributes({
           {addButtonText}
         </Button>
       </div>
-    </div>
+    </styled.Container>
   );
 }

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.types.ts
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.types.ts
@@ -20,4 +20,5 @@ export type Props = {
   searchAttributes: Array<SearchAttributeOption>;
   addButtonText?: string;
   showSectionBorder?: boolean;
+  showFieldErrorMessages?: boolean;
 };

--- a/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.types.ts
+++ b/src/views/workflow-actions/workflow-actions-search-attributes/workflow-actions-search-attributes.types.ts
@@ -19,4 +19,5 @@ export type Props = {
   error?: string | Array<Partial<Record<'key' | 'value', string>> | undefined>;
   searchAttributes: Array<SearchAttributeOption>;
   addButtonText?: string;
+  showSectionBorder?: boolean;
 };


### PR DESCRIPTION
## Summary


- Add memo JSON textarea and search-attributes key/value editor to the advanced form
- Revalidate start-workflow search attributes on change via `trigger`  (This fix an issue with stale validation in start form that i noticed)


## Changes

- Load custom search attributes by `cluster` via `useSearchAttributes`
- Reuse `WorkflowActionsSearchAttributes` with `showSectionBorder={false}` so layout matches other horizontal advanced fields
- Show per-field validation messages in the create-schedule form via `showFieldErrorMessages`; start workflow keeps border-only errors (default)
- Extend form schema, `refineCreateScheduleForm`, and transform to validate memo JSON and map search attributes into `startWorkflow`
- use Trigger to revalidate search attributes on each change after submit to fix this issue:
 
https://github.com/user-attachments/assets/ee7cbdfc-fd8a-47c6-99db-e5fa49a5ae32



## Test plan

- Test schedules

https://github.com/user-attachments/assets/88fda638-ce37-4c61-995e-1a62fc9d9ab2


- Test start workflow

https://github.com/user-attachments/assets/67562cb8-a938-4c1d-a339-3cbcc7af3158


