### PR TITLE
fix: Add double quotes to JSON key names (by updating react-json-view-lite)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "react-icons": "^5.1.0",
         "react-intersection-observer": "^9.8.1",
         "react-joyride": "^3.0.0",
-        "react-json-view-lite": "^1.4.0",
+        "react-json-view-lite": "^2.5.0",
         "react-markdown": "^10.1.0",
         "react-virtuoso": "^4.10.4",
         "react-visjs-timeline": "^1.6.0",
@@ -94,7 +94,7 @@
       },
       "engines": {
         "node": ">=24.0.0",
-        "npm": ">=11.0.0"
+        "npm": ">=11.10.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -12390,14 +12390,15 @@
       }
     },
     "node_modules/react-json-view-lite": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.4.0.tgz",
-      "integrity": "sha512-wh6F6uJyYAmQ4fK0e8dSQMEWuvTs2Wr3el3sLD9bambX1+pSWUVXIz1RFaoy3TI1mZ0FqdpKq9YgbgTTgyrmXA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.5.0.tgz",
+      "integrity": "sha512-tk7o7QG9oYyELWHL8xiMQ8x4WzjCzbWNyig3uexmkLb54r8jO0yH3WCWx8UZS0c49eSA4QUmG5caiRJ8fAn58g==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-lifecycles-compat": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-icons": "^5.1.0",
     "react-intersection-observer": "^9.8.1",
     "react-joyride": "^3.0.0",
-    "react-json-view-lite": "^1.4.0",
+    "react-json-view-lite": "^2.5.0",
     "react-markdown": "^10.1.0",
     "react-virtuoso": "^4.10.4",
     "react-visjs-timeline": "^1.6.0",

--- a/src/components/pretty-json/pretty-json.tsx
+++ b/src/components/pretty-json/pretty-json.tsx
@@ -14,7 +14,11 @@ export default function PrettyJson({ json }: Props) {
       data={json as object}
       shouldExpandNode={allExpanded}
       clickToExpandNode
-      style={{ ...cls, noQuotesForStringValues: false }}
+      style={{
+        ...cls,
+        noQuotesForStringValues: false,
+        quotesForFieldNames: true,
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary
### Problem
The PrettyJson component did not display JSON key names with double quotes, thus displaying invalid JSON.

### Solution
- Bump react-json-view-lite to 2.5.0
- This adds the style prop `quotesForFieldNames` which we set to add double quotes to JSON keys

## Test plan
Ran locally.

### Before
<img width="1648" height="1088" alt="Screenshot 2026-06-24 at 13 53 19" src="https://github.com/user-attachments/assets/914d1fa7-6fe8-4a53-93ee-fb9e1f7440be" />
<img width="1639" height="711" alt="Screenshot 2026-06-24 at 13 53 38" src="https://github.com/user-attachments/assets/d2b1216e-53bc-4664-893b-798f645af3b5" />

### After
<img width="1712" height="1140" alt="Screenshot 2026-06-24 at 13 52 00" src="https://github.com/user-attachments/assets/d3deca5a-73e3-40a1-8e18-0094efc78e69" />
<img width="1640" height="723" alt="Screenshot 2026-06-24 at 13 54 19" src="https://github.com/user-attachments/assets/d9c56b05-3fad-4c25-bf02-2e874b108ca8" />
