### PR TITLE
fix: Hide event ID for pending events in ungrouped history view

### DIFF
--- a/src/views/workflow-history-v2/workflow-history-ungrouped-event/__tests__/workflow-history-ungrouped-event.test.tsx
+++ b/src/views/workflow-history-v2/workflow-history-ungrouped-event/__tests__/workflow-history-ungrouped-event.test.tsx
@@ -5,6 +5,10 @@ import {
   startActivityTaskEvent,
 } from '@/views/workflow-history/__fixtures__/workflow-history-activity-events';
 import { mockActivityEventGroup } from '@/views/workflow-history/__fixtures__/workflow-history-event-groups';
+import {
+  pendingActivityTaskStartEvent,
+  pendingDecisionTaskStartEvent,
+} from '@/views/workflow-history/__fixtures__/workflow-history-pending-events';
 import type WorkflowHistoryGroupLabel from '@/views/workflow-history/workflow-history-group-label/workflow-history-group-label';
 import type WorkflowHistoryTimelineResetButton from '@/views/workflow-history/workflow-history-timeline-reset-button/workflow-history-timeline-reset-button';
 
@@ -130,6 +134,21 @@ const mockActivityEventGroupWithMetadata: ActivityHistoryGroup = {
     },
   ],
 };
+
+const createMockPendingEventInfo = (
+  event:
+    | typeof pendingActivityTaskStartEvent
+    | typeof pendingDecisionTaskStartEvent
+): UngroupedEventInfo => ({
+  ...createMockEventInfo(event),
+  id: event.computedEventId,
+  eventMetadata: {
+    label: 'Pending',
+    status: 'WAITING',
+    timeMs: null,
+    timeLabel: 'Pending',
+  },
+});
 
 const createMockEventInfo = (
   event: ExtendedHistoryEvent = scheduleActivityTaskEvent,
@@ -449,6 +468,26 @@ describe(WorkflowHistoryUngroupedEvent.name, () => {
     setup({ eventInfo });
 
     expect(screen.getByText('Scheduled')).toBeInTheDocument();
+  });
+
+  it('renders dash instead of event id for pending activity event', () => {
+    const eventInfo = createMockPendingEventInfo(pendingActivityTaskStartEvent);
+    setup({ eventInfo });
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(
+      screen.queryByText(pendingActivityTaskStartEvent.computedEventId)
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders dash instead of event id for pending decision event', () => {
+    const eventInfo = createMockPendingEventInfo(pendingDecisionTaskStartEvent);
+    setup({ eventInfo });
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(
+      screen.queryByText(pendingDecisionTaskStartEvent.computedEventId)
+    ).not.toBeInTheDocument();
   });
 
   it('shows remaining duration badge alongside elapsed time when expectedEndTimeInfo exists', () => {

--- a/src/views/workflow-history-v2/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
+++ b/src/views/workflow-history-v2/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from 'react';
 
 import { Panel } from 'baseui/accordion';
-import { MdOutlineCircle } from 'react-icons/md';
+import { MdHourglassTop, MdOutlineCircle } from 'react-icons/md';
 
 import formatDate from '@/utils/data-formatters/format-date';
 import formatTimeDiff from '@/utils/datetime/format-time-diff';
 import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+import isPendingHistoryEvent from '@/views/workflow-history/workflow-history-event-details/helpers/is-pending-history-event';
 import WorkflowHistoryGroupLabel from '@/views/workflow-history/workflow-history-group-label/workflow-history-group-label';
 import WorkflowHistoryRemainingDurationBadge from '@/views/workflow-history/workflow-history-remaining-duration-badge/workflow-history-remaining-duration-badge';
 import WorkflowHistoryTimelineResetButton from '@/views/workflow-history/workflow-history-timeline-reset-button/workflow-history-timeline-reset-button';
@@ -53,6 +54,8 @@ export default function WorkflowHistoryUngroupedEvent({
     ([eventId]) => eventId === eventInfo.id
   )?.[1].eventDetails;
 
+  const isPendingEvent = isPendingHistoryEvent(eventInfo.event);
+ 
   return (
     <Panel
       title={
@@ -63,7 +66,9 @@ export default function WorkflowHistoryUngroupedEvent({
                 .content
             }
           />
-          <styled.HeaderLabel>{eventInfo.id}</styled.HeaderLabel>
+          <styled.HeaderLabel>
+            {isPendingEvent ? <MdHourglassTop /> : eventInfo.id}
+          </styled.HeaderLabel>
           <styled.HeaderLabel>
             <WorkflowHistoryGroupLabel
               label={eventInfo.label}

--- a/src/views/workflow-history-v2/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
+++ b/src/views/workflow-history-v2/workflow-history-ungrouped-event/workflow-history-ungrouped-event.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 
 import { Panel } from 'baseui/accordion';
-import { MdHourglassTop, MdOutlineCircle } from 'react-icons/md';
+import { MdOutlineCircle } from 'react-icons/md';
 
 import formatDate from '@/utils/data-formatters/format-date';
 import formatTimeDiff from '@/utils/datetime/format-time-diff';
@@ -55,7 +55,7 @@ export default function WorkflowHistoryUngroupedEvent({
   )?.[1].eventDetails;
 
   const isPendingEvent = isPendingHistoryEvent(eventInfo.event);
- 
+
   return (
     <Panel
       title={
@@ -67,7 +67,7 @@ export default function WorkflowHistoryUngroupedEvent({
             }
           />
           <styled.HeaderLabel>
-            {isPendingEvent ? <MdHourglassTop /> : eventInfo.id}
+            {isPendingEvent ? '-' : eventInfo.id}
           </styled.HeaderLabel>
           <styled.HeaderLabel>
             <WorkflowHistoryGroupLabel


### PR DESCRIPTION
## Summary
### Problem
The Workflow History's ungrouped view displays events in a table keyed by Event ID. However, pending events have a computed event ID which, while used in the UI for sorting, is not an actual event ID.

### Solution
Hide the (computed) event ID for pending events, showing a dash instead.

## Test plan
Updated unit tests + ran locally.

### Before
<img width="1628" height="583" alt="Screenshot 2026-06-24 at 13 51 12" src="https://github.com/user-attachments/assets/eac4480d-6142-4301-986b-685ad0bb8f2f" />

### After
<img width="1683" height="586" alt="Screenshot 2026-06-24 at 14 28 09" src="https://github.com/user-attachments/assets/93e8415f-c18d-437e-92a4-1d7bfe6b8ae1" />
