### PR TITLE
test(utils): add sort-by and config validation coverage

### DIFF
--- a/src/utils/__tests__/sort-by.test.ts
+++ b/src/utils/__tests__/sort-by.test.ts
@@ -1,4 +1,57 @@
-import { toggleSortOrder } from '../sort-by';
+import sortBy, { getSortCompareFunction, toggleSortOrder } from '../sort-by';
+
+describe(getSortCompareFunction.name, () => {
+  it('sorts strings using locale-aware comparison in ASC order', () => {
+    const compare = getSortCompareFunction<{ v: string }>((item) => item.v, 'ASC');
+    const items = [{ v: 'b' }, { v: 'a' }];
+
+    expect([...items].sort(compare)).toEqual([{ v: 'a' }, { v: 'b' }]);
+  });
+
+  it('sorts numbers in ASC order', () => {
+    const compare = getSortCompareFunction<{ v: number }>((item) => item.v, 'ASC');
+    const items = [{ v: 3 }, { v: 1 }, { v: 2 }];
+
+    expect([...items].sort(compare)).toEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
+  });
+
+  it('inverts non-equal comparisons for DESC order', () => {
+    const compare = getSortCompareFunction<{ v: number }>((item) => item.v, 'DESC');
+    const items = [{ v: 1 }, { v: 3 }, { v: 2 }];
+
+    expect([...items].sort(compare)).toEqual([{ v: 3 }, { v: 2 }, { v: 1 }]);
+  });
+
+  it('returns zero when sort values are equal', () => {
+    const compare = getSortCompareFunction<{ v: number }>((item) => item.v, 'DESC');
+
+    expect(compare({ v: 1 }, { v: 1 })).toBe(0);
+  });
+
+  it('places undefined and null before other values with undefined first', () => {
+    const compare = getSortCompareFunction<{ v: number | null | undefined }>(
+      (item) => item.v,
+      'ASC'
+    );
+    const items = [{ v: 2 }, { v: null }, { v: undefined }, { v: 1 }];
+
+    expect([...items].sort(compare)).toEqual([
+      { v: undefined },
+      { v: null },
+      { v: 1 },
+      { v: 2 },
+    ]);
+  });
+});
+
+describe(sortBy.name, () => {
+  it('sorts a copy of the input array', () => {
+    const items = [{ v: 2 }, { v: 1 }];
+
+    expect(sortBy(items, (item) => item.v, 'ASC')).toEqual([{ v: 1 }, { v: 2 }]);
+    expect(items).toEqual([{ v: 2 }, { v: 1 }]);
+  });
+});
 
 describe(toggleSortOrder.name, () => {
   it('inverts sort order of current column (ASC -> DESC)', () => {

--- a/src/utils/__tests__/sort-by.test.ts
+++ b/src/utils/__tests__/sort-by.test.ts
@@ -2,28 +2,40 @@ import sortBy, { getSortCompareFunction, toggleSortOrder } from '../sort-by';
 
 describe(getSortCompareFunction.name, () => {
   it('sorts strings using locale-aware comparison in ASC order', () => {
-    const compare = getSortCompareFunction<{ v: string }>((item) => item.v, 'ASC');
+    const compare = getSortCompareFunction<{ v: string }>(
+      (item) => item.v,
+      'ASC'
+    );
     const items = [{ v: 'b' }, { v: 'a' }];
 
     expect([...items].sort(compare)).toEqual([{ v: 'a' }, { v: 'b' }]);
   });
 
   it('sorts numbers in ASC order', () => {
-    const compare = getSortCompareFunction<{ v: number }>((item) => item.v, 'ASC');
+    const compare = getSortCompareFunction<{ v: number }>(
+      (item) => item.v,
+      'ASC'
+    );
     const items = [{ v: 3 }, { v: 1 }, { v: 2 }];
 
     expect([...items].sort(compare)).toEqual([{ v: 1 }, { v: 2 }, { v: 3 }]);
   });
 
   it('inverts non-equal comparisons for DESC order', () => {
-    const compare = getSortCompareFunction<{ v: number }>((item) => item.v, 'DESC');
+    const compare = getSortCompareFunction<{ v: number }>(
+      (item) => item.v,
+      'DESC'
+    );
     const items = [{ v: 1 }, { v: 3 }, { v: 2 }];
 
     expect([...items].sort(compare)).toEqual([{ v: 3 }, { v: 2 }, { v: 1 }]);
   });
 
   it('returns zero when sort values are equal', () => {
-    const compare = getSortCompareFunction<{ v: number }>((item) => item.v, 'DESC');
+    const compare = getSortCompareFunction<{ v: number }>(
+      (item) => item.v,
+      'DESC'
+    );
 
     expect(compare({ v: 1 }, { v: 1 })).toBe(0);
   });
@@ -48,7 +60,10 @@ describe(sortBy.name, () => {
   it('sorts a copy of the input array', () => {
     const items = [{ v: 2 }, { v: 1 }];
 
-    expect(sortBy(items, (item) => item.v, 'ASC')).toEqual([{ v: 1 }, { v: 2 }]);
+    expect(sortBy(items, (item) => item.v, 'ASC')).toEqual([
+      { v: 1 },
+      { v: 2 },
+    ]);
     expect(items).toEqual([{ v: 2 }, { v: 1 }]);
   });
 });

--- a/src/utils/config/__tests__/get-config-value.node.ts
+++ b/src/utils/config/__tests__/get-config-value.node.ts
@@ -38,4 +38,21 @@ describe('getConfigValue', () => {
     expect(mockFn).toHaveBeenCalledWith(undefined);
     expect(result).toBe('resolvedValue');
   });
+
+  it('throws when resolver arguments fail validation', async () => {
+    // @ts-expect-error COMPUTED is not a loaded config
+    await expect(getConfigValue('COMPUTED', { invalid: true })).rejects.toThrow(
+      "Failed to parse config 'COMPUTED' arguments:"
+    );
+  });
+
+  it('throws when resolver return value fails validation', async () => {
+    // @ts-expect-error COMPUTED doesn't exist in the original loaded configs but it exists in the mocks
+    const mockFn = getLoadedGlobalConfigs().COMPUTED as jest.Mock;
+    mockFn.mockResolvedValue(123);
+    // @ts-expect-error COMPUTED is not a loaded config
+    await expect(getConfigValue('COMPUTED')).rejects.toThrow(
+      "Failed to parse config 'COMPUTED' resolved value:"
+    );
+  });
 });

--- a/src/utils/merge-sorted-arrays.ts
+++ b/src/utils/merge-sorted-arrays.ts
@@ -20,7 +20,7 @@
 export default function mergeSortedArrays<T>({
   sortedArrays,
   itemsCount,
-  compareFunc = (a: T, b: T): number => (a < b ? -1 : 1),
+  compareFunc,
 }: {
   sortedArrays: Array<Array<T>>;
   itemsCount: number;


### PR DESCRIPTION
## Summary

- Add unit tests for `getSortCompareFunction` and `sortBy` (ASC/DESC ordering, null/undefined handling, immutability).
- Add unit tests for `getConfigValue` validation failures (invalid resolver arguments and invalid resolved values).
- Remove the incorrect default `compareFunc` from `mergeSortedArrays`; callers already pass an explicit comparator, and the types was not optional.

## Test plan

- [x] `npm run test:unit:browser -- sort-by.test.ts merge-sorted-arrays.test.ts`
- [x] `npm run test:unit:node -- get-config-value.node.ts`
