### PR TITLE
feat(batch-actions): surface live RPS from the batcher heartbeat

### DIFF
--- a/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
+++ b/src/route-handlers/describe-batch-action/__fixtures__/mock-describe-batch-operation-workflow.ts
@@ -189,11 +189,14 @@ export const mockBatcherStartedHistoryWithUnknownType = buildHistoryResponse({
   RPS: 50,
 });
 
-// Mirrors the batcher's HeartBeatDetails struct (Go field names) used for progress.
+// Mirrors the batcher's HeartBeatDetails struct (Go field names). RPS is the
+// live, signal-tuned value — deliberately different from the start-input RPS
+// (100) so tests can prove the heartbeat value overrides the input.
 export const MOCK_BATCH_PROGRESS = {
   TotalEstimate: 200,
   SuccessCount: 120,
   ErrorCount: 5,
+  RPS: 250,
 };
 
 // Running batch whose pending batcher activity is reporting progress via heartbeat.

--- a/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
+++ b/src/route-handlers/describe-batch-action/__tests__/describe-batch-action.node.ts
@@ -15,6 +15,7 @@ import {
   mockDescribeBatchOperationWorkflowFailed,
   mockDescribeBatchOperationWorkflowFailedWithPendingProgress,
   mockDescribeBatchOperationWorkflowRunning,
+  mockDescribeBatchOperationWorkflowRunningWithProgress,
   mockDescribeBatchOperationWorkflowTerminated,
   mockDescribeBatchOperationWorkflowOtherDomain,
   mockDescribeNonBatchWorkflow,
@@ -75,6 +76,26 @@ describe(describeBatchAction.name, () => {
     expect(body.status).toEqual('RUNNING');
     expect(body.endTime).toBeUndefined();
     expect(body.startTime).toEqual(1717408148258);
+    // No heartbeat yet, so rps falls back to the start-input value.
+    expect(body.rps).toEqual(100);
+  });
+
+  it('overrides the start-input rps with the live rps from the running heartbeat', async () => {
+    const { res } = await setup({
+      describeResponse: mockDescribeBatchOperationWorkflowRunningWithProgress,
+    });
+
+    expect(res.status).toEqual(200);
+    const body = await res.json();
+    expect(body.status).toEqual('RUNNING');
+    // Live, signal-tuned value from the heartbeat (250), not the input (100).
+    expect(body.rps).toEqual(MOCK_BATCH_PROGRESS.RPS);
+    // rps is surfaced at the top level, not nested in progress.
+    expect(body.progress).toEqual({
+      totalEstimate: MOCK_BATCH_PROGRESS.TotalEstimate,
+      successCount: MOCK_BATCH_PROGRESS.SuccessCount,
+      errorCount: MOCK_BATCH_PROGRESS.ErrorCount,
+    });
   });
 
   it('maps TERMINATED close status to aborted', async () => {
@@ -133,6 +154,8 @@ describe(describeBatchAction.name, () => {
       successCount: MOCK_BATCH_PROGRESS.SuccessCount,
       errorCount: MOCK_BATCH_PROGRESS.ErrorCount,
     });
+    // Final heartbeat carries the last effective rps, overriding the input.
+    expect(body.rps).toEqual(MOCK_BATCH_PROGRESS.RPS);
   });
 
   it('returns 200 and flags progressError when the close-event read fails', async () => {

--- a/src/route-handlers/describe-batch-action/describe-batch-action.types.ts
+++ b/src/route-handlers/describe-batch-action/describe-batch-action.types.ts
@@ -10,14 +10,19 @@ import type heartbeatDetailsSchema from './schemas/heartbeat-details-schema';
 // single source of truth.
 export type BatchActionType = keyof typeof BATCH_ACTION_TYPE;
 
-export type BatchActionProgress = z.infer<typeof heartbeatDetailsSchema>;
+export type BatchActionProgress = Omit<
+  z.infer<typeof heartbeatDetailsSchema>,
+  'rps'
+>;
 
 // Outcome of reading progress from a heartbeat payload. `progressError` is set
 // when a payload was present but did not match the expected heartbeat shape (as
-// opposed to simply being absent, which leaves both fields undefined).
+// opposed to simply being absent, which leaves both fields undefined). `rps` is
+// the live, signal-tuned rate limit carried by the same heartbeat, when present.
 export type BatchActionProgressResult = {
   progress?: BatchActionProgress;
   progressError?: boolean;
+  rps?: number;
 };
 
 export type RouteParams = {

--- a/src/route-handlers/describe-batch-action/helpers/__tests__/get-batch-action-progress.node.ts
+++ b/src/route-handlers/describe-batch-action/helpers/__tests__/get-batch-action-progress.node.ts
@@ -46,7 +46,7 @@ describe('getRunningProgressFromDescribe', () => {
       getRunningProgressFromDescribe(
         mockDescribeBatchOperationWorkflowRunningWithProgress
       )
-    ).toEqual({ progress: EXPECTED_PROGRESS });
+    ).toEqual({ progress: EXPECTED_PROGRESS, rps: MOCK_BATCH_PROGRESS.RPS });
     expect(logger.warn).not.toHaveBeenCalled();
   });
 
@@ -104,7 +104,7 @@ describe('getFinalProgressFromCloseEvent', () => {
       getFinalProgressFromCloseEvent(
         mockBatcherCloseEventHistory.history?.events?.[0]
       )
-    ).toEqual({ progress: EXPECTED_PROGRESS });
+    ).toEqual({ progress: EXPECTED_PROGRESS, rps: MOCK_BATCH_PROGRESS.RPS });
     expect(logger.warn).not.toHaveBeenCalled();
   });
 

--- a/src/route-handlers/describe-batch-action/helpers/get-batch-action-progress.ts
+++ b/src/route-handlers/describe-batch-action/helpers/get-batch-action-progress.ts
@@ -25,7 +25,12 @@ function parseHeartBeatDetails(
     return { progressError: true };
   }
 
-  return { progress: result.data };
+  // The heartbeat carries both progress counts and the live, signal-tuned rps;
+  // split them so rps surfaces at the top level (overriding the start-input
+  // value) while progress stays counts-only. Omit rps when absent so it never
+  // clobbers the input rps with undefined.
+  const { rps, ...progress } = result.data;
+  return { progress, ...(rps !== undefined ? { rps } : {}) };
 }
 
 // While the batch is running, progress is surfaced on the batcher activity's

--- a/src/route-handlers/describe-batch-action/schemas/heartbeat-details-schema.ts
+++ b/src/route-handlers/describe-batch-action/schemas/heartbeat-details-schema.ts
@@ -8,11 +8,15 @@ const heartbeatDetailsSchema = z
     TotalEstimate: z.number(),
     SuccessCount: z.number().catch(0),
     ErrorCount: z.number().catch(0),
+    // Live, signal-tuned rate limit in effect for the running activity.
+    // Optional so a batcher that predates the field still parses.
+    RPS: z.number().optional().catch(undefined),
   })
-  .transform(({ TotalEstimate, SuccessCount, ErrorCount }) => ({
+  .transform(({ TotalEstimate, SuccessCount, ErrorCount, RPS }) => ({
     totalEstimate: TotalEstimate,
     successCount: SuccessCount,
     errorCount: ErrorCount,
+    rps: RPS,
   }));
 
 export default heartbeatDetailsSchema;


### PR DESCRIPTION
**Stacked PR 4 of 4** — makes an RPS edit actually visible.

> Based on #1359 (`batch-ui-rps-3-wiring`). Review/merge after the rest of the stack.

## Change
The batcher now reports its current, signal-tuned RPS in `HeartBeatDetails.RPS` (alongside progress). This reads it:
- Parse the optional `RPS` from the heartbeat — the running activity heartbeat, and the final workflow result on completion.
- Surface it as the top-level `rps`, overriding the start-input value via the existing spread order. Falls back to the input `rps` when no heartbeat carries it (backward-compatible with batchers that predate the field).
- `progress` stays counts-only; `rps` is top-level (what the UI displays/edits).

## Tests
- describe handler: live rps overrides input (running + completed); input fallback when no heartbeat.
- progress helper: rps split out of the heartbeat; absent `RPS` omits the key (no clobber).

## Stack
1. Foundation (#1357, merged)
2. Edit RPS modal + tune-signal hook (#1358)
3. Wire the RPS Edit button (#1359)
4. **This PR** — surface the live RPS so the edit is visible