### PR TITLE
feat(schedule-details): wire config-driven detail sections rendering

### DIFF
--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { HttpResponse, type HttpResponseResolver } from 'msw';
+import { HttpResponse, delay, type HttpResponseResolver } from 'msw';
 
 import {
   act,
@@ -23,29 +23,22 @@ jest.mock('next/navigation', () => ({
 }));
 
 describe(ScheduleDetails.name, () => {
-  it('shows loading first then renders details placeholder after describe succeeds', async () => {
-    // Success resolver for describe request
-    const { promise: resolveResponsePromise, resolve: resolveResponse } =
-      getDeferredPromise();
-
+  it('shows loading first then renders the config-driven sections container', async () => {
     const describeResolver = jest.fn(async () => {
-      await resolveResponsePromise;
+      await delay(100);
       return HttpResponse.json(getMockRunningDescribeScheduleResponse());
     });
 
     setup({ describeResolver });
 
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
-    // Resolve the promise to simulate the describe request succeeding
-    resolveResponse();
 
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
-    expect(screen.getByText('Details — coming soon')).toBeInTheDocument();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
     expect(describeResolver).toHaveBeenCalledTimes(1);
   });
 
   it('throws into error boundary when describe fails', async () => {
-    // Error resolver for describe request
     const describeResolver = jest.fn(() =>
       HttpResponse.json(
         { message: 'Failed to describe schedule' },
@@ -90,16 +83,4 @@ function setup({
       ],
     }
   );
-}
-
-function getDeferredPromise(): {
-  promise: Promise<void>;
-  resolve: () => void;
-} {
-  let resolve = () => {};
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-
-  return { promise, resolve };
 }

--- a/src/views/schedule-details/config/schedule-details-sections.config.ts
+++ b/src/views/schedule-details/config/schedule-details-sections.config.ts
@@ -1,0 +1,5 @@
+import { type ScheduleDetailsSectionConfig } from '@/views/schedule-details/schedule-details.types';
+
+const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [];
+
+export default scheduleDetailsSectionsConfig;

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -3,11 +3,18 @@ import React from 'react';
 
 import PageSection from '@/components/page-section/page-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+import { type ScheduleDetailsTableRow } from '@/views/schedule-details/schedule-details-table/schedule-details-table.types';
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
 
-import { type Props } from './schedule-details.types';
+import scheduleDetailsSectionsConfig from './config/schedule-details-sections.config';
+import ScheduleDetailsSection from './schedule-details-section/schedule-details-section';
+
+import { cssStyles } from './schedule-details.styles';
+import { type Props, type ScheduleDetailRowConfig } from './schedule-details.types';
 
 export default function ScheduleDetails({ params }: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
   const { data, isLoading, isPending } = useDescribeSchedule({
     domain: params.domain,
     cluster: params.cluster,
@@ -18,6 +25,7 @@ export default function ScheduleDetails({ params }: Props) {
   if (isLoading || isPending) {
     return <SectionLoadingIndicator />;
   }
+
   // Should never happen as we have throwOnError set to true but it is for better type safety below
   if (!data) {
     throw new Error('Schedule data is unavailable');
@@ -25,7 +33,44 @@ export default function ScheduleDetails({ params }: Props) {
 
   return (
     <PageSection>
-      <div>Details — coming soon</div>
+      <div className={cls.detailsSectionsContainer}>
+        {scheduleDetailsSectionsConfig.map((section) => {
+          const rows = getRowsFromConfig(
+            section.rowsConfig,
+            data,
+            params.scheduleId
+          );
+          if (!rows.length) {
+            return null;
+          }
+
+          return (
+            <ScheduleDetailsSection
+              key={section.key}
+              title={section.title}
+              rows={rows}
+            />
+          );
+        })}
+      </div>
     </PageSection>
   );
+}
+
+function getRowsFromConfig(
+  config: ScheduleDetailRowConfig[],
+  data: NonNullable<ReturnType<typeof useDescribeSchedule>['data']>,
+  scheduleId: string
+): ScheduleDetailsTableRow[] {
+  const args = { describeSchedule: data, scheduleId };
+  return config
+    .filter(
+      (rowConfig) =>
+        !rowConfig.hide || !rowConfig.hide({ describeSchedule: data, scheduleId })
+    )
+    .map((rowConfig) => ({
+      key: rowConfig.key,
+      label: rowConfig.getLabel(),
+      value: rowConfig.getValue(args),
+    }));
 }


### PR DESCRIPTION
## Summary
- Wire `ScheduleDetails` to render config-driven collapsible sections from the describe response.

## Changes
- Add empty `schedule-details-sections.config.ts` registry and `getRowsFromConfig` mapping in `schedule-details.tsx`.

## Testing
- [x] `npm run test:unit:browser schedule-details`

Made with [Cursor](https://cursor.com)