### PR TITLE
feat(schedule-details): add specifications detail section config

### DIFF
--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -34,8 +34,82 @@ describe(ScheduleDetails.name, () => {
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
 
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
-    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
     expect(describeResolver).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders schedule specifications section rows', async () => {
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(
+          getMockRunningDescribeScheduleResponse({
+            info: {
+              createTime: { seconds: '1745490629', nanos: 850000000 },
+              nextRunTime: { seconds: '1745490629', nanos: 850000000 },
+              lastRunTime: { seconds: '1745490629', nanos: 850000000 },
+              totalRuns: '32',
+              lastUpdateTime: null,
+              ongoingBackfills: [],
+              missedRuns: '0',
+              skippedRuns: '0',
+            },
+            spec: {
+              cronExpression: '0 * * * *',
+              startTime: { seconds: '1735689600', nanos: 0 },
+              endTime: null,
+              jitter: { seconds: '300', nanos: 0 },
+            },
+          })
+        ),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Schedule specifications' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Schedule action' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: 'Schedule policies' })
+    ).not.toBeInTheDocument();
+
+    expect(
+      screen.getByRole('rowheader', { name: 'Schedule Id' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('my-schedule')).toBeInTheDocument();
+    expect(
+      screen.getByRole('rowheader', { name: 'Cron execution' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Every hour (0 * * * *)')).toBeInTheDocument();
+    expect(screen.getByText('5m')).toBeInTheDocument();
+  });
+
+  it('hides optional specification rows when schedule fields are missing', async () => {
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(
+          getMockRunningDescribeScheduleResponse({
+            spec: {
+              cronExpression: '*/10 * * * *',
+              startTime: null,
+              endTime: null,
+              jitter: null,
+            },
+          })
+        ),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Schedule specifications' })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Start time' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Creation time' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Jitter duration' })
+    ).not.toBeInTheDocument();
   });
 
   it('throws into error boundary when describe fails', async () => {

--- a/src/views/schedule-details/config/schedule-details-sections.config.ts
+++ b/src/views/schedule-details/config/schedule-details-sections.config.ts
@@ -1,5 +1,13 @@
 import { type ScheduleDetailsSectionConfig } from '@/views/schedule-details/schedule-details.types';
 
-const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [];
+import scheduleSpecificationsDetailsConfig from './schedule-specifications-details.config';
+
+const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
+  {
+    key: 'specifications',
+    title: 'Schedule specifications',
+    rowsConfig: scheduleSpecificationsDetailsConfig,
+  },
+];
 
 export default scheduleDetailsSectionsConfig;

--- a/src/views/schedule-details/config/schedule-specifications-details.config.ts
+++ b/src/views/schedule-details/config/schedule-specifications-details.config.ts
@@ -1,0 +1,84 @@
+import { createElement } from 'react';
+
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import ScheduleDetailsBadges from '../schedule-details-badges/schedule-details-badges';
+import ScheduleDetailsMemo from '../schedule-details-memo/schedule-details-memo';
+import {
+  formatScheduleCronExpression,
+  formatScheduleDuration,
+  formatScheduleTimestamp,
+} from '../helpers/schedule-details-formatters';
+
+const scheduleSpecificationsDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'scheduleId',
+    getLabel: () => 'Schedule Id',
+    getValue: ({ scheduleId }) => scheduleId,
+  },
+  {
+    key: 'cronExpression',
+    getLabel: () => 'Cron execution',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleCronExpression(describeSchedule.spec?.cronExpression),
+  },
+  {
+    key: 'nextRunTime',
+    getLabel: () => 'Next run',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.info?.nextRunTime),
+  },
+  {
+    key: 'lastRunTime',
+    getLabel: () => 'Last run',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.info?.lastRunTime),
+  },
+  {
+    key: 'totalRuns',
+    getLabel: () => 'Total runs',
+    getValue: ({ describeSchedule }) => {
+      const total = describeSchedule.info?.totalRuns;
+      if (!total) return null;
+      return createElement(ScheduleDetailsBadges, { labels: [`${total} runs`] });
+    },
+  },
+  {
+    key: 'createTime',
+    getLabel: () => 'Creation time',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.info?.createTime),
+    hide: ({ describeSchedule }) => !describeSchedule.info?.createTime,
+  },
+  {
+    key: 'startTime',
+    getLabel: () => 'Start time',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.spec?.startTime),
+    hide: ({ describeSchedule }) => !describeSchedule.spec?.startTime,
+  },
+  {
+    key: 'endTime',
+    getLabel: () => 'End time',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleTimestamp(describeSchedule.spec?.endTime),
+    hide: ({ describeSchedule }) => !describeSchedule.spec?.endTime,
+  },
+  {
+    key: 'memo',
+    getLabel: () => 'Memo',
+    getValue: ({ describeSchedule }) =>
+      createElement(ScheduleDetailsMemo, { memo: describeSchedule.memo }),
+    hide: ({ describeSchedule }) => !describeSchedule.memo?.fields,
+  },
+
+  {
+    key: 'jitter',
+    getLabel: () => 'Jitter duration',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(describeSchedule.spec?.jitter),
+    hide: ({ describeSchedule }) => !describeSchedule.spec?.jitter,
+  },
+];
+
+export default scheduleSpecificationsDetailsConfig;


### PR DESCRIPTION
## Summary
- Add the Schedule specifications config group (cron, runs, memo, jitter).

## Changes
- `schedule-specifications-details.config.ts` and register in sections config.
- ScheduleDetails tests for specification rows and hidden optional fields.

## Testing
- [x] `npm run test:unit:browser schedule-details`

Made with [Cursor](https://cursor.com)