### PR TITLE
feat(schedule-details): add action detail section config

### DIFF
--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -6,6 +6,7 @@ import {
   act,
   render,
   screen,
+  userEvent,
   waitForElementToBeRemoved,
 } from '@/test-utils/rtl';
 
@@ -58,6 +59,23 @@ describe(ScheduleDetails.name, () => {
               endTime: null,
               jitter: { seconds: '300', nanos: 0 },
             },
+            action: {
+              startWorkflow: {
+                workflowType: { name: 'ScheduleWorker' },
+                taskList: {
+                  name: 'schedule-task-list',
+                  kind: 'TASK_LIST_KIND_NORMAL',
+                  baseName: 'schedule-task-list',
+                },
+                input: null,
+                workflowIdPrefix: 'schedule-prefix',
+                executionStartToCloseTimeout: { seconds: '1800', nanos: 0 },
+                taskStartToCloseTimeout: null,
+                retryPolicy: null,
+                memo: null,
+                searchAttributes: null,
+              },
+            },
           })
         ),
     });
@@ -66,8 +84,8 @@ describe(ScheduleDetails.name, () => {
       await screen.findByRole('heading', { name: 'Schedule specifications' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'Schedule action' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: 'Schedule action' })
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', { name: 'Schedule policies' })
     ).not.toBeInTheDocument();
@@ -81,6 +99,50 @@ describe(ScheduleDetails.name, () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Every hour (0 * * * *)')).toBeInTheDocument();
     expect(screen.getByText('5m')).toBeInTheDocument();
+    expect(screen.getByText('ScheduleWorker')).toBeInTheDocument();
+  });
+
+  it('collapses and expands the schedule action section', async () => {
+    const user = userEvent.setup();
+
+    setup({
+      describeResolver: () =>
+        HttpResponse.json(
+          getMockRunningDescribeScheduleResponse({
+            action: {
+              startWorkflow: {
+                workflowType: { name: 'ScheduleWorker' },
+                taskList: {
+                  name: 'schedule-task-list',
+                  kind: 'TASK_LIST_KIND_NORMAL',
+                  baseName: 'schedule-task-list',
+                },
+                input: null,
+                workflowIdPrefix: null,
+                executionStartToCloseTimeout: null,
+                taskStartToCloseTimeout: null,
+                retryPolicy: null,
+                memo: null,
+                searchAttributes: null,
+              },
+            },
+          })
+        ),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Schedule action' })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', { name: 'Collapse Schedule action details' })
+    );
+    expect(
+      screen.queryByRole('rowheader', { name: 'Workflow type' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Expand Schedule action details' })
+    ).toBeInTheDocument();
   });
 
   it('hides optional specification rows when schedule fields are missing', async () => {
@@ -94,6 +156,7 @@ describe(ScheduleDetails.name, () => {
               endTime: null,
               jitter: null,
             },
+            action: { startWorkflow: null },
           })
         ),
     });
@@ -110,6 +173,15 @@ describe(ScheduleDetails.name, () => {
     expect(
       screen.queryByRole('rowheader', { name: 'Jitter duration' })
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Workflow Id Prefix' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('rowheader', { name: 'Schedule Search attributes' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: 'Schedule action' })
+    ).toBeInTheDocument();
   });
 
   it('throws into error boundary when describe fails', async () => {

--- a/src/views/schedule-details/config/schedule-action-details.config.ts
+++ b/src/views/schedule-details/config/schedule-action-details.config.ts
@@ -1,0 +1,66 @@
+import { createElement } from 'react';
+
+import ScheduleDetailsBadges from '@/views/schedule-details/schedule-details-badges/schedule-details-badges';
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import { formatScheduleDuration } from '../helpers/schedule-details-formatters';
+import scheduleRetryPolicyDetailsConfig from './schedule-retry-policy-details.config';
+
+const scheduleActionDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'workflowType',
+    getLabel: () => 'Workflow type',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.workflowType?.name,
+  },
+  {
+    key: 'taskList',
+    getLabel: () => 'Tasklist',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.taskList?.name,
+  },
+  {
+    key: 'taskStartToCloseTimeout',
+    getLabel: () => 'Task start to close timeout',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.taskStartToCloseTimeout
+      ),
+  },
+  {
+    key: 'executionStartToCloseTimeout',
+    getLabel: () => 'Execution start to close timeout',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.executionStartToCloseTimeout
+      ),
+  },
+  {
+    key: 'workflowIdPrefix',
+    getLabel: () => 'Workflow Id Prefix',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.workflowIdPrefix,
+    hide: ({ describeSchedule }) =>
+      !describeSchedule.action?.startWorkflow?.workflowIdPrefix,
+  },
+  ...scheduleRetryPolicyDetailsConfig,
+  {
+    key: 'scheduleSearchAttributes',
+    getLabel: () => 'Schedule Search attributes',
+    getValue: ({ describeSchedule }) => {
+      const indexedFields =
+        describeSchedule.searchAttributes?.indexedFields ?? {};
+      if (Object.keys(indexedFields).length === 0) return null;
+      return createElement(ScheduleDetailsBadges, {
+        labels: Object.keys(indexedFields),
+      });
+    },
+    hide: ({ describeSchedule }) => {
+      return !Object.keys(
+        describeSchedule.searchAttributes?.indexedFields ?? {}
+      ).length;
+    },
+  },
+];
+
+export default scheduleActionDetailsConfig;

--- a/src/views/schedule-details/config/schedule-details-sections.config.ts
+++ b/src/views/schedule-details/config/schedule-details-sections.config.ts
@@ -1,5 +1,6 @@
 import { type ScheduleDetailsSectionConfig } from '@/views/schedule-details/schedule-details.types';
 
+import scheduleActionDetailsConfig from './schedule-action-details.config';
 import scheduleSpecificationsDetailsConfig from './schedule-specifications-details.config';
 
 const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
@@ -7,6 +8,11 @@ const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
     key: 'specifications',
     title: 'Schedule specifications',
     rowsConfig: scheduleSpecificationsDetailsConfig,
+  },
+  {
+    key: 'action',
+    title: 'Schedule action',
+    rowsConfig: scheduleActionDetailsConfig,
   },
 ];
 

--- a/src/views/schedule-details/config/schedule-retry-policy-details.config.ts
+++ b/src/views/schedule-details/config/schedule-retry-policy-details.config.ts
@@ -1,0 +1,68 @@
+import { createElement } from 'react';
+
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import ScheduleDetailsBadges from '../schedule-details-badges/schedule-details-badges';
+import { formatScheduleDuration } from '../helpers/schedule-details-formatters';
+import { hideWithoutRetryPolicy } from '../helpers/schedule-details-row-hide';
+
+const scheduleRetryPolicyDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'retryPolicy.initialInterval',
+    getLabel: () => 'retryPolicy.initialInterval',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.retryPolicy?.initialInterval
+      ),
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.backoffCoefficient',
+    getLabel: () => 'retryPolicy.backoffCoefficient',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.retryPolicy?.backoffCoefficient,
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.maximumInterval',
+    getLabel: () => 'retryPolicy.maximumInterval',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.retryPolicy?.maximumInterval
+      ),
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.maximumAttempts',
+    getLabel: () => 'retryPolicy.maximumAttempts',
+    getValue: ({ describeSchedule }) =>
+      describeSchedule.action?.startWorkflow?.retryPolicy?.maximumAttempts,
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.expirationInterval',
+    getLabel: () => 'retryPolicy.expirationInterval',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleDuration(
+        describeSchedule.action?.startWorkflow?.retryPolicy?.expirationInterval
+      ),
+    hide: hideWithoutRetryPolicy,
+  },
+  {
+    key: 'retryPolicy.nonRetryableErrorReasons',
+    getLabel: () => 'retryPolicy.nonRetryableErrorReasons',
+    getValue: ({ describeSchedule }) => {
+      const reasons =
+        describeSchedule.action?.startWorkflow?.retryPolicy
+          ?.nonRetryableErrorReasons;
+      if (!reasons?.length) {
+        return null;
+      }
+
+      return createElement(ScheduleDetailsBadges, { labels: reasons });
+    },
+    hide: hideWithoutRetryPolicy,
+  },
+];
+
+export default scheduleRetryPolicyDetailsConfig;


### PR DESCRIPTION
## Summary
- Add the Schedule action config group including retry policy rows.

## Changes
- `schedule-action-details.config.ts`, `schedule-retry-policy-details.config.ts`, and section registration.
- Tests for action rows and section collapse.

## Testing
- [x] `npm run test:unit:browser schedule-details`

Made with [Cursor](https://cursor.com)