### PR TITLE
feat(schedule-details): add policies detail section config

### DIFF
--- a/src/views/schedule-details/__tests__/schedule-details.test.tsx
+++ b/src/views/schedule-details/__tests__/schedule-details.test.tsx
@@ -24,10 +24,55 @@ jest.mock('next/navigation', () => ({
 }));
 
 describe(ScheduleDetails.name, () => {
-  it('shows loading first then renders the config-driven sections container', async () => {
+  it('shows loading first then renders detail sections with representative values', async () => {
+    const user = userEvent.setup();
     const describeResolver = jest.fn(async () => {
       await delay(100);
-      return HttpResponse.json(getMockRunningDescribeScheduleResponse());
+      return HttpResponse.json(
+        getMockRunningDescribeScheduleResponse({
+          info: {
+            createTime: { seconds: '1745490629', nanos: 850000000 },
+            nextRunTime: { seconds: '1745490629', nanos: 850000000 },
+            lastRunTime: { seconds: '1745490629', nanos: 850000000 },
+            totalRuns: '32',
+            lastUpdateTime: null,
+            ongoingBackfills: [],
+            missedRuns: '0',
+            skippedRuns: '0',
+          },
+          spec: {
+            cronExpression: '0 * * * *',
+            startTime: { seconds: '1735689600', nanos: 0 },
+            endTime: null,
+            jitter: { seconds: '300', nanos: 0 },
+          },
+          policies: {
+            overlapPolicy: 'SCHEDULE_OVERLAP_POLICY_BUFFER',
+            catchUpPolicy: 'SCHEDULE_CATCH_UP_POLICY_ONE',
+            catchUpWindow: { seconds: '3600', nanos: 0 },
+            pauseOnFailure: true,
+            bufferLimit: 10,
+            concurrencyLimit: 2,
+          },
+          action: {
+            startWorkflow: {
+              workflowType: { name: 'ScheduleWorker' },
+              taskList: {
+                name: 'schedule-task-list',
+                kind: 'TASK_LIST_KIND_NORMAL',
+                baseName: 'schedule-task-list',
+              },
+              input: null,
+              workflowIdPrefix: 'schedule-prefix',
+              executionStartToCloseTimeout: { seconds: '1800', nanos: 0 },
+              taskStartToCloseTimeout: null,
+              retryPolicy: null,
+              memo: null,
+              searchAttributes: null,
+            },
+          },
+        })
+      );
     });
 
     setup({ describeResolver });
@@ -35,60 +80,15 @@ describe(ScheduleDetails.name, () => {
     expect(screen.getByRole('progressbar')).toBeInTheDocument();
 
     await waitForElementToBeRemoved(() => screen.queryByRole('progressbar'));
-    expect(describeResolver).toHaveBeenCalledTimes(1);
-  });
-
-  it('renders schedule specifications section rows', async () => {
-    setup({
-      describeResolver: () =>
-        HttpResponse.json(
-          getMockRunningDescribeScheduleResponse({
-            info: {
-              createTime: { seconds: '1745490629', nanos: 850000000 },
-              nextRunTime: { seconds: '1745490629', nanos: 850000000 },
-              lastRunTime: { seconds: '1745490629', nanos: 850000000 },
-              totalRuns: '32',
-              lastUpdateTime: null,
-              ongoingBackfills: [],
-              missedRuns: '0',
-              skippedRuns: '0',
-            },
-            spec: {
-              cronExpression: '0 * * * *',
-              startTime: { seconds: '1735689600', nanos: 0 },
-              endTime: null,
-              jitter: { seconds: '300', nanos: 0 },
-            },
-            action: {
-              startWorkflow: {
-                workflowType: { name: 'ScheduleWorker' },
-                taskList: {
-                  name: 'schedule-task-list',
-                  kind: 'TASK_LIST_KIND_NORMAL',
-                  baseName: 'schedule-task-list',
-                },
-                input: null,
-                workflowIdPrefix: 'schedule-prefix',
-                executionStartToCloseTimeout: { seconds: '1800', nanos: 0 },
-                taskStartToCloseTimeout: null,
-                retryPolicy: null,
-                memo: null,
-                searchAttributes: null,
-              },
-            },
-          })
-        ),
-    });
-
     expect(
-      await screen.findByRole('heading', { name: 'Schedule specifications' })
+      screen.getByRole('heading', { name: 'Schedule specifications' })
     ).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'Schedule action' })
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('heading', { name: 'Schedule policies' })
-    ).not.toBeInTheDocument();
+      screen.getByRole('heading', { name: 'Schedule policies' })
+    ).toBeInTheDocument();
 
     expect(
       screen.getByRole('rowheader', { name: 'Schedule Id' })
@@ -99,40 +99,9 @@ describe(ScheduleDetails.name, () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Every hour (0 * * * *)')).toBeInTheDocument();
     expect(screen.getByText('5m')).toBeInTheDocument();
+    expect(screen.getByText('Buffer')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
     expect(screen.getByText('ScheduleWorker')).toBeInTheDocument();
-  });
-
-  it('collapses and expands the schedule action section', async () => {
-    const user = userEvent.setup();
-
-    setup({
-      describeResolver: () =>
-        HttpResponse.json(
-          getMockRunningDescribeScheduleResponse({
-            action: {
-              startWorkflow: {
-                workflowType: { name: 'ScheduleWorker' },
-                taskList: {
-                  name: 'schedule-task-list',
-                  kind: 'TASK_LIST_KIND_NORMAL',
-                  baseName: 'schedule-task-list',
-                },
-                input: null,
-                workflowIdPrefix: null,
-                executionStartToCloseTimeout: null,
-                taskStartToCloseTimeout: null,
-                retryPolicy: null,
-                memo: null,
-                searchAttributes: null,
-              },
-            },
-          })
-        ),
-    });
-
-    expect(
-      await screen.findByRole('heading', { name: 'Schedule action' })
-    ).toBeInTheDocument();
 
     await user.click(
       screen.getByRole('button', { name: 'Collapse Schedule action details' })
@@ -143,9 +112,11 @@ describe(ScheduleDetails.name, () => {
     expect(
       screen.getByRole('button', { name: 'Expand Schedule action details' })
     ).toBeInTheDocument();
+
+    expect(describeResolver).toHaveBeenCalledTimes(1);
   });
 
-  it('hides optional specification rows when schedule fields are missing', async () => {
+  it('hides optional detail rows when schedule fields are missing', async () => {
     setup({
       describeResolver: () =>
         HttpResponse.json(
@@ -155,6 +126,14 @@ describe(ScheduleDetails.name, () => {
               startTime: null,
               endTime: null,
               jitter: null,
+            },
+            policies: {
+              overlapPolicy: 'SCHEDULE_OVERLAP_POLICY_INVALID',
+              catchUpPolicy: 'SCHEDULE_CATCH_UP_POLICY_INVALID',
+              catchUpWindow: null,
+              pauseOnFailure: false,
+              bufferLimit: 0,
+              concurrencyLimit: 0,
             },
             action: { startWorkflow: null },
           })
@@ -179,6 +158,11 @@ describe(ScheduleDetails.name, () => {
     expect(
       screen.queryByRole('rowheader', { name: 'Schedule Search attributes' })
     ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('rowheader', { name: 'Overlap policy' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('Default (SkipNew)')).toBeInTheDocument();
+    expect(screen.getByText('Default (Skip)')).toBeInTheDocument();
     expect(
       screen.getByRole('heading', { name: 'Schedule action' })
     ).toBeInTheDocument();

--- a/src/views/schedule-details/config/schedule-details-sections.config.ts
+++ b/src/views/schedule-details/config/schedule-details-sections.config.ts
@@ -1,6 +1,7 @@
 import { type ScheduleDetailsSectionConfig } from '@/views/schedule-details/schedule-details.types';
 
 import scheduleActionDetailsConfig from './schedule-action-details.config';
+import schedulePoliciesDetailsConfig from './schedule-policies-details.config';
 import scheduleSpecificationsDetailsConfig from './schedule-specifications-details.config';
 
 const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
@@ -13,6 +14,11 @@ const scheduleDetailsSectionsConfig: ScheduleDetailsSectionConfig[] = [
     key: 'action',
     title: 'Schedule action',
     rowsConfig: scheduleActionDetailsConfig,
+  },
+  {
+    key: 'policies',
+    title: 'Schedule policies',
+    rowsConfig: schedulePoliciesDetailsConfig,
   },
 ];
 

--- a/src/views/schedule-details/config/schedule-policies-details.config.ts
+++ b/src/views/schedule-details/config/schedule-policies-details.config.ts
@@ -1,0 +1,58 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { type ScheduleDetailRowConfig } from '@/views/schedule-details/schedule-details.types';
+
+import {
+  formatBooleanValue,
+  formatScheduleEnumWithDefault,
+  formatScheduleLimitValue,
+} from '../helpers/schedule-details-formatters';
+
+const schedulePoliciesDetailsConfig: ScheduleDetailRowConfig[] = [
+  {
+    key: 'overlapPolicy',
+    getLabel: () => 'Overlap policy',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleEnumWithDefault(
+        describeSchedule.policies?.overlapPolicy,
+        'SCHEDULE_OVERLAP_POLICY',
+        ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_SKIP_NEW
+      ),
+  },
+  {
+    key: 'catchUpPolicy',
+    getLabel: () => 'Catchup policy',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleEnumWithDefault(
+        describeSchedule.policies?.catchUpPolicy,
+        'SCHEDULE_CATCH_UP_POLICY',
+        ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP
+      ),
+  },
+  {
+    key: 'pauseOnFailure',
+    getLabel: () => 'Pause on failure',
+    getValue: ({ describeSchedule }) =>
+      formatBooleanValue(describeSchedule.policies?.pauseOnFailure),
+  },
+  {
+    key: 'bufferLimit',
+    getLabel: () => 'Buffer limit',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleLimitValue(describeSchedule.policies?.bufferLimit),
+    hide: ({ describeSchedule }) =>
+      describeSchedule.policies?.overlapPolicy !==
+      ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+  },
+  {
+    key: 'concurrencyLimit',
+    getLabel: () => 'Concurrency limit',
+    getValue: ({ describeSchedule }) =>
+      formatScheduleLimitValue(describeSchedule.policies?.concurrencyLimit),
+    hide: ({ describeSchedule }) =>
+      describeSchedule.policies?.overlapPolicy !==
+      ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+  },
+];
+
+export default schedulePoliciesDetailsConfig;


### PR DESCRIPTION
## Summary
- Add the Schedule policies config group (overlap, catchup, limits).

## Changes
- `schedule-policies-details.config.ts` and section registration.
- Full integration tests across all three detail sections.

## Testing
- [x] `npm run test:unit:browser schedule-details`

Made with [Cursor](https://cursor.com)