### PR TITLE
feat(schedule-actions): pause/resume API

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/(actions)/pause/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/(actions)/pause/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { pauseSchedule } from '@/route-handlers/pause-schedule/pause-schedule';
+import { type RouteParams } from '@/route-handlers/pause-schedule/pause-schedule.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function POST(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    pauseSchedule,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/(actions)/unpause/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/(actions)/unpause/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { unpauseSchedule } from '@/route-handlers/unpause-schedule/unpause-schedule';
+import { type RouteParams } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function POST(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    unpauseSchedule,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
+++ b/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
@@ -91,20 +91,6 @@ describe(pauseSchedule.name, () => {
       })
     );
   });
-
-  it('returns an error if scheduleId is missing from route params', async () => {
-    const { res, mockPauseSchedule } = await setup({
-      scheduleId: '',
-    });
-
-    expect(mockPauseSchedule).not.toHaveBeenCalled();
-    expect(res.status).toEqual(400);
-    expect(await res.json()).toEqual(
-      expect.objectContaining({
-        message: 'Missing scheduleId in route params',
-      })
-    );
-  });
 });
 
 async function setup({

--- a/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
+++ b/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
@@ -1,0 +1,121 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import { pauseSchedule } from '../pause-schedule';
+import { type Context } from '../pause-schedule.types';
+
+describe(pauseSchedule.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls pauseSchedule and returns valid response', async () => {
+    const { res, mockPauseSchedule } = await setup({});
+
+    expect(mockPauseSchedule).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      scheduleId: 'mock-schedule-id',
+      reason: undefined,
+      identity: undefined,
+    });
+
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  it('calls pauseSchedule with optional reason in request body', async () => {
+    const { mockPauseSchedule } = await setup({
+      requestBody: JSON.stringify({ reason: 'Maintenance window' }),
+    });
+
+    expect(mockPauseSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'Maintenance window',
+      })
+    );
+  });
+
+  it('returns an error if pauseSchedule throws a GRPCError', async () => {
+    const { res, mockPauseSchedule } = await setup({
+      error: new GRPCError('Schedule not found', {
+        grpcStatusCode: status.NOT_FOUND,
+      }),
+    });
+
+    expect(mockPauseSchedule).toHaveBeenCalled();
+    expect(res.status).toEqual(404);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Schedule not found',
+      })
+    );
+  });
+
+  it('returns an error if the request body is not in an expected format', async () => {
+    const { res, mockPauseSchedule } = await setup({
+      requestBody: JSON.stringify({ reason: 123 }),
+    });
+
+    expect(mockPauseSchedule).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Invalid values provided for schedule pause',
+      })
+    );
+  });
+
+  it('returns an error if scheduleId is missing from route params', async () => {
+    const { res, mockPauseSchedule } = await setup({
+      scheduleId: '',
+    });
+
+    expect(mockPauseSchedule).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Missing scheduleId in route params',
+      })
+    );
+  });
+});
+
+async function setup({
+  requestBody = '{}',
+  scheduleId = 'mock-schedule-id',
+  error,
+}: {
+  requestBody?: string;
+  scheduleId?: string;
+  error?: GRPCError;
+}) {
+  const mockPauseSchedule = jest
+    .spyOn(mockGrpcClusterMethods, 'pauseSchedule')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw error;
+      }
+      return {};
+    });
+
+  const res = await pauseSchedule(
+    new NextRequest('http://localhost', {
+      method: 'POST',
+      body: requestBody,
+    }),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        scheduleId,
+      },
+    },
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockPauseSchedule };
+}

--- a/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
+++ b/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
@@ -7,6 +7,10 @@ import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middle
 import { pauseSchedule } from '../pause-schedule';
 import { type Context } from '../pause-schedule.types';
 
+const defaultRequestBody = {
+  reason: 'Pausing schedule from cadence-web UI',
+};
+
 describe(pauseSchedule.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -18,7 +22,7 @@ describe(pauseSchedule.name, () => {
     expect(mockPauseSchedule).toHaveBeenCalledWith({
       domain: 'mock-domain',
       scheduleId: 'mock-schedule-id',
-      reason: undefined,
+      reason: defaultRequestBody.reason,
       identity: undefined,
     });
 
@@ -26,32 +30,35 @@ describe(pauseSchedule.name, () => {
     expect(await res.json()).toEqual({});
   });
 
-  it('returns valid response when request has no body', async () => {
+  it('returns an error when request has no body', async () => {
     const { res, mockPauseSchedule } = await setup({
       requestBody: null,
     });
 
-    expect(mockPauseSchedule).toHaveBeenCalledWith({
-      domain: 'mock-domain',
-      scheduleId: 'mock-schedule-id',
-      reason: undefined,
-      identity: undefined,
-    });
-    expect(res.status).toEqual(200);
-    expect(await res.json()).toEqual({});
+    expect(mockPauseSchedule).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Invalid values provided for schedule pause',
+      })
+    );
   });
 
-  it('returns valid response when request body is malformed JSON', async () => {
+  it('returns an error when request body is malformed JSON', async () => {
     const { res, mockPauseSchedule } = await setup({
       requestBody: 'not-json',
     });
 
-    expect(mockPauseSchedule).toHaveBeenCalled();
-    expect(res.status).toEqual(200);
-    expect(await res.json()).toEqual({});
+    expect(mockPauseSchedule).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Invalid values provided for schedule pause',
+      })
+    );
   });
 
-  it('calls pauseSchedule with optional reason in request body', async () => {
+  it('calls pauseSchedule with reason in request body', async () => {
     const { mockPauseSchedule } = await setup({
       requestBody: JSON.stringify({ reason: 'Maintenance window' }),
     });
@@ -91,10 +98,24 @@ describe(pauseSchedule.name, () => {
       })
     );
   });
+
+  it('returns an error when reason is empty', async () => {
+    const { res, mockPauseSchedule } = await setup({
+      requestBody: JSON.stringify({ reason: '' }),
+    });
+
+    expect(mockPauseSchedule).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Invalid values provided for schedule pause',
+      })
+    );
+  });
 });
 
 async function setup({
-  requestBody = '{}',
+  requestBody = JSON.stringify(defaultRequestBody),
   scheduleId = 'mock-schedule-id',
   error,
 }: {
@@ -104,7 +125,7 @@ async function setup({
 }) {
   const mockPauseSchedule = jest
     .spyOn(mockGrpcClusterMethods, 'pauseSchedule')
-    .mockImplementationOnce(async () => {
+    .mockImplementation(async () => {
       if (error) {
         throw error;
       }

--- a/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
+++ b/src/route-handlers/pause-schedule/__tests__/pause-schedule.node.ts
@@ -26,6 +26,31 @@ describe(pauseSchedule.name, () => {
     expect(await res.json()).toEqual({});
   });
 
+  it('returns valid response when request has no body', async () => {
+    const { res, mockPauseSchedule } = await setup({
+      requestBody: null,
+    });
+
+    expect(mockPauseSchedule).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      scheduleId: 'mock-schedule-id',
+      reason: undefined,
+      identity: undefined,
+    });
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  it('returns valid response when request body is malformed JSON', async () => {
+    const { res, mockPauseSchedule } = await setup({
+      requestBody: 'not-json',
+    });
+
+    expect(mockPauseSchedule).toHaveBeenCalled();
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual({});
+  });
+
   it('calls pauseSchedule with optional reason in request body', async () => {
     const { mockPauseSchedule } = await setup({
       requestBody: JSON.stringify({ reason: 'Maintenance window' }),
@@ -87,7 +112,7 @@ async function setup({
   scheduleId = 'mock-schedule-id',
   error,
 }: {
-  requestBody?: string;
+  requestBody?: string | null;
   scheduleId?: string;
   error?: GRPCError;
 }) {
@@ -103,7 +128,7 @@ async function setup({
   const res = await pauseSchedule(
     new NextRequest('http://localhost', {
       method: 'POST',
-      body: requestBody,
+      ...(requestBody === null ? {} : { body: requestBody }),
     }),
     {
       params: {

--- a/src/route-handlers/pause-schedule/pause-schedule.ts
+++ b/src/route-handlers/pause-schedule/pause-schedule.ts
@@ -15,7 +15,7 @@ export async function pauseSchedule(
   requestParams: RequestParams,
   ctx: Context
 ) {
-  // allow empty body
+  // catch to allow empty body
   const requestBody = await request.json().catch(() => ({}));
   const { data, error } = pauseScheduleRequestBodySchema.safeParse(requestBody);
 
@@ -39,7 +39,7 @@ export async function pauseSchedule(
       identity: ctx.userInfo?.id,
     });
 
-    return NextResponse.json(response);
+    return NextResponse.json(response satisfies PauseScheduleResponse);
   } catch (e) {
     logger.error<RouteHandlerErrorPayload>(
       { requestParams: params, error: e },

--- a/src/route-handlers/pause-schedule/pause-schedule.ts
+++ b/src/route-handlers/pause-schedule/pause-schedule.ts
@@ -32,14 +32,14 @@ export async function pauseSchedule(
   const params = requestParams.params;
 
   try {
-    await ctx.grpcClusterMethods.pauseSchedule({
+    const response = await ctx.grpcClusterMethods.pauseSchedule({
       domain: params.domain,
       scheduleId: params.scheduleId,
       reason: data.reason,
       identity: ctx.userInfo?.id,
     });
 
-    return NextResponse.json({} satisfies PauseScheduleResponse);
+    return NextResponse.json(response);
   } catch (e) {
     logger.error<RouteHandlerErrorPayload>(
       { requestParams: params, error: e },

--- a/src/route-handlers/pause-schedule/pause-schedule.ts
+++ b/src/route-handlers/pause-schedule/pause-schedule.ts
@@ -1,0 +1,63 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import pauseScheduleRequestBodySchema from './schemas/pause-schedule-request-body-schema';
+import {
+  type Context,
+  type PauseScheduleResponse,
+  type RequestParams,
+} from './pause-schedule.types';
+
+export async function pauseSchedule(
+  request: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const requestBody = await request.json();
+  const { data, error } = pauseScheduleRequestBodySchema.safeParse(requestBody);
+
+  if (error) {
+    return NextResponse.json(
+      {
+        message: 'Invalid values provided for schedule pause',
+        validationErrors: error.errors,
+      },
+      { status: 400 }
+    );
+  }
+
+  const params = requestParams.params;
+
+  if (!params.scheduleId) {
+    return NextResponse.json(
+      { message: 'Missing scheduleId in route params' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ctx.grpcClusterMethods.pauseSchedule({
+      domain: params.domain,
+      scheduleId: params.scheduleId,
+      reason: data.reason,
+      identity: ctx.userInfo?.id,
+    });
+
+    return NextResponse.json({} satisfies PauseScheduleResponse);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: params, error: e },
+      'Error pausing schedule'
+    );
+
+    return NextResponse.json(
+      {
+        message: e instanceof GRPCError ? e.message : 'Error pausing schedule',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/pause-schedule/pause-schedule.ts
+++ b/src/route-handlers/pause-schedule/pause-schedule.ts
@@ -31,13 +31,6 @@ export async function pauseSchedule(
 
   const params = requestParams.params;
 
-  if (!params.scheduleId) {
-    return NextResponse.json(
-      { message: 'Missing scheduleId in route params' },
-      { status: 400 }
-    );
-  }
-
   try {
     await ctx.grpcClusterMethods.pauseSchedule({
       domain: params.domain,

--- a/src/route-handlers/pause-schedule/pause-schedule.ts
+++ b/src/route-handlers/pause-schedule/pause-schedule.ts
@@ -3,19 +3,20 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
-import pauseScheduleRequestBodySchema from './schemas/pause-schedule-request-body-schema';
 import {
   type Context,
   type PauseScheduleResponse,
   type RequestParams,
 } from './pause-schedule.types';
+import pauseScheduleRequestBodySchema from './schemas/pause-schedule-request-body-schema';
 
 export async function pauseSchedule(
   request: NextRequest,
   requestParams: RequestParams,
   ctx: Context
 ) {
-  const requestBody = await request.json();
+  // allow empty body
+  const requestBody = await request.json().catch(() => ({}));
   const { data, error } = pauseScheduleRequestBodySchema.safeParse(requestBody);
 
   if (error) {

--- a/src/route-handlers/pause-schedule/pause-schedule.types.ts
+++ b/src/route-handlers/pause-schedule/pause-schedule.types.ts
@@ -1,0 +1,16 @@
+import { type PauseScheduleResponse as PauseScheduleResponseProto } from '@/__generated__/proto-ts/uber/cadence/api/v1/PauseScheduleResponse';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+  scheduleId: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type PauseScheduleResponse = PauseScheduleResponseProto;
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/pause-schedule/schemas/pause-schedule-request-body-schema.ts
+++ b/src/route-handlers/pause-schedule/schemas/pause-schedule-request-body-schema.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+const pauseScheduleRequestBodySchema = z.object({
+  reason: z.string().optional(),
+});
+
+export default pauseScheduleRequestBodySchema;

--- a/src/route-handlers/pause-schedule/schemas/pause-schedule-request-body-schema.ts
+++ b/src/route-handlers/pause-schedule/schemas/pause-schedule-request-body-schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const pauseScheduleRequestBodySchema = z.object({
-  reason: z.string(),
+  reason: z.string().min(1),
 });
 
 export default pauseScheduleRequestBodySchema;

--- a/src/route-handlers/pause-schedule/schemas/pause-schedule-request-body-schema.ts
+++ b/src/route-handlers/pause-schedule/schemas/pause-schedule-request-body-schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 const pauseScheduleRequestBodySchema = z.object({
-  reason: z.string().optional(),
+  reason: z.string(),
 });
 
 export default pauseScheduleRequestBodySchema;

--- a/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
+++ b/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
@@ -96,20 +96,6 @@ describe(unpauseSchedule.name, () => {
       })
     );
   });
-
-  it('returns an error if scheduleId is missing from route params', async () => {
-    const { res, mockUnpauseSchedule } = await setup({
-      scheduleId: '',
-    });
-
-    expect(mockUnpauseSchedule).not.toHaveBeenCalled();
-    expect(res.status).toEqual(400);
-    expect(await res.json()).toEqual(
-      expect.objectContaining({
-        message: 'Missing scheduleId in route params',
-      })
-    );
-  });
 });
 
 async function setup({

--- a/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
+++ b/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
@@ -27,6 +27,31 @@ describe(unpauseSchedule.name, () => {
     expect(await res.json()).toEqual({});
   });
 
+  it('returns valid response when request has no body', async () => {
+    const { res, mockUnpauseSchedule } = await setup({
+      requestBody: null,
+    });
+
+    expect(mockUnpauseSchedule).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      scheduleId: 'mock-schedule-id',
+      reason: undefined,
+      catchUpPolicy: undefined,
+    });
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  it('returns valid response when request body is malformed JSON', async () => {
+    const { res, mockUnpauseSchedule } = await setup({
+      requestBody: 'not-json',
+    });
+
+    expect(mockUnpauseSchedule).toHaveBeenCalled();
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual({});
+  });
+
   it('calls unpauseSchedule with optional request body fields', async () => {
     const { mockUnpauseSchedule } = await setup({
       requestBody: JSON.stringify({
@@ -92,7 +117,7 @@ async function setup({
   scheduleId = 'mock-schedule-id',
   error,
 }: {
-  requestBody?: string;
+  requestBody?: string | null;
   scheduleId?: string;
   error?: GRPCError;
 }) {
@@ -108,7 +133,7 @@ async function setup({
   const res = await unpauseSchedule(
     new NextRequest('http://localhost', {
       method: 'POST',
-      body: requestBody,
+      ...(requestBody === null ? {} : { body: requestBody }),
     }),
     {
       params: {

--- a/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
+++ b/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
@@ -1,0 +1,126 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import { unpauseSchedule } from '../unpause-schedule';
+import { type Context } from '../unpause-schedule.types';
+
+describe(unpauseSchedule.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls unpauseSchedule and returns valid response', async () => {
+    const { res, mockUnpauseSchedule } = await setup({});
+
+    expect(mockUnpauseSchedule).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      scheduleId: 'mock-schedule-id',
+      reason: undefined,
+      catchUpPolicy: undefined,
+    });
+
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  it('calls unpauseSchedule with optional request body fields', async () => {
+    const { mockUnpauseSchedule } = await setup({
+      requestBody: JSON.stringify({
+        reason: 'Maintenance complete',
+        catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP,
+      }),
+    });
+
+    expect(mockUnpauseSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reason: 'Maintenance complete',
+        catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP,
+      })
+    );
+  });
+
+  it('returns an error if unpauseSchedule throws a GRPCError', async () => {
+    const { res, mockUnpauseSchedule } = await setup({
+      error: new GRPCError('Schedule not found', {
+        grpcStatusCode: status.NOT_FOUND,
+      }),
+    });
+
+    expect(mockUnpauseSchedule).toHaveBeenCalled();
+    expect(res.status).toEqual(404);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Schedule not found',
+      })
+    );
+  });
+
+  it('returns an error if the request body is not in an expected format', async () => {
+    const { res, mockUnpauseSchedule } = await setup({
+      requestBody: JSON.stringify({ reason: 123 }),
+    });
+
+    expect(mockUnpauseSchedule).not.toHaveBeenCalled();
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Invalid values provided for schedule unpause',
+      })
+    );
+  });
+
+  it('returns an error if scheduleId is missing from route params', async () => {
+    const { res, mockUnpauseSchedule } = await setup({
+      scheduleId: '',
+    });
+
+    expect(mockUnpauseSchedule).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        message: 'Missing scheduleId in route params',
+      })
+    );
+  });
+});
+
+async function setup({
+  requestBody = '{}',
+  scheduleId = 'mock-schedule-id',
+  error,
+}: {
+  requestBody?: string;
+  scheduleId?: string;
+  error?: GRPCError;
+}) {
+  const mockUnpauseSchedule = jest
+    .spyOn(mockGrpcClusterMethods, 'unpauseSchedule')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw error;
+      }
+      return {};
+    });
+
+  const res = await unpauseSchedule(
+    new NextRequest('http://localhost', {
+      method: 'POST',
+      body: requestBody,
+    }),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        scheduleId,
+      },
+    },
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockUnpauseSchedule };
+}

--- a/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
+++ b/src/route-handlers/unpause-schedule/__tests__/unpause-schedule.node.ts
@@ -109,7 +109,7 @@ async function setup({
 }) {
   const mockUnpauseSchedule = jest
     .spyOn(mockGrpcClusterMethods, 'unpauseSchedule')
-    .mockImplementationOnce(async () => {
+    .mockImplementation(async () => {
       if (error) {
         throw error;
       }

--- a/src/route-handlers/unpause-schedule/schemas/unpause-schedule-request-body-schema.ts
+++ b/src/route-handlers/unpause-schedule/schemas/unpause-schedule-request-body-schema.ts
@@ -1,5 +1,6 @@
-import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { z } from 'zod';
+
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 
 const unpauseScheduleRequestBodySchema = z.object({
   reason: z.string().optional(),

--- a/src/route-handlers/unpause-schedule/schemas/unpause-schedule-request-body-schema.ts
+++ b/src/route-handlers/unpause-schedule/schemas/unpause-schedule-request-body-schema.ts
@@ -1,0 +1,9 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { z } from 'zod';
+
+const unpauseScheduleRequestBodySchema = z.object({
+  reason: z.string().optional(),
+  catchUpPolicy: z.nativeEnum(ScheduleCatchUpPolicy).optional(),
+});
+
+export default unpauseScheduleRequestBodySchema;

--- a/src/route-handlers/unpause-schedule/unpause-schedule.ts
+++ b/src/route-handlers/unpause-schedule/unpause-schedule.ts
@@ -15,6 +15,7 @@ export async function unpauseSchedule(
   requestParams: RequestParams,
   ctx: Context
 ) {
+  // catch to allow empty body
   const requestBody = await request.json().catch(() => ({}));
   const { data, error } =
     unpauseScheduleRequestBodySchema.safeParse(requestBody);
@@ -39,7 +40,7 @@ export async function unpauseSchedule(
       catchUpPolicy: data.catchUpPolicy,
     });
 
-    return NextResponse.json(response);
+    return NextResponse.json(response satisfies UnpauseScheduleResponse);
   } catch (e) {
     logger.error<RouteHandlerErrorPayload>(
       { requestParams: params, error: e },

--- a/src/route-handlers/unpause-schedule/unpause-schedule.ts
+++ b/src/route-handlers/unpause-schedule/unpause-schedule.ts
@@ -15,7 +15,7 @@ export async function unpauseSchedule(
   requestParams: RequestParams,
   ctx: Context
 ) {
-  const requestBody = await request.json();
+  const requestBody = await request.json().catch(() => ({}));
   const { data, error } =
     unpauseScheduleRequestBodySchema.safeParse(requestBody);
 

--- a/src/route-handlers/unpause-schedule/unpause-schedule.ts
+++ b/src/route-handlers/unpause-schedule/unpause-schedule.ts
@@ -32,14 +32,14 @@ export async function unpauseSchedule(
   const params = requestParams.params;
 
   try {
-    await ctx.grpcClusterMethods.unpauseSchedule({
+    const response = await ctx.grpcClusterMethods.unpauseSchedule({
       domain: params.domain,
       scheduleId: params.scheduleId,
       reason: data.reason,
       catchUpPolicy: data.catchUpPolicy,
     });
 
-    return NextResponse.json({} satisfies UnpauseScheduleResponse);
+    return NextResponse.json(response);
   } catch (e) {
     logger.error<RouteHandlerErrorPayload>(
       { requestParams: params, error: e },

--- a/src/route-handlers/unpause-schedule/unpause-schedule.ts
+++ b/src/route-handlers/unpause-schedule/unpause-schedule.ts
@@ -31,13 +31,6 @@ export async function unpauseSchedule(
 
   const params = requestParams.params;
 
-  if (!params.scheduleId) {
-    return NextResponse.json(
-      { message: 'Missing scheduleId in route params' },
-      { status: 400 }
-    );
-  }
-
   try {
     await ctx.grpcClusterMethods.unpauseSchedule({
       domain: params.domain,

--- a/src/route-handlers/unpause-schedule/unpause-schedule.ts
+++ b/src/route-handlers/unpause-schedule/unpause-schedule.ts
@@ -1,0 +1,65 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import unpauseScheduleRequestBodySchema from './schemas/unpause-schedule-request-body-schema';
+import {
+  type Context,
+  type RequestParams,
+  type UnpauseScheduleResponse,
+} from './unpause-schedule.types';
+
+export async function unpauseSchedule(
+  request: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const requestBody = await request.json();
+  const { data, error } =
+    unpauseScheduleRequestBodySchema.safeParse(requestBody);
+
+  if (error) {
+    return NextResponse.json(
+      {
+        message: 'Invalid values provided for schedule unpause',
+        validationErrors: error.errors,
+      },
+      { status: 400 }
+    );
+  }
+
+  const params = requestParams.params;
+
+  if (!params.scheduleId) {
+    return NextResponse.json(
+      { message: 'Missing scheduleId in route params' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await ctx.grpcClusterMethods.unpauseSchedule({
+      domain: params.domain,
+      scheduleId: params.scheduleId,
+      reason: data.reason,
+      catchUpPolicy: data.catchUpPolicy,
+    });
+
+    return NextResponse.json({} satisfies UnpauseScheduleResponse);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: params, error: e },
+      'Error unpausing schedule'
+    );
+
+    return NextResponse.json(
+      {
+        message:
+          e instanceof GRPCError ? e.message : 'Error unpausing schedule',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/unpause-schedule/unpause-schedule.types.ts
+++ b/src/route-handlers/unpause-schedule/unpause-schedule.types.ts
@@ -1,0 +1,16 @@
+import { type UnpauseScheduleResponse as UnpauseScheduleResponseProto } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleResponse';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+  scheduleId: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type UnpauseScheduleResponse = UnpauseScheduleResponseProto;
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -30,6 +30,10 @@ import { type ListOpenWorkflowExecutionsRequest__Input } from '@/__generated__/p
 import { type ListOpenWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListOpenWorkflowExecutionsResponse';
 import { type ListSchedulesRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesRequest';
 import { type ListSchedulesResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesResponse';
+import { type PauseScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/PauseScheduleRequest';
+import { type PauseScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/PauseScheduleResponse';
+import { type UnpauseScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleRequest';
+import { type UnpauseScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleResponse';
 import { type ListTaskListPartitionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsRequest';
 import { type ListTaskListPartitionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsResponse';
 import { type ListWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListWorkflowExecutionsRequest';
@@ -115,6 +119,12 @@ export type GRPCClusterMethods = {
   listSchedules: (
     payload: ListSchedulesRequest__Input
   ) => Promise<ListSchedulesResponse>;
+  pauseSchedule: (
+    payload: PauseScheduleRequest__Input
+  ) => Promise<PauseScheduleResponse>;
+  unpauseSchedule: (
+    payload: UnpauseScheduleRequest__Input
+  ) => Promise<UnpauseScheduleResponse>;
   listTaskListPartitions: (
     payload: ListTaskListPartitionsRequest__Input
   ) => Promise<ListTaskListPartitionsResponse>;
@@ -332,6 +342,20 @@ const getClusterServicesMethods = async (
       ListSchedulesResponse
     >({
       method: 'ListSchedules',
+      metadata: metadata,
+    }),
+    pauseSchedule: scheduleService.request<
+      PauseScheduleRequest__Input,
+      PauseScheduleResponse
+    >({
+      method: 'PauseSchedule',
+      metadata: metadata,
+    }),
+    unpauseSchedule: scheduleService.request<
+      UnpauseScheduleRequest__Input,
+      UnpauseScheduleResponse
+    >({
+      method: 'UnpauseSchedule',
       metadata: metadata,
     }),
     listTaskListPartitions: workflowService.request<

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -30,14 +30,12 @@ import { type ListOpenWorkflowExecutionsRequest__Input } from '@/__generated__/p
 import { type ListOpenWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListOpenWorkflowExecutionsResponse';
 import { type ListSchedulesRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesRequest';
 import { type ListSchedulesResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListSchedulesResponse';
-import { type PauseScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/PauseScheduleRequest';
-import { type PauseScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/PauseScheduleResponse';
-import { type UnpauseScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleRequest';
-import { type UnpauseScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleResponse';
 import { type ListTaskListPartitionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsRequest';
 import { type ListTaskListPartitionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListTaskListPartitionsResponse';
 import { type ListWorkflowExecutionsRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListWorkflowExecutionsRequest';
 import { type ListWorkflowExecutionsResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/ListWorkflowExecutionsResponse';
+import { type PauseScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/PauseScheduleRequest';
+import { type PauseScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/PauseScheduleResponse';
 import { type QueryWorkflowRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/QueryWorkflowRequest';
 import { type QueryWorkflowResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/QueryWorkflowResponse';
 import { type RequestCancelWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/RequestCancelWorkflowExecutionRequest';
@@ -52,6 +50,8 @@ import { type StartWorkflowExecutionRequest__Input } from '@/__generated__/proto
 import { type StartWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/StartWorkflowExecutionResponse';
 import { type TerminateWorkflowExecutionRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/TerminateWorkflowExecutionRequest';
 import { type TerminateWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/TerminateWorkflowExecutionResponse';
+import { type UnpauseScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleRequest';
+import { type UnpauseScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleResponse';
 import { type UpdateDomainRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateDomainRequest';
 import { type UpdateDomainResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateDomainResponse';
 import { type ClusterConfig } from '@/config/dynamic/resolvers/clusters.types';

--- a/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
@@ -18,6 +18,8 @@ export const mockGrpcClusterMethods: GRPCClusterMethods = {
   listDomains: jest.fn(),
   listFailoverHistory: jest.fn(),
   listSchedules: jest.fn(),
+  pauseSchedule: jest.fn(),
+  unpauseSchedule: jest.fn(),
   listTaskListPartitions: jest.fn(),
   listWorkflows: jest.fn(),
   openWorkflows: jest.fn(),


### PR DESCRIPTION
## Summary
- Wire `pauseSchedule` and `unpauseSchedule` into `GRPCClusterMethods` and the gRPC mock.
- Add route handlers with Zod body validation (`reason` optional; unpause also accepts optional `catchUpPolicy`).
- Expose `POST .../schedules/{scheduleId}/pause` and `POST .../schedules/{scheduleId}/unpause` API routes.

## Test plan
<img width="681" height="84" alt="Screenshot 2026-06-26 at 03 18 06" src="https://github.com/user-attachments/assets/44681a16-a328-4ebd-81d0-37a0ad160af0" />
<img width="781" height="77" alt="Screenshot 2026-06-26 at 03 19 17" src="https://github.com/user-attachments/assets/4b30e17a-5e25-4b00-8bd8-f3aaa9b9dac9" />
<img width="673" height="75" alt="Screenshot 2026-06-26 at 03 17 35" src="https://github.com/user-attachments/assets/379977f6-04a0-4c40-8619-6fb014990ba6" />
<img width="905" height="138" alt="Screenshot 2026-06-26 at 03 17 40" src="https://github.com/user-attachments/assets/ec7cef07-a88d-458e-9ae2-d7d238fc3b01" />

## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- [x] Schedules Create Form
- [x] Schedules Details
- Schedules Actions
  - #1414
