### PR TITLE
fix(start-workflow): trim whitespaces

### DIFF
--- a/src/route-handlers/start-workflow/__tests__/start-workflow.node.ts
+++ b/src/route-handlers/start-workflow/__tests__/start-workflow.node.ts
@@ -249,6 +249,41 @@ describe(startWorkflow.name, () => {
     expect(responseData.validationErrors).toBeDefined();
   });
 
+  it('trims whitespace from identifier fields', async () => {
+    const { mockStartWorkflow } = await setup({
+      requestBody: {
+        ...defaultRequestBody,
+        workflowId: '  test-workflow-id  ',
+        workflowType: { name: '  TestWorkflow  ' },
+        taskList: { name: '  test-task-list  ' },
+      },
+    });
+
+    expect(mockStartWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowId: 'test-workflow-id',
+        workflowType: { name: 'TestWorkflow' },
+        taskList: { name: 'test-task-list' },
+      })
+    );
+  });
+
+  it('treats whitespace-only workflowId as missing and generates one', async () => {
+    const generatedWorkflowId = '123e4567-e89b-12d3-a456-426614174000';
+    jest.spyOn(crypto, 'randomUUID').mockReturnValue(generatedWorkflowId);
+
+    const { mockStartWorkflow } = await setup({
+      requestBody: {
+        ...defaultRequestBody,
+        workflowId: '   ',
+      } as StartWorkflowRequestBody,
+    });
+
+    expect(mockStartWorkflow).toHaveBeenCalledWith(
+      expect.objectContaining({ workflowId: generatedWorkflowId })
+    );
+  });
+
   it('handles GRPC errors correctly', async () => {
     const { res, mockStartWorkflow } = await setup({
       error: 'Internal server error',

--- a/src/route-handlers/start-workflow/schemas/start-workflow-request-body-schema.ts
+++ b/src/route-handlers/start-workflow/schemas/start-workflow-request-body-schema.ts
@@ -9,12 +9,16 @@ import { jsonValueSchema } from './json-value-schema';
 
 const startWorkflowRequestBodySchema = z.object({
   workflowType: z.object({
-    name: z.string().min(1),
+    name: z.string().trim().min(1),
   }),
   taskList: z.object({
-    name: z.string().min(1),
+    name: z.string().trim().min(1),
   }),
-  workflowId: z.string().optional(),
+  workflowId: z
+    .string()
+    .trim()
+    .optional()
+    .transform((v) => v || undefined),
   workerSDKLanguage: z.enum(WORKER_SDK_LANGUAGES),
   input: z.array(jsonValueSchema).optional(),
   executionStartToCloseTimeoutSeconds: z.number().positive(),

--- a/src/views/workflow-actions/workflow-action-start-form/schemas/start-workflow-form-schema.ts
+++ b/src/views/workflow-actions/workflow-action-start-form/schemas/start-workflow-form-schema.ts
@@ -10,10 +10,10 @@ import { getCronFieldsError } from '../helpers/get-cron-fields-error';
 
 const baseSchema = z.object({
   workflowType: z.object({
-    name: z.string().min(1, 'Workflow type name is required'),
+    name: z.string().trim().min(1, 'Workflow type name is required'),
   }),
   taskList: z.object({
-    name: z.string().min(1, 'Task list name is required'),
+    name: z.string().trim().min(1, 'Task list name is required'),
   }),
   workerSDKLanguage: z.enum(WORKER_SDK_LANGUAGES),
   input: z
@@ -38,7 +38,7 @@ const baseSchema = z.object({
         }
       }
     }),
-  workflowId: z.string().optional(),
+  workflowId: z.string().trim().optional(),
   executionStartToCloseTimeoutSeconds: z.number().positive(),
   taskStartToCloseTimeoutSeconds: z.number().positive().optional(),
   workflowIdReusePolicy: z.enum(WORKFLOW_ID_REUSE_POLICIES).optional(),

--- a/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.tsx
+++ b/src/views/workflow-actions/workflow-action-start-form/workflow-action-start-form.tsx
@@ -50,8 +50,12 @@ export default function WorkflowActionStartForm({
     defaultValue: '',
   });
 
+  // Search with the trimmed value so leading/trailing spaces in the input
+  // don't change the lookup (the field itself keeps the user's raw text).
+  const trimmedTaskListName = taskListName.trim();
+
   const { debouncedValue: debouncedTaskListName, isDebouncePending } =
-    useDebouncedValue(taskListName, TASK_LIST_DEBOUNCE_MS);
+    useDebouncedValue(trimmedTaskListName, TASK_LIST_DEBOUNCE_MS);
 
   const {
     data: taskListData,
@@ -64,10 +68,10 @@ export default function WorkflowActionStartForm({
   });
 
   const isTaskListLoading =
-    (isDebouncePending && taskListName.length > 0) || isTaskListQueryLoading;
+    (isDebouncePending && trimmedTaskListName.length > 0) ||
+    isTaskListQueryLoading;
 
   const inputError = getMultiJsonErrorMessage(fieldErrors, 'input');
-
   const taskListCaptionMessage = getTaskListCaptionMessage({
     taskListData,
     isTaskListLoading,
@@ -101,12 +105,6 @@ export default function WorkflowActionStartForm({
               // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
               inputRef={ref}
               aria-label="Task List"
-              onChange={(e) => {
-                field.onChange(e.target.value.trim());
-              }}
-              onBlur={() => {
-                field.onBlur();
-              }}
               error={Boolean(
                 getFieldErrorMessage(fieldErrors, 'taskList.name')
               )}


### PR DESCRIPTION
## The issue
 workflow types are not trimmed from spaces. This can cause workflows to fail with hard to find type
 
 ## The Fix
 - Added native Zod  .trim() to workflowType, Id, and taskList.
 - Removed the redundant onChange trim from the form component.
 
 ## Testing
 
- Validated tasklist search uses the trimmed value (trim happens on the component)
- users can still add spaces within the text.
- validated using empty strings