### PR TITLE
fix(batch-actions): placeholder position matches other banners

### DIFF
--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -169,13 +169,7 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
 
   if (batchActions.length === 0 && !isDraftOpen) {
     return (
-      <styled.Container>
-        <styled.DetailPanel>
-          <DomainBatchActionsNoActionsPlaceholder
-            onCreateNew={handleCreateNew}
-          />
-        </styled.DetailPanel>
-      </styled.Container>
+      <DomainBatchActionsNoActionsPlaceholder onCreateNew={handleCreateNew} />
     );
   }
 


### PR DESCRIPTION
## What changed

Batch actions placeholder was in a div that made it stick to the top. Now it is matching to other panels like Archival.

<img width="1710" height="1125" alt="image" src="https://github.com/user-attachments/assets/d62fc24d-ca5a-408d-945b-a327a269eaef" />
