### PR TITLE
feat(schedule-actions): add delete confirmation action 

### DIFF
--- a/src/config/dynamic/resolvers/__tests__/schedule-actions-enabled.node.ts
+++ b/src/config/dynamic/resolvers/__tests__/schedule-actions-enabled.node.ts
@@ -26,6 +26,7 @@ describe(scheduleActionsEnabled.name, () => {
     expect(result).toEqual({
       pause: 'ENABLED',
       resume: 'ENABLED',
+      delete: 'ENABLED',
     });
   });
 
@@ -40,6 +41,7 @@ describe(scheduleActionsEnabled.name, () => {
     expect(result).toEqual({
       pause: 'DISABLED_UNAUTHORIZED',
       resume: 'DISABLED_UNAUTHORIZED',
+      delete: 'DISABLED_UNAUTHORIZED',
     });
   });
 
@@ -54,6 +56,7 @@ describe(scheduleActionsEnabled.name, () => {
     expect(result).toEqual({
       pause: 'DISABLED_DEFAULT',
       resume: 'DISABLED_DEFAULT',
+      delete: 'DISABLED_DEFAULT',
     });
   });
 });

--- a/src/config/dynamic/resolvers/schedule-actions-enabled.constants.ts
+++ b/src/config/dynamic/resolvers/schedule-actions-enabled.constants.ts
@@ -4,16 +4,19 @@ export const AUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
   {
     pause: 'ENABLED',
     resume: 'ENABLED',
+    delete: 'ENABLED',
   };
 
 export const UNAUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
   {
     pause: 'DISABLED_UNAUTHORIZED',
     resume: 'DISABLED_UNAUTHORIZED',
+    delete: 'DISABLED_UNAUTHORIZED',
   };
 
 export const DEFAULT_DISABLED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
   {
     pause: 'DISABLED_DEFAULT',
     resume: 'DISABLED_DEFAULT',
+    delete: 'DISABLED_DEFAULT',
   };

--- a/src/config/dynamic/resolvers/schedule-actions-enabled.types.ts
+++ b/src/config/dynamic/resolvers/schedule-actions-enabled.types.ts
@@ -1,6 +1,6 @@
 import type SCHEDULE_ACTIONS_DISABLED_VALUES_CONFIG from './schedule-actions-disabled-values.config';
 
-export type ScheduleActionID = 'pause' | 'resume';
+export type ScheduleActionID = 'pause' | 'resume' | 'delete';
 
 export type ScheduleActionDisabledValue =
   (typeof SCHEDULE_ACTIONS_DISABLED_VALUES_CONFIG)[number];

--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -74,6 +74,7 @@ const resolverSchemas: ResolverSchemas = {
     returnType: z.object({
       pause: scheduleActionsEnabledValueSchema,
       resume: scheduleActionsEnabledValueSchema,
+      delete: scheduleActionsEnabledValueSchema,
     }),
   },
   CRON_LIST_ENABLED: {

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -53,6 +53,7 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
   SCHEDULE_ACTIONS_ENABLED: {
     pause: 'ENABLED',
     resume: 'ENABLED',
+    delete: 'ENABLED',
   },
   SCHEDULES_ENABLED: false,
   WORKFLOWS_LIST_ENABLED: false,

--- a/src/views/schedule-actions/__fixtures__/schedule-actions-config.tsx
+++ b/src/views/schedule-actions/__fixtures__/schedule-actions-config.tsx
@@ -1,4 +1,5 @@
 import {
+  MdDeleteOutline,
   MdOutlineWarningAmber,
   MdPauseCircleOutline,
   MdPlayCircleOutline,
@@ -6,6 +7,7 @@ import {
 import { z } from 'zod';
 
 import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { type DeleteScheduleResponse } from '@/route-handlers/delete-schedule/delete-schedule.types';
 import { type PauseScheduleResponse } from '@/route-handlers/pause-schedule/pause-schedule.types';
 import { type UnpauseScheduleResponse } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
 
@@ -95,7 +97,27 @@ export const mockResumeActionConfig: ScheduleAction<
   renderSuccessMessage: () => 'Mock resume notification',
 };
 
+export const mockDeleteActionConfig: ScheduleAction<DeleteScheduleResponse> = {
+  id: 'delete',
+  label: 'Delete',
+  subtitle: 'Mock delete a schedule',
+  modal: {
+    text: 'Deletes the schedule permanently. In-progress workflow runs are not affected.',
+    withForm: false,
+  },
+  icon: MdDeleteOutline,
+  getRunnableStatus: () => 'RUNNABLE',
+  apiRoute: (params) =>
+    `/api/domains/${params.domain}/${params.cluster}/schedules/${params.scheduleId}`,
+  httpMethod: 'DELETE',
+  renderSuccessMessage: () => 'Schedule deleted.',
+  onSuccess: ({ router, params }) => {
+    router.push(`/domains/${params.domain}/${params.cluster}/schedules`);
+  },
+};
+
 export const mockScheduleActionsConfig = [
   mockPauseActionConfig,
   mockResumeActionConfig,
+  mockDeleteActionConfig,
 ] as const;

--- a/src/views/schedule-actions/__fixtures__/schedule-actions-config.tsx
+++ b/src/views/schedule-actions/__fixtures__/schedule-actions-config.tsx
@@ -102,7 +102,12 @@ export const mockDeleteActionConfig: ScheduleAction<DeleteScheduleResponse> = {
   label: 'Delete',
   subtitle: 'Mock delete a schedule',
   modal: {
-    text: 'Deletes the schedule permanently. In-progress workflow runs are not affected.',
+    banner: {
+      kind: 'warning',
+      icon: MdOutlineWarningAmber,
+      render: () =>
+        'Deletes the schedule permanently. In-progress workflow runs are not affected.',
+    },
     withForm: false,
   },
   icon: MdDeleteOutline,

--- a/src/views/schedule-actions/__tests__/schedule-actions.test.tsx
+++ b/src/views/schedule-actions/__tests__/schedule-actions.test.tsx
@@ -152,6 +152,7 @@ function setup({
             {
               pause: 'ENABLED',
               resume: 'ENABLED',
+              delete: 'ENABLED',
             },
             { status: 200 }
           );

--- a/src/views/schedule-actions/config/schedule-actions.config.ts
+++ b/src/views/schedule-actions/config/schedule-actions.config.ts
@@ -81,10 +81,11 @@ const deleteScheduleActionConfig: ScheduleAction<DeleteScheduleResponse> = {
   label: 'Delete',
   subtitle: 'Delete this schedule permanently',
   modal: {
-    text: 'Deletes the schedule permanently. In-progress workflow runs are not affected.',
-    docsLink: {
-      text: 'Read more about schedules',
-      href: 'https://cadenceworkflow.io/docs/concepts/schedules',
+    banner: {
+      kind: 'warning',
+      icon: MdOutlineWarningAmber,
+      render: () =>
+        'Deletes the schedule permanently. In-progress workflow runs are not affected.',
     },
     withForm: false,
   },

--- a/src/views/schedule-actions/config/schedule-actions.config.ts
+++ b/src/views/schedule-actions/config/schedule-actions.config.ts
@@ -1,9 +1,11 @@
 import {
+  MdDeleteOutline,
   MdOutlineWarningAmber,
   MdPauseCircleOutline,
   MdPlayCircleOutline,
 } from 'react-icons/md';
 
+import { type DeleteScheduleResponse } from '@/route-handlers/delete-schedule/delete-schedule.types';
 import { type PauseScheduleResponse } from '@/route-handlers/pause-schedule/pause-schedule.types';
 import { type UnpauseScheduleResponse } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
 
@@ -74,9 +76,41 @@ const resumeScheduleActionConfig: ScheduleAction<
   renderSuccessMessage: () => 'Schedule has been resumed.',
 };
 
+const deleteScheduleActionConfig: ScheduleAction<DeleteScheduleResponse> = {
+  id: 'delete',
+  label: 'Delete',
+  subtitle: 'Delete this schedule permanently',
+  modal: {
+    text: 'Deletes the schedule permanently. In-progress workflow runs are not affected.',
+    docsLink: {
+      text: 'Read more about schedules',
+      href: 'https://cadenceworkflow.io/docs/concepts/schedules',
+    },
+    withForm: false,
+  },
+  icon: MdDeleteOutline,
+  getRunnableStatus: () => 'RUNNABLE',
+  apiRoute: (params) =>
+    `/api/domains/${encodeURIComponent(params.domain)}/${encodeURIComponent(params.cluster)}/schedules/${encodeURIComponent(params.scheduleId)}`,
+  httpMethod: 'DELETE',
+  renderSuccessMessage: () => 'Schedule deleted.',
+  onSuccess: ({ queryClient, params, router }) => {
+    router.push(
+      `/domains/${encodeURIComponent(params.domain)}/${encodeURIComponent(params.cluster)}/schedules`
+    );
+    queryClient.invalidateQueries({
+      queryKey: [
+        'listSchedules',
+        { domain: params.domain, cluster: params.cluster },
+      ],
+    });
+  },
+};
+
 const scheduleActionsConfig = [
   pauseScheduleActionConfig,
   resumeScheduleActionConfig,
+  deleteScheduleActionConfig,
 ] as const;
 
 /** Discriminated union of configured actions; use at menu/selection boundaries. */

--- a/src/views/schedule-actions/schedule-actions-menu/__tests__/schedule-actions-menu.test.tsx
+++ b/src/views/schedule-actions/schedule-actions-menu/__tests__/schedule-actions-menu.test.tsx
@@ -41,7 +41,7 @@ describe(ScheduleActionsMenu.name, () => {
     });
 
     const menuButtons = screen.getAllByRole('button');
-    expect(menuButtons).toHaveLength(2);
+    expect(menuButtons).toHaveLength(3);
 
     expect(within(menuButtons[0]).getByText('Mock pause')).toBeInTheDocument();
     expect(
@@ -54,6 +54,12 @@ describe(ScheduleActionsMenu.name, () => {
       within(menuButtons[1]).getByText('Mock resume a schedule')
     ).toBeInTheDocument();
     expect(menuButtons[1]).not.toBeDisabled();
+
+    expect(within(menuButtons[2]).getByText('Delete')).toBeInTheDocument();
+    expect(
+      within(menuButtons[2]).getByText('Mock delete a schedule')
+    ).toBeInTheDocument();
+    expect(menuButtons[2]).not.toBeDisabled();
   });
 
   it('disables menu items and shows tooltip if they are disabled from config', async () => {
@@ -61,6 +67,7 @@ describe(ScheduleActionsMenu.name, () => {
       actionsEnabledConfig: {
         pause: 'DISABLED_DEFAULT',
         resume: 'DISABLED_DEFAULT',
+        delete: 'DISABLED_DEFAULT',
       },
     });
 

--- a/src/views/schedule-actions/schedule-actions-modal-content/__tests__/schedule-actions-modal-content.test.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/__tests__/schedule-actions-modal-content.test.tsx
@@ -1,15 +1,12 @@
-import { QueryClient } from '@tanstack/react-query';
 import { HttpResponse } from 'msw';
 
 import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 
 import { mockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
-import { type DeleteScheduleResponse } from '@/route-handlers/delete-schedule/delete-schedule.types';
 import { type PauseScheduleResponse } from '@/route-handlers/pause-schedule/pause-schedule.types';
 import { type UnpauseScheduleResponse } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
 
 import { mockScheduleActionsConfig } from '../../__fixtures__/schedule-actions-config';
-import { type ScheduleAction } from '../../schedule-actions.types';
 import ScheduleActionsModalContent from '../schedule-actions-modal-content';
 
 const mockScheduleParams = {
@@ -28,10 +25,9 @@ jest.mock('baseui/snackbar', () => ({
   }),
 }));
 
-const mockPush = jest.fn();
 jest.mock('next/navigation', () => ({
   ...jest.requireActual('next/navigation'),
-  useRouter: () => ({ push: mockPush }),
+  useRouter: () => ({ push: jest.fn() }),
 }));
 
 describe(ScheduleActionsModalContent.name, () => {
@@ -144,81 +140,13 @@ describe(ScheduleActionsModalContent.name, () => {
       );
     });
   });
-
-  describe('delete action', () => {
-    it('renders confirmation copy with no form inputs', () => {
-      setup({ actionConfig: mockScheduleActionsConfig[2] });
-
-      expect(screen.getAllByText('Delete schedule').length).toBeGreaterThan(0);
-      expect(
-        screen.getByText(
-          'Deletes the schedule permanently. In-progress workflow runs are not affected.'
-        )
-      ).toBeInTheDocument();
-      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-    });
-
-    it('closes without DELETE when Cancel is clicked', async () => {
-      const { user, mockOnClose } = setup({
-        actionConfig: mockScheduleActionsConfig[2],
-      });
-
-      await user.click(screen.getByText('Cancel'));
-      expect(mockOnClose).toHaveBeenCalled();
-      expect(mockEnqueue).not.toHaveBeenCalled();
-    });
-
-    it('DELETEs with no body, navigates to list, and shows snackbar on success', async () => {
-      const { user, mockOnClose, getLatestRequestBody, waitForRequest } = setup(
-        { actionConfig: mockScheduleActionsConfig[2] }
-      );
-
-      await user.click(screen.getByRole('button', { name: 'Delete schedule' }));
-
-      await waitForRequest();
-      expect(getLatestRequestBody()).toBeNull();
-
-      await waitFor(() => {
-        expect(mockPush).toHaveBeenCalledWith(
-          '/domains/mock-domain/mock-cluster/schedules'
-        );
-      });
-      expect(mockEnqueue).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'Schedule deleted.' })
-      );
-      expect(mockOnClose).toHaveBeenCalled();
-    });
-
-    it('does not invalidate describeSchedule after delete', async () => {
-      const invalidateQueriesSpy = jest.spyOn(
-        QueryClient.prototype,
-        'invalidateQueries'
-      );
-
-      const { user, waitForRequest } = setup({
-        actionConfig: mockScheduleActionsConfig[2],
-      });
-
-      await user.click(screen.getByRole('button', { name: 'Delete schedule' }));
-
-      await waitForRequest();
-
-      expect(invalidateQueriesSpy).not.toHaveBeenCalledWith(
-        expect.objectContaining({
-          queryKey: ['describeSchedule', mockScheduleParams],
-        })
-      );
-    });
-  });
 });
 
 function setup({
   error,
-  actionConfig,
   schedule = mockDescribeScheduleResponse,
 }: {
   error?: boolean;
-  actionConfig?: ScheduleAction<any, any, any>;
   schedule?: typeof mockDescribeScheduleResponse;
 }) {
   const user = userEvent.setup();
@@ -231,7 +159,7 @@ function setup({
 
   render(
     <ScheduleActionsModalContent
-      action={actionConfig ?? mockScheduleActionsConfig[0]}
+      action={mockScheduleActionsConfig[0]}
       params={{ ...mockScheduleParams }}
       schedule={schedule}
       onCloseModal={mockOnClose}
@@ -257,18 +185,6 @@ function setup({
             return HttpResponse.json(
               {} satisfies PauseScheduleResponse | UnpauseScheduleResponse
             );
-          },
-        },
-        {
-          path: '/api/domains/:domain/:cluster/schedules/:scheduleId',
-          httpMethod: 'DELETE',
-          mockOnce: false,
-          httpResolver: async ({ request }) => {
-            const text = await request.text();
-            latestRequestBody = text ? JSON.parse(text) : null;
-            requestPromiseResolve(null);
-
-            return HttpResponse.json({} satisfies DeleteScheduleResponse);
           },
         },
       ],

--- a/src/views/schedule-actions/schedule-actions-modal-content/__tests__/schedule-actions-modal-content.test.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/__tests__/schedule-actions-modal-content.test.tsx
@@ -1,8 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
 import { HttpResponse } from 'msw';
 
 import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 
 import { mockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type DeleteScheduleResponse } from '@/route-handlers/delete-schedule/delete-schedule.types';
 import { type PauseScheduleResponse } from '@/route-handlers/pause-schedule/pause-schedule.types';
 import { type UnpauseScheduleResponse } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
 
@@ -142,6 +144,72 @@ describe(ScheduleActionsModalContent.name, () => {
       );
     });
   });
+
+  describe('delete action', () => {
+    it('renders confirmation copy with no form inputs', () => {
+      setup({ actionConfig: mockScheduleActionsConfig[2] });
+
+      expect(screen.getAllByText('Delete schedule').length).toBeGreaterThan(0);
+      expect(
+        screen.getByText(
+          'Deletes the schedule permanently. In-progress workflow runs are not affected.'
+        )
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('closes without DELETE when Cancel is clicked', async () => {
+      const { user, mockOnClose } = setup({
+        actionConfig: mockScheduleActionsConfig[2],
+      });
+
+      await user.click(screen.getByText('Cancel'));
+      expect(mockOnClose).toHaveBeenCalled();
+      expect(mockEnqueue).not.toHaveBeenCalled();
+    });
+
+    it('DELETEs with no body, navigates to list, and shows snackbar on success', async () => {
+      const { user, mockOnClose, getLatestRequestBody, waitForRequest } = setup(
+        { actionConfig: mockScheduleActionsConfig[2] }
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Delete schedule' }));
+
+      await waitForRequest();
+      expect(getLatestRequestBody()).toBeNull();
+
+      await waitFor(() => {
+        expect(mockPush).toHaveBeenCalledWith(
+          '/domains/mock-domain/mock-cluster/schedules'
+        );
+      });
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Schedule deleted.' })
+      );
+      expect(mockOnClose).toHaveBeenCalled();
+    });
+
+    it('does not invalidate describeSchedule after delete', async () => {
+      const invalidateQueriesSpy = jest.spyOn(
+        QueryClient.prototype,
+        'invalidateQueries'
+      );
+
+      const { user, waitForRequest } = setup({
+        actionConfig: mockScheduleActionsConfig[2],
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Delete schedule' }));
+
+      await waitForRequest();
+
+      expect(invalidateQueriesSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ['describeSchedule', mockScheduleParams],
+        })
+      );
+    });
+  });
 });
 
 function setup({
@@ -189,6 +257,18 @@ function setup({
             return HttpResponse.json(
               {} satisfies PauseScheduleResponse | UnpauseScheduleResponse
             );
+          },
+        },
+        {
+          path: '/api/domains/:domain/:cluster/schedules/:scheduleId',
+          httpMethod: 'DELETE',
+          mockOnce: false,
+          httpResolver: async ({ request }) => {
+            const text = await request.text();
+            latestRequestBody = text ? JSON.parse(text) : null;
+            requestPromiseResolve(null);
+
+            return HttpResponse.json({} satisfies DeleteScheduleResponse);
           },
         },
       ],

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.styles.ts
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.styles.ts
@@ -1,5 +1,6 @@
 import { styled as createStyled, type Theme, withStyle } from 'baseui';
 import { type BannerOverrides } from 'baseui/banner';
+import { StyledLink } from 'baseui/link';
 import { ModalBody, ModalFooter, ModalHeader } from 'baseui/modal';
 import { type StyleObject } from 'styletron-react';
 
@@ -27,6 +28,13 @@ export const styled = {
     display: 'flex',
     justifyContent: 'space-between',
   }),
+  Link: withStyle(StyledLink, ({ $theme }: { $theme: Theme }) => ({
+    alignSelf: 'start',
+    ...$theme.typography.LabelSmall,
+    display: 'flex',
+    alignItems: 'center',
+    columnGap: $theme.sizing.scale100,
+  })),
 };
 
 export const overrides = {

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.styles.ts
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.styles.ts
@@ -1,6 +1,5 @@
 import { styled as createStyled, type Theme, withStyle } from 'baseui';
 import { type BannerOverrides } from 'baseui/banner';
-import { StyledLink } from 'baseui/link';
 import { ModalBody, ModalFooter, ModalHeader } from 'baseui/modal';
 import { type StyleObject } from 'styletron-react';
 
@@ -28,13 +27,6 @@ export const styled = {
     display: 'flex',
     justifyContent: 'space-between',
   }),
-  Link: withStyle(StyledLink, ({ $theme }: { $theme: Theme }) => ({
-    alignSelf: 'start',
-    ...$theme.typography.LabelSmall,
-    display: 'flex',
-    alignItems: 'center',
-    columnGap: $theme.sizing.scale100,
-  })),
 };
 
 export const overrides = {

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
@@ -8,7 +8,7 @@ import { ModalButton } from 'baseui/modal';
 import { useSnackbar } from 'baseui/snackbar';
 import { useRouter } from 'next/navigation';
 import { type DefaultValues, type FieldValues, useForm } from 'react-hook-form';
-import { MdCheckCircle, MdErrorOutline, MdOpenInNew } from 'react-icons/md';
+import { MdCheckCircle, MdErrorOutline } from 'react-icons/md';
 
 import request from '@/utils/request';
 import { type RequestError } from '@/utils/request/request-error';
@@ -113,14 +113,6 @@ export default function ScheduleActionsModalContent<
   const Form = action.modal.form;
   const isSubmitDisabled = Object.keys(validationErrors).length > 0;
 
-  const modalText = action.modal.text ? (
-    Array.isArray(action.modal.text) ? (
-      action.modal.text.map((text, index) => <p key={index}>{text}</p>)
-    ) : (
-      <p>{action.modal.text}</p>
-    )
-  ) : null;
-
   const modalBanner = action.modal.banner ? (
     <Banner
       hierarchy={HIERARCHY.low}
@@ -155,17 +147,6 @@ export default function ScheduleActionsModalContent<
             </div>
           )}
           <styled.ModalBodyContent>
-            {modalText}
-            {action.modal.docsLink && (
-              <styled.Link
-                href={action.modal.docsLink.href}
-                target="_blank"
-                rel="noreferrer"
-              >
-                {action.modal.docsLink.text}
-                <MdOpenInNew />
-              </styled.Link>
-            )}
             {action.modal.withForm && Form && (
               <Form
                 fieldErrors={validationErrors}

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
@@ -71,11 +71,13 @@ export default function ScheduleActionsModalContent<
         }).then((res) => res.json() as Result);
       },
       onSuccess: (result, mutationParams) => {
-        queryClient.invalidateQueries({
-          queryKey: ['describeSchedule', params],
-        });
-
-        action.onSuccess?.({ queryClient, params, router });
+        if (!action.onSuccess)
+          queryClient.invalidateQueries({
+            queryKey: ['describeSchedule', params],
+          });
+        else {
+          action.onSuccess?.({ queryClient, params, router });
+        }
 
         onCloseModal();
         enqueue({

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
@@ -8,7 +8,7 @@ import { ModalButton } from 'baseui/modal';
 import { useSnackbar } from 'baseui/snackbar';
 import { useRouter } from 'next/navigation';
 import { type DefaultValues, type FieldValues, useForm } from 'react-hook-form';
-import { MdCheckCircle, MdErrorOutline } from 'react-icons/md';
+import { MdCheckCircle, MdErrorOutline, MdOpenInNew } from 'react-icons/md';
 
 import request from '@/utils/request';
 import { type RequestError } from '@/utils/request/request-error';
@@ -62,15 +62,22 @@ export default function ScheduleActionsModalContent<
         cluster,
         scheduleId,
         submissionData,
-      }: ScheduleActionInput<SubmissionData>) =>
-        request(action.apiRoute({ domain, cluster, scheduleId }), {
-          method: 'POST',
-          body: JSON.stringify(submissionData ?? {}),
-        }).then((res) => res.json() as Result),
+      }: ScheduleActionInput<SubmissionData>) => {
+        const httpMethod = action.httpMethod ?? 'POST';
+
+        return request(action.apiRoute({ domain, cluster, scheduleId }), {
+          method: httpMethod,
+          ...(httpMethod === 'POST'
+            ? { body: JSON.stringify(submissionData ?? {}) }
+            : {}),
+        }).then((res) => res.json() as Result);
+      },
       onSuccess: (result, mutationParams) => {
-        queryClient.invalidateQueries({
-          queryKey: ['describeSchedule', params],
-        });
+        if (action.id !== 'delete') {
+          queryClient.invalidateQueries({
+            queryKey: ['describeSchedule', params],
+          });
+        }
 
         action.onSuccess?.({ queryClient, params, router });
 
@@ -105,6 +112,17 @@ export default function ScheduleActionsModalContent<
     });
   };
 
+  const Form = action.modal.form;
+  const isSubmitDisabled = Object.keys(validationErrors).length > 0;
+
+  const modalText = action.modal.text ? (
+    Array.isArray(action.modal.text) ? (
+      action.modal.text.map((text, index) => <p key={index}>{text}</p>)
+    ) : (
+      <p>{action.modal.text}</p>
+    )
+  ) : null;
+
   const modalBanner = action.modal.banner ? (
     <Banner
       hierarchy={HIERARCHY.low}
@@ -117,9 +135,6 @@ export default function ScheduleActionsModalContent<
       {action.modal.banner.render(schedule)}
     </Banner>
   ) : null;
-
-  const Form = action.modal.form;
-  const isSubmitDisabled = Object.keys(validationErrors).length > 0;
 
   return (
     <>
@@ -142,6 +157,17 @@ export default function ScheduleActionsModalContent<
             </div>
           )}
           <styled.ModalBodyContent>
+            {modalText}
+            {action.modal.docsLink && (
+              <styled.Link
+                href={action.modal.docsLink.href}
+                target="_blank"
+                rel="noreferrer"
+              >
+                {action.modal.docsLink.text}
+                <MdOpenInNew />
+              </styled.Link>
+            )}
             {action.modal.withForm && Form && (
               <Form
                 fieldErrors={validationErrors}

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
@@ -67,17 +67,13 @@ export default function ScheduleActionsModalContent<
 
         return request(action.apiRoute({ domain, cluster, scheduleId }), {
           method: httpMethod,
-          ...(httpMethod === 'POST'
-            ? { body: JSON.stringify(submissionData ?? {}) }
-            : {}),
+          body: JSON.stringify(submissionData ?? {}),
         }).then((res) => res.json() as Result);
       },
       onSuccess: (result, mutationParams) => {
-        if (action.id !== 'delete') {
-          queryClient.invalidateQueries({
-            queryKey: ['describeSchedule', params],
-          });
-        }
+        queryClient.invalidateQueries({
+          queryKey: ['describeSchedule', params],
+        });
 
         action.onSuccess?.({ queryClient, params, router });
 

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -86,7 +86,7 @@ export type ScheduleActionModalForm<FormData, SubmissionData> =
       transformFormDataToSubmission?: undefined;
     };
 
-export type ScheduleActionHttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+export type ScheduleActionHttpMethod = 'POST' | 'PUT' | 'DELETE';
 
 export type ScheduleAction<
   Result,

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -97,11 +97,6 @@ export type ScheduleAction<
   label: string;
   subtitle: string;
   modal: {
-    text?: string | string[];
-    docsLink?: {
-      text: string;
-      href: string;
-    };
     banner?: ScheduleActionModalBanner;
   } & ScheduleActionModalForm<FormData, SubmissionData>;
   icon: ScheduleActionIcon;

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -86,6 +86,8 @@ export type ScheduleActionModalForm<FormData, SubmissionData> =
       transformFormDataToSubmission?: undefined;
     };
 
+export type ScheduleActionHttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+
 export type ScheduleAction<
   Result,
   FormData = undefined,
@@ -107,7 +109,7 @@ export type ScheduleAction<
     schedule: DescribeScheduleResponse
   ) => ScheduleActionRunnableStatus;
   apiRoute: (params: ScheduleActionInputParams) => string;
-  httpMethod?: 'POST' | 'DELETE';
+  httpMethod?: ScheduleActionHttpMethod;
   getConfirmSubmissionData?: () => SubmissionData;
   renderSuccessMessage: (
     props: ScheduleActionSuccessMessageProps<SubmissionData, Result>

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -95,6 +95,11 @@ export type ScheduleAction<
   label: string;
   subtitle: string;
   modal: {
+    text?: string | string[];
+    docsLink?: {
+      text: string;
+      href: string;
+    };
     banner?: ScheduleActionModalBanner;
   } & ScheduleActionModalForm<FormData, SubmissionData>;
   icon: ScheduleActionIcon;
@@ -102,6 +107,7 @@ export type ScheduleAction<
     schedule: DescribeScheduleResponse
   ) => ScheduleActionRunnableStatus;
   apiRoute: (params: ScheduleActionInputParams) => string;
+  httpMethod?: 'POST' | 'DELETE';
   getConfirmSubmissionData?: () => SubmissionData;
   renderSuccessMessage: (
     props: ScheduleActionSuccessMessageProps<SubmissionData, Result>


### PR DESCRIPTION
## Summary

Adds the Delete schedule action to the schedule-actions menu as a confirmation-only modal with a warning banner. On success, the UI navigates to the schedules list and invalidates `listSchedules`.


## Changes

- `schedule-actions.config.ts` — delete action config with warning banner, `DELETE` on the schedule resource, and navigate-on-success handler
- `schedule-actions-modal-content/` — optional `httpMethod` per action; send request body for non-GET methods
- `schedule-actions.types.ts` — `ScheduleActionHttpMethod` type (`POST` | `PUT` | `DELETE`)
- `schedule-actions-enabled` — enable `delete` in dynamic config and resolver schema
- Tests and fixtures for delete action in menu, modal, and orchestrator

## Testing

- `npm run test:unit:browser -- schedule-actions` — 25 tests passed

https://github.com/user-attachments/assets/f14fc08a-1108-4258-8503-d84d5c5f0132

<img width="1211" height="596" alt="Screenshot 2026-07-02 at 02 01 49" src="https://github.com/user-attachments/assets/3d85e452-1fb1-4156-bc8d-1f225727e452" />

## Stack

- **Depends on:** #1427 (merged) — schedule-actions mount on schedule page
- **API:** delete schedule handler merged in #1420
- **Part of:** schedule-actions stack — SLICE-4 (delete UI)

Made with [Cursor](https://cursor.com)