### PR TITLE
feat(page-tabs): gracefully handle config resolver failures

### DIFF
--- a/src/views/domain-page/domain-page-tabs/__tests__/domain-page-tabs.test.tsx
+++ b/src/views/domain-page/domain-page-tabs/__tests__/domain-page-tabs.test.tsx
@@ -5,6 +5,7 @@ import { HttpResponse } from 'msw';
 import { render, screen, userEvent } from '@/test-utils/rtl';
 
 import ErrorBoundary from '@/components/error-boundary/error-boundary';
+import SnackbarProvider from '@/components/snackbar-provider/snackbar-provider';
 import { type GetConfigResponse } from '@/route-handlers/get-config/get-config.types';
 import { mockConsoleError } from '@/test-utils/mock-console-error';
 
@@ -53,6 +54,10 @@ jest.mock('../../config/domain-page-tabs.config', () => ({
     title: 'Schedules',
     artwork: () => <div data-testid="schedules-artwork" />,
   },
+  'batch-actions': {
+    title: 'Batch actions',
+    artwork: () => <div data-testid="batch-actions-artwork" />,
+  },
   failovers: {
     title: 'Failovers',
     artwork: () => <div data-testid="failovers-artwork" />,
@@ -92,7 +97,7 @@ describe(DomainPageTabs.name, () => {
   it('renders Schedules tab when schedules feature is enabled', async () => {
     await setup({ enableSchedules: true });
 
-    expect(screen.getByText('Schedules')).toBeInTheDocument();
+    expect(await screen.findByText('Schedules')).toBeInTheDocument();
   });
 
   it('renders tabs with cron and failover history enabled', async () => {
@@ -102,9 +107,9 @@ describe(DomainPageTabs.name, () => {
     });
 
     expect(screen.getByText('Workflows')).toBeInTheDocument();
-    expect(screen.getByText('Cron')).toBeInTheDocument();
+    expect(await screen.findByText('Cron')).toBeInTheDocument();
     expect(screen.getByText('Metadata')).toBeInTheDocument();
-    expect(screen.getByText('Failovers')).toBeInTheDocument();
+    expect(await screen.findByText('Failovers')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
     expect(screen.getByText('Archival')).toBeInTheDocument();
   });
@@ -153,24 +158,27 @@ describe(DomainPageTabs.name, () => {
     expect(screen.queryByTestId('schedules-artwork')).toBeNull();
   });
 
-  it('handles errors gracefully', async () => {
-    // Mute console.error to avoid polluting the test output.
-    const silencedErrorRegexes = [
-      /RequestError: Failed to fetch config/,
-      /The above error occurred in the <DomainPageTabs> component/,
-    ];
+  it('hides gated tabs and shows an error snackbar when resolvers fail', async () => {
+    // Mute console.error for the failed config requests.
     const { restore: restoreConsoleError } = mockConsoleError({
-      silencedErrorRegexes,
+      silencedErrorRegexes: [/RequestError: Failed to fetch config/],
     });
 
     try {
       await setup({ error: true });
 
+      // Non-gated tabs still render — the tab bar is not torn down.
+      expect(await screen.findByText('Workflows')).toBeInTheDocument();
+      expect(screen.getByText('Metadata')).toBeInTheDocument();
+
+      // Gated tabs are hidden and a single error snackbar lists them.
+      expect(screen.queryByText('Cron')).toBeNull();
       expect(
-        await screen.findByText('Error: Failed to fetch config')
+        await screen.findByText(
+          'Failed to load Failovers, Cron, Batch actions, Schedules tabs'
+        )
       ).toBeInTheDocument();
     } finally {
-      // Be sure to restore the console.error.
       restoreConsoleError();
     }
   });
@@ -209,9 +217,11 @@ async function setup(opts?: {
     <ErrorBoundary
       fallbackRender={({ error }) => <div>Error: {error.message}</div>}
     >
-      <Suspense fallback={<div>Loading...</div>}>
-        <DomainPageTabs />
-      </Suspense>
+      <SnackbarProvider>
+        <Suspense fallback={<div>Loading...</div>}>
+          <DomainPageTabs />
+        </Suspense>
+      </SnackbarProvider>
     </ErrorBoundary>,
     {
       endpointsMocks: [

--- a/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
+++ b/src/views/domain-page/domain-page-tabs/domain-page-tabs.tsx
@@ -5,78 +5,59 @@ import omit from 'lodash/omit';
 import { useRouter, useParams } from 'next/navigation';
 
 import PageTabs from '@/components/page-tabs/page-tabs';
-import useSuspenseConfigValue from '@/hooks/use-config-value/use-suspense-config-value';
 import decodeUrlParams from '@/utils/decode-url-params';
+import useConfigGatedTabs from '@/views/shared/hooks/use-config-gated-tabs';
 
 import domainPageTabsConfig from '../config/domain-page-tabs.config';
 import DomainPageActionsDropdown from '../domain-page-actions-dropdown/domain-page-actions-dropdown';
 import DomainPageHelp from '../domain-page-help/domain-page-help';
 
 import { styled } from './domain-page-tabs.styles';
-import {
-  type DomainPageTabName,
-  type DomainPageTabsParams,
-} from './domain-page-tabs.types';
+import { type DomainPageTabsParams } from './domain-page-tabs.types';
 
 export default function DomainPageTabs() {
   const router = useRouter();
   const params = useParams<DomainPageTabsParams>();
   const decodedParams = decodeUrlParams(params) as DomainPageTabsParams;
 
-  const { data: isFailoverHistoryEnabled } = useSuspenseConfigValue(
-    'FAILOVER_HISTORY_ENABLED'
-  );
+  const configArgs = {
+    domain: decodedParams.domain,
+    cluster: decodedParams.cluster,
+  };
 
-  const { data: isCronListEnabled } = useSuspenseConfigValue(
-    'CRON_LIST_ENABLED',
+  const { tabsToHide } = useConfigGatedTabs([
     {
-      domain: decodedParams.domain,
-      cluster: decodedParams.cluster,
-    }
-  );
-
-  const { data: isBatchActionsEnabled } = useSuspenseConfigValue(
-    'BATCH_ACTIONS_UI_ENABLED',
+      tab: 'failovers',
+      title: domainPageTabsConfig.failovers.title,
+      key: 'FAILOVER_HISTORY_ENABLED',
+    },
     {
-      domain: decodedParams.domain,
-      cluster: decodedParams.cluster,
-    }
-  );
-
-  const { data: isSchedulesEnabled } = useSuspenseConfigValue(
-    'SCHEDULES_ENABLED',
+      tab: 'cron-list',
+      title: domainPageTabsConfig['cron-list'].title,
+      key: 'CRON_LIST_ENABLED',
+      args: configArgs,
+    },
     {
-      domain: decodedParams.domain,
-      cluster: decodedParams.cluster,
-    }
-  );
-
-  const tabsConfig = useMemo<Partial<typeof domainPageTabsConfig>>(() => {
-    const tabsToHide: Array<DomainPageTabName> = [];
-
-    if (!isFailoverHistoryEnabled) {
-      tabsToHide.push('failovers');
-    }
-
-    if (!isCronListEnabled) {
-      tabsToHide.push('cron-list');
-    }
-
-    if (!isBatchActionsEnabled) {
-      tabsToHide.push('batch-actions');
-    }
-
-    if (!isSchedulesEnabled) {
-      tabsToHide.push('schedules');
-    }
-
-    return omit(domainPageTabsConfig, tabsToHide);
-  }, [
-    isFailoverHistoryEnabled,
-    isCronListEnabled,
-    isBatchActionsEnabled,
-    isSchedulesEnabled,
+      tab: 'batch-actions',
+      title: domainPageTabsConfig['batch-actions'].title,
+      key: 'BATCH_ACTIONS_UI_ENABLED',
+      args: configArgs,
+    },
+    {
+      tab: 'schedules',
+      title: domainPageTabsConfig.schedules.title,
+      key: 'SCHEDULES_ENABLED',
+      args: configArgs,
+    },
   ]);
+
+  const tabsToHideKey = tabsToHide.join(',');
+
+  const tabsConfig = useMemo<Partial<typeof domainPageTabsConfig>>(
+    () => omit(domainPageTabsConfig, tabsToHide),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tabsToHideKey]
+  );
 
   const tabList = useMemo(
     () =>

--- a/src/views/shared/hooks/use-config-gated-tabs.styles.ts
+++ b/src/views/shared/hooks/use-config-gated-tabs.styles.ts
@@ -1,0 +1,12 @@
+import { type Theme } from 'baseui';
+import { type SnackbarElementOverrides } from 'baseui/snackbar';
+
+export const overrides = {
+  errorSnackbar: {
+    Root: {
+      style: ({ $theme }: { $theme: Theme }) => ({
+        backgroundColor: $theme.colors.backgroundNegative,
+      }),
+    },
+  } satisfies SnackbarElementOverrides,
+};

--- a/src/views/shared/hooks/use-config-gated-tabs.ts
+++ b/src/views/shared/hooks/use-config-gated-tabs.ts
@@ -68,21 +68,23 @@ export default function useConfigGatedTabs<Name extends string>(
   const failedTitles = gates
     .filter((_, index) => results[index]?.data.status === 'error')
     .map((gate) => gate.title);
-  const failedTitlesKey = failedTitles.join(', ');
+  const failedMessage = failedTitles.length
+    ? `Failed to load ${failedTitles.join(', ')} tab${
+        failedTitles.length > 1 ? 's' : ''
+      }`
+    : '';
 
   useEffect(() => {
-    if (!failedTitlesKey) return;
+    if (!failedMessage) return;
     enqueue(
       {
-        message: `Failed to load ${failedTitlesKey} tab${
-          failedTitlesKey.includes(',') ? 's' : ''
-        }`,
+        message: failedMessage,
         actionMessage: 'Close',
         overrides: overrides.errorSnackbar,
       },
       DURATION.medium
     );
-  }, [failedTitlesKey, enqueue]);
+  }, [failedMessage, enqueue]);
 
   return { tabsToHide };
 }

--- a/src/views/shared/hooks/use-config-gated-tabs.ts
+++ b/src/views/shared/hooks/use-config-gated-tabs.ts
@@ -1,0 +1,88 @@
+'use client';
+import { useEffect } from 'react';
+
+import { useSuspenseQueries } from '@tanstack/react-query';
+import { DURATION, useSnackbar } from 'baseui/snackbar';
+import queryString from 'query-string';
+
+import request from '@/utils/request';
+
+import { overrides } from './use-config-gated-tabs.styles';
+import {
+  type ConfigTabGate,
+  type ConfigGateResult,
+  type UseConfigGatedTabsResult,
+} from './use-config-gated-tabs.types';
+
+/**
+ * Resolves a set of config-gated tabs without failing the whole tab bar when a
+ * resolver errors.
+ *
+ * Suspends only while loading (so the tab bar renders all at once, no pop-in),
+ * but the query resolves to a value-or-error sentinel instead of throwing — a
+ * single failing resolver can't tear down the bar via the error boundary. Tabs
+ * fail closed (hidden unless the resolver returned `true`) and any tab whose
+ * resolver errored is surfaced in one error snackbar.
+ */
+export default function useConfigGatedTabs<Name extends string>(
+  gates: Array<ConfigTabGate<Name>>
+): UseConfigGatedTabsResult<Name> {
+  const { enqueue } = useSnackbar();
+
+  const results = useSuspenseQueries({
+    queries: gates.map((gate) => ({
+      // Distinct key from `dynamic_config` so the sentinel shape does not
+      // clobber the boolean cache read by plain useConfigValue consumers.
+      queryKey: [
+        'dynamic_config_gated',
+        { configKey: gate.key, jsonArgs: gate.args },
+      ] as const,
+      // Resolve (never throw) so suspense only gates on loading, not errors.
+      queryFn: async (): Promise<ConfigGateResult> => {
+        try {
+          const response = await request(
+            queryString.stringifyUrl({
+              url: '/api/config',
+              query: {
+                configKey: gate.key,
+                jsonArgs: JSON.stringify(gate.args),
+              },
+            }),
+            { method: 'GET' }
+          );
+          return { status: 'ok', enabled: (await response.json()) === true };
+        } catch {
+          return { status: 'error' };
+        }
+      },
+    })),
+  });
+
+  const tabsToHide = gates
+    .filter((_, index) => {
+      const result = results[index]?.data;
+      return !(result?.status === 'ok' && result.enabled);
+    })
+    .map((gate) => gate.tab);
+
+  const failedTitles = gates
+    .filter((_, index) => results[index]?.data.status === 'error')
+    .map((gate) => gate.title);
+  const failedTitlesKey = failedTitles.join(', ');
+
+  useEffect(() => {
+    if (!failedTitlesKey) return;
+    enqueue(
+      {
+        message: `Failed to load ${failedTitlesKey} tab${
+          failedTitlesKey.includes(',') ? 's' : ''
+        }`,
+        actionMessage: 'Close',
+        overrides: overrides.errorSnackbar,
+      },
+      DURATION.medium
+    );
+  }, [failedTitlesKey, enqueue]);
+
+  return { tabsToHide };
+}

--- a/src/views/shared/hooks/use-config-gated-tabs.types.ts
+++ b/src/views/shared/hooks/use-config-gated-tabs.types.ts
@@ -1,0 +1,24 @@
+import {
+  type GetConfigArgs,
+  type GetConfigKeys,
+} from '@/route-handlers/get-config/get-config.types';
+
+export type ConfigTabGate<Name extends string> = {
+  /** The tab key controlled by this config gate. */
+  tab: Name;
+  /** Human-readable tab name, used in the failure snackbar. */
+  title: string;
+  /** The dynamic config key whose resolver decides tab visibility. */
+  key: GetConfigKeys;
+  args?: GetConfigArgs<GetConfigKeys>;
+};
+
+/** Value-or-error sentinel so a failed resolver does not throw under suspense. */
+export type ConfigGateResult =
+  | { status: 'ok'; enabled: boolean }
+  | { status: 'error' };
+
+export type UseConfigGatedTabsResult<Name extends string> = {
+  /** Tabs to omit — either disabled or failed to resolve (fail closed). */
+  tabsToHide: Array<Name>;
+};

--- a/src/views/workflow-page/workflow-page-tabs/__tests__/workflow-page-tabs.test.tsx
+++ b/src/views/workflow-page/workflow-page-tabs/__tests__/workflow-page-tabs.test.tsx
@@ -5,6 +5,7 @@ import { HttpResponse } from 'msw';
 import { render, screen, act, fireEvent } from '@/test-utils/rtl';
 
 import ErrorBoundary from '@/components/error-boundary/error-boundary';
+import SnackbarProvider from '@/components/snackbar-provider/snackbar-provider';
 
 import { mockWorkflowPageTabsConfig } from '../../__fixtures__/workflow-page-tabs-config';
 import WorkflowPageTabs from '../workflow-page-tabs';
@@ -66,7 +67,7 @@ describe('WorkflowPageTabs', () => {
     expect(screen.getByText('History')).toBeInTheDocument();
     expect(screen.getByText('Queries')).toBeInTheDocument();
     expect(screen.getByText('Stack Trace')).toBeInTheDocument();
-    expect(screen.getByText('Diagnostics')).toBeInTheDocument();
+    expect(await screen.findByText('Diagnostics')).toBeInTheDocument();
   });
 
   it('renders tabs buttons correctly', async () => {
@@ -93,7 +94,9 @@ describe('WorkflowPageTabs', () => {
     expect(screen.getByTestId('history-artwork')).toBeInTheDocument();
     expect(screen.getByTestId('queries-artwork')).toBeInTheDocument();
     expect(screen.getByTestId('stack-trace-artwork')).toBeInTheDocument();
-    expect(screen.getByTestId('diagnostics-artwork')).toBeInTheDocument();
+    expect(
+      await screen.findByTestId('diagnostics-artwork')
+    ).toBeInTheDocument();
   });
 
   it('reroutes when new tab is clicked', async () => {
@@ -107,11 +110,17 @@ describe('WorkflowPageTabs', () => {
     expect(mockPushFn).toHaveBeenCalledWith('history');
   });
 
-  it('handles errors gracefully', async () => {
+  it('hides the diagnostics tab and shows an error snackbar when the resolver fails', async () => {
     await setup({ error: true });
 
+    // Non-gated tabs still render — the tab bar is not torn down.
+    expect(await screen.findByText('Summary')).toBeInTheDocument();
+    expect(screen.getByText('History')).toBeInTheDocument();
+
+    // Diagnostics is hidden and an error snackbar surfaces the failure.
+    expect(screen.queryByText('Diagnostics')).toBeNull();
     expect(
-      await screen.findByText('Error: Failed to fetch config')
+      await screen.findByText('Failed to load Diagnostics tab')
     ).toBeInTheDocument();
   });
 });
@@ -127,9 +136,11 @@ async function setup({
     <ErrorBoundary
       fallbackRender={({ error }) => <div>Error: {error.message}</div>}
     >
-      <Suspense fallback={<div>Loading...</div>}>
-        <WorkflowPageTabs />
-      </Suspense>
+      <SnackbarProvider>
+        <Suspense fallback={<div>Loading...</div>}>
+          <WorkflowPageTabs />
+        </Suspense>
+      </SnackbarProvider>
     </ErrorBoundary>,
     {
       endpointsMocks: [

--- a/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
+++ b/src/views/workflow-page/workflow-page-tabs/workflow-page-tabs.tsx
@@ -6,8 +6,8 @@ import { useRouter, useParams } from 'next/navigation';
 
 import ErrorBoundary from '@/components/error-boundary/error-boundary';
 import PageTabs from '@/components/page-tabs/page-tabs';
-import useSuspenseConfigValue from '@/hooks/use-config-value/use-suspense-config-value';
 import decodeUrlParams from '@/utils/decode-url-params';
+import useConfigGatedTabs from '@/views/shared/hooks/use-config-gated-tabs';
 import WorkflowActions from '@/views/workflow-actions/workflow-actions';
 
 import workflowPageTabsConfig from '../config/workflow-page-tabs.config';
@@ -21,16 +21,18 @@ export default function WorkflowPageTabs() {
   const params = useParams<WorkflowPageTabsParams>();
   const decodedParams = decodeUrlParams(params) as WorkflowPageTabsParams;
 
-  const { data: isWorkflowDiagnosticsEnabled } = useSuspenseConfigValue(
-    'WORKFLOW_DIAGNOSTICS_ENABLED'
-  );
+  const { tabsToHide } = useConfigGatedTabs([
+    {
+      tab: 'diagnostics',
+      title: workflowPageTabsConfig.diagnostics.title,
+      key: 'WORKFLOW_DIAGNOSTICS_ENABLED',
+    },
+  ]);
 
   const filteredTabsConfig = useMemo(
-    () =>
-      isWorkflowDiagnosticsEnabled
-        ? workflowPageTabsConfig
-        : omit(workflowPageTabsConfig, 'diagnostics'),
-    [isWorkflowDiagnosticsEnabled]
+    () => omit(workflowPageTabsConfig, tabsToHide),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [tabsToHide.join(',')]
   );
 
   const tabList = useMemo(


### PR DESCRIPTION
## Problem

Tab visibility on the domain and workflow pages is gated by dynamic config resolvers, read via `useSuspenseConfigValue`. Because suspense queries throw on error, a single failing resolver propagates to the error boundary and tears down the **entire** tab bar.

In the OSS build every resolver fails closed (`catch { return false }`), so this never happens. But forks override these resolvers with implementations that make API calls and other logic that can genuinely fail — and there the whole navigation disappears.

## Change

Add a shared `useConfigGatedTabs` hook that:

- **Keeps suspense for loading** — the tab bar still renders all at once, no tab pop-in.
- **Never throws on error** — each config read resolves to a value-or-error sentinel via a `queryFn` that catches, so one failing resolver can't tear down the bar. A distinct query key is used so the sentinel shape doesn't clobber the boolean cache read by plain `useConfigValue` consumers.
- **Fails closed** — a tab is hidden unless its resolver returned `true` (matching current OSS semantics); successfully-resolved tabs are unaffected by a sibling's failure.
- **Surfaces failures** — all failed tabs are reported together in a single dismissible error snackbar, e.g. `Failed to load Batch actions, Schedules tabs`.

Wired into the domain and workflow page tab bars. The schedule page tab bar gates nothing by config, so it's untouched.

## Testing

- Updated unit tests for both tab bars to cover graceful degradation (failed tabs hidden + snackbar shown, rest of the bar intact).
<img width="1314" height="798" alt="image" src="https://github.com/user-attachments/assets/ac597bbc-b0a6-4b06-bb8c-1acb98a2aad2" />
