### PR TITLE
feat(batch-actions): guided tour on first visit

### DIFF
--- a/src/views/domain-batch-actions/config/domain-batch-actions-tour.config.ts
+++ b/src/views/domain-batch-actions/config/domain-batch-actions-tour.config.ts
@@ -1,0 +1,63 @@
+import { type Step } from 'react-joyride';
+
+const welcomeStep: Step = {
+  target: 'body',
+  placement: 'center',
+  skipBeacon: true,
+  title: 'Batch actions',
+  content:
+    'Run the same action — like terminate, cancel, reset or signal — across many workflows at once. Here is a quick tour.',
+};
+
+const newActionStep: Step = {
+  target: '[data-tour="batch-new-action-button"]',
+  placement: 'right',
+  skipBeacon: true,
+  title: 'Draft a new batch action',
+  content:
+    'Start here. Create a draft, pick the workflows to target, then choose what to do with them.',
+};
+
+const historyStep: Step = {
+  target: '[data-tour="batch-history"]',
+  placement: 'right',
+  skipBeacon: true,
+  title: 'Track your batch actions',
+  content:
+    'In-progress and past batch actions show up here. Select one to see its status and progress.',
+};
+
+// Overview tour — auto-starts on first visit to the Batch actions tab.
+// When there is no history yet, only the welcome + entry-point steps apply
+// (the history list is not rendered).
+export const domainBatchActionsOverviewTourConfig: Step[] = [
+  welcomeStep,
+  newActionStep,
+  historyStep,
+];
+
+export const domainBatchActionsOverviewEmptyTourConfig: Step[] = [
+  welcomeStep,
+  newActionStep,
+];
+
+// Draft tour — auto-starts when a new draft is opened, where the form and the
+// Select/Query toggle actually exist in the DOM.
+export const domainBatchActionsDraftTourConfig: Step[] = [
+  {
+    target: '[data-tour="batch-draft-params"]',
+    placement: 'bottom',
+    skipBeacon: true,
+    title: 'Set up your action',
+    content:
+      'Give the batch action a description and set an RPS limit to control how fast it runs.',
+  },
+  {
+    target: '[data-tour="batch-input-toggle"]',
+    placement: 'bottom',
+    skipBeacon: true,
+    title: 'Choose your targets',
+    content:
+      'Use Select to pick workflows one by one, or switch to Query to match many workflows with a search query.',
+  },
+];

--- a/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail.tsx
@@ -7,6 +7,7 @@ import { MdDeleteOutline } from 'react-icons/md';
 
 import Button from '@/components/button/button';
 import ErrorPanel from '@/components/error-panel/error-panel';
+import GuidedTourProvider from '@/components/guided-tour/guided-tour-provider/guided-tour-provider';
 import PanelSection from '@/components/panel-section/panel-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import { type BatchActionType } from '@/route-handlers/describe-batch-action/describe-batch-action.types';
@@ -19,6 +20,7 @@ import WorkflowsList from '@/views/shared/workflows-list/workflows-list';
 import domainBatchActionsConfirmationModalConfig from '../config/domain-batch-actions-confirmation-modal.config';
 import domainBatchActionsFiltersConfig from '../config/domain-batch-actions-filters.config';
 import domainBatchActionsNewActionFloatingBarConfig from '../config/domain-batch-actions-new-action-floating-bar.config';
+import { domainBatchActionsDraftTourConfig } from '../config/domain-batch-actions-tour.config';
 import DomainBatchActionsConfirmationModal from '../domain-batch-actions-confirmation-modal/domain-batch-actions-confirmation-modal';
 import DomainBatchActionsNewActionFloatingBar from '../domain-batch-actions-new-action-floating-bar/domain-batch-actions-new-action-floating-bar';
 import DomainBatchActionsNewActionInfoBanner from '../domain-batch-actions-new-action-info-banner/domain-batch-actions-new-action-info-banner';
@@ -118,92 +120,99 @@ export default function DomainBatchActionsNewActionDetail({
         })
       : undefined;
   return (
-    <styled.Container>
-      <styled.Header>
-        <styled.Title>New batch action</styled.Title>
-        <Button
-          kind="secondary"
-          size="compact"
-          overrides={overrides.discardButton}
-          startEnhancer={<MdDeleteOutline />}
-          onClick={onDiscard}
-        >
-          Discard batch action
-        </Button>
-      </styled.Header>
-      <DomainBatchActionsNewActionInfoBanner />
-      <DomainBatchActionsNewActionParams
-        control={control}
-        fieldErrors={errors}
-      />
-      <div>
-        <WorkflowsHeader
-          pageQueryParamsConfig={domainPageQueryParamsConfig}
-          pageFiltersConfig={domainBatchActionsFiltersConfig}
-          inputTypeQueryParamKey="batchInputType"
-          searchQueryParamKey="batchSearch"
-          queryStringQueryParamKey="batchQuery"
-          searchSegmentLabel="Select"
-          refetchQuery={refetchAll}
-          isQueryRunning={isQueryFetching}
-          noSpacing
-        />
-        {queryHint && (
-          <styled.QueryHint $kind={queryHint.kind}>
-            {queryHint.message}
-          </styled.QueryHint>
-        )}
-      </div>
-      {isDataLoading && <SectionLoadingIndicator />}
-      {!isDataLoading && errorPanelProps && (
-        <PanelSection>
-          <ErrorPanel {...errorPanelProps} reset={refetchAll} />
-        </PanelSection>
-      )}
-      {!isDataLoading && !errorPanelProps && (
-        <WorkflowsList
-          workflows={workflows}
-          columns={visibleColumns}
-          error={queryError}
-          hasNextPage={hasNextPage}
-          fetchNextPage={fetchNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          selection={listSelection}
-        />
-      )}
-      {!isDataLoading && !errorPanelProps && !!totalWorkflowCount && (
-        <styled.FloatingBarSlot>
-          <DomainBatchActionsNewActionFloatingBar
-            selectedCount={selectedCount}
-            totalCount={totalWorkflowCount}
-            actions={domainBatchActionsNewActionFloatingBarConfig}
-            onActionClick={handleActionClick}
-            disabled={hasValidationErrors}
+    <GuidedTourProvider
+      tourId="batch-actions-draft"
+      steps={domainBatchActionsDraftTourConfig}
+    >
+      <styled.Container>
+        <styled.Header>
+          <styled.Title>New batch action</styled.Title>
+          <Button
+            kind="secondary"
+            size="compact"
+            overrides={overrides.discardButton}
+            startEnhancer={<MdDeleteOutline />}
+            onClick={onDiscard}
+          >
+            Discard batch action
+          </Button>
+        </styled.Header>
+        <DomainBatchActionsNewActionInfoBanner />
+        <div data-tour="batch-draft-params">
+          <DomainBatchActionsNewActionParams
+            control={control}
+            fieldErrors={errors}
           />
-        </styled.FloatingBarSlot>
-      )}
-      <DomainBatchActionsConfirmationModal
-        config={domainBatchActionsConfirmationModalConfig}
-        actionId={activeAction}
-        selectedCount={selectedCount}
-        isSubmitting={isStartingBatchAction}
-        onClose={() => setActiveAction(null)}
-        onConfirm={(payload) =>
-          handleConfirm({
-            batchType: payload.actionId,
-            // An empty target is blocked before submit (required-query in query
-            // mode, non-empty selection in select mode), so the query is
-            // guaranteed non-empty here.
-            query: getBatchActionQuery(),
-            reason: getValues('description'),
-            rps: getValues('rps'),
-            signalParams:
-              payload.actionId === 'signal'
-                ? payload.submissionData
-                : undefined,
-          })
-        }
-      />
-    </styled.Container>
+        </div>
+        <div data-tour="batch-input-toggle">
+          <WorkflowsHeader
+            pageQueryParamsConfig={domainPageQueryParamsConfig}
+            pageFiltersConfig={domainBatchActionsFiltersConfig}
+            inputTypeQueryParamKey="batchInputType"
+            searchQueryParamKey="batchSearch"
+            queryStringQueryParamKey="batchQuery"
+            searchSegmentLabel="Select"
+            refetchQuery={refetchAll}
+            isQueryRunning={isQueryFetching}
+            noSpacing
+          />
+          {queryHint && (
+            <styled.QueryHint $kind={queryHint.kind}>
+              {queryHint.message}
+            </styled.QueryHint>
+          )}
+        </div>
+        {isDataLoading && <SectionLoadingIndicator />}
+        {!isDataLoading && errorPanelProps && (
+          <PanelSection>
+            <ErrorPanel {...errorPanelProps} reset={refetchAll} />
+          </PanelSection>
+        )}
+        {!isDataLoading && !errorPanelProps && (
+          <WorkflowsList
+            workflows={workflows}
+            columns={visibleColumns}
+            error={queryError}
+            hasNextPage={hasNextPage}
+            fetchNextPage={fetchNextPage}
+            isFetchingNextPage={isFetchingNextPage}
+            selection={listSelection}
+          />
+        )}
+        {!isDataLoading && !errorPanelProps && !!totalWorkflowCount && (
+          <styled.FloatingBarSlot>
+            <DomainBatchActionsNewActionFloatingBar
+              selectedCount={selectedCount}
+              totalCount={totalWorkflowCount}
+              actions={domainBatchActionsNewActionFloatingBarConfig}
+              onActionClick={handleActionClick}
+              disabled={hasValidationErrors}
+            />
+          </styled.FloatingBarSlot>
+        )}
+        <DomainBatchActionsConfirmationModal
+          config={domainBatchActionsConfirmationModalConfig}
+          actionId={activeAction}
+          selectedCount={selectedCount}
+          isSubmitting={isStartingBatchAction}
+          onClose={() => setActiveAction(null)}
+          onConfirm={(payload) =>
+            handleConfirm({
+              batchType: payload.actionId,
+              // An empty target is blocked before submit (required-query in query
+              // mode, non-empty selection in select mode), so the query is
+              // guaranteed non-empty here.
+              query: getBatchActionQuery(),
+              reason: getValues('description'),
+              rps: getValues('rps'),
+              signalParams:
+                payload.actionId === 'signal'
+                  ? payload.submissionData
+                  : undefined,
+            })
+          }
+        />
+      </styled.Container>
+    </GuidedTourProvider>
   );
 }

--- a/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder.tsx
@@ -8,18 +8,20 @@ export default function DomainBatchActionsNoActionsPlaceholder({
   onCreateNew,
 }: Props) {
   return (
-    <ErrorPanel
-      message="No batch actions found"
-      description="Click the button below to get started with Batch Workflow actions. Easily process multiple tasks at once and automate your workflows with just a few simple steps."
-      actions={[
-        {
-          kind: 'callback',
-          label: 'New batch action',
-          buttonKind: 'primary',
-          startEnhancer: MdAdd,
-          onClick: onCreateNew,
-        },
-      ]}
-    />
+    <div data-tour="batch-new-action-button">
+      <ErrorPanel
+        message="No batch actions found"
+        description="Click the button below to get started with Batch Workflow actions. Easily process multiple tasks at once and automate your workflows with just a few simple steps."
+        actions={[
+          {
+            kind: 'callback',
+            label: 'New batch action',
+            buttonKind: 'primary',
+            startEnhancer: MdAdd,
+            onClick: onCreateNew,
+          },
+        ]}
+      />
+    </div>
   );
 }

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
@@ -33,11 +33,12 @@ export default function DomainBatchActionsSidebar({
         startEnhancer={<MdAdd />}
         overrides={overrides.newActionButton}
         onClick={onCreateNew}
+        data-tour="batch-new-action-button"
       >
         New batch action
       </Button>
       <styled.SectionLabel>Batch history</styled.SectionLabel>
-      <styled.List>
+      <styled.List data-tour="batch-history">
         {isDraftOpen && (
           <DomainBatchActionsSidebarItem
             label="Untitled batch action"

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -6,6 +6,7 @@ import { notFound } from 'next/navigation';
 import { MdErrorOutline } from 'react-icons/md';
 
 import ErrorPanel from '@/components/error-panel/error-panel';
+import GuidedTourProvider from '@/components/guided-tour/guided-tour-provider/guided-tour-provider';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import useConfigValue from '@/hooks/use-config-value/use-config-value';
 import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
@@ -15,6 +16,10 @@ import { type DomainPageTabContentProps } from '@/views/domain-page/domain-page-
 import useDescribeBatchAction from '@/views/shared/hooks/use-describe-batch-action/use-describe-batch-action';
 import useListBatchActions from '@/views/shared/hooks/use-list-batch-actions/use-list-batch-actions';
 
+import {
+  domainBatchActionsOverviewEmptyTourConfig,
+  domainBatchActionsOverviewTourConfig,
+} from './config/domain-batch-actions-tour.config';
 import DomainBatchActionDetail from './domain-batch-actions-detail/domain-batch-actions-detail';
 import DomainBatchActionsNewActionDetail from './domain-batch-actions-new-action-detail/domain-batch-actions-new-action-detail';
 import DomainBatchActionsNoActionsPlaceholder from './domain-batch-actions-no-actions-placeholder/domain-batch-actions-no-actions-placeholder';
@@ -167,101 +172,110 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
     setQueryParams(BATCH_DRAFT_RESET_PARAMS);
   };
 
-  if (batchActions.length === 0 && !isDraftOpen) {
-    return (
-      <DomainBatchActionsNoActionsPlaceholder onCreateNew={handleCreateNew} />
-    );
-  }
+  const isEmpty = batchActions.length === 0 && !isDraftOpen;
 
   return (
-    <styled.Container>
-      <styled.Sidebar>
-        <DomainBatchActionsSidebar
-          batchActions={batchActions}
-          isDraftOpen={isDraftOpen}
-          isDraftSelected={isDraftSelected}
-          selectedActionId={selectedActionId}
-          onSelectAction={handleSelectAction}
-          onSelectDraft={handleSelectDraft}
-          onCreateNew={handleCreateNew}
-          fetchNextPage={fetchNextPage}
-          hasNextPage={hasNextPage}
-          isFetchingNextPage={isFetchingNextPage}
-          error={error}
-        />
-      </styled.Sidebar>
-      <styled.DetailPanel>
-        {isDraftSelected && (
-          <DomainBatchActionsNewActionDetail
-            domain={props.domain}
-            cluster={props.cluster}
-            onDiscard={handleDiscard}
-          />
-        )}
-        {!isDraftSelected &&
-          (selectedActionId || isInvalidSelection) &&
-          (isSelectedActionNotFound ? (
-            <ErrorPanel
-              message="Batch action not found"
-              description="This batch action does not exist or is no longer available."
-              actions={[
-                {
-                  kind: 'callback',
-                  label: 'View batch actions',
-                  onClick: handleClearSelectedAction,
-                },
-              ]}
+    <GuidedTourProvider
+      tourId="batch-actions-overview"
+      steps={
+        isEmpty
+          ? domainBatchActionsOverviewEmptyTourConfig
+          : domainBatchActionsOverviewTourConfig
+      }
+    >
+      {isEmpty ? (
+        <DomainBatchActionsNoActionsPlaceholder onCreateNew={handleCreateNew} />
+      ) : (
+        <styled.Container>
+          <styled.Sidebar>
+            <DomainBatchActionsSidebar
+              batchActions={batchActions}
+              isDraftOpen={isDraftOpen}
+              isDraftSelected={isDraftSelected}
+              selectedActionId={selectedActionId}
+              onSelectAction={handleSelectAction}
+              onSelectDraft={handleSelectDraft}
+              onCreateNew={handleCreateNew}
+              fetchNextPage={fetchNextPage}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+              error={error}
             />
-          ) : batchActionDetailError && !batchActionDetail ? (
-            <ErrorPanel
-              error={batchActionDetailError}
-              message="Failed to load batch action details"
-              actions={[
-                {
-                  kind: 'callback',
-                  label: 'Retry',
-                  onClick: () => refetchBatchActionDetail(),
-                },
-              ]}
-            />
-          ) : (
-            selectedWorkflowId &&
-            (isLoadingBatchActionDetail || batchActionDetail) && (
-              <>
-                {batchActionDetailError && batchActionDetail && (
-                  <Banner
-                    hierarchy={HIERARCHY.low}
-                    kind={KIND.warning}
-                    artwork={{ icon: MdErrorOutline }}
-                    action={{
+          </styled.Sidebar>
+          <styled.DetailPanel>
+            {isDraftSelected && (
+              <DomainBatchActionsNewActionDetail
+                domain={props.domain}
+                cluster={props.cluster}
+                onDiscard={handleDiscard}
+              />
+            )}
+            {!isDraftSelected &&
+              (selectedActionId || isInvalidSelection) &&
+              (isSelectedActionNotFound ? (
+                <ErrorPanel
+                  message="Batch action not found"
+                  description="This batch action does not exist or is no longer available."
+                  actions={[
+                    {
+                      kind: 'callback',
+                      label: 'View batch actions',
+                      onClick: handleClearSelectedAction,
+                    },
+                  ]}
+                />
+              ) : batchActionDetailError && !batchActionDetail ? (
+                <ErrorPanel
+                  error={batchActionDetailError}
+                  message="Failed to load batch action details"
+                  actions={[
+                    {
+                      kind: 'callback',
                       label: 'Retry',
                       onClick: () => refetchBatchActionDetail(),
-                    }}
-                  >
-                    Showing last known data. Could not refresh batch action
-                    details.
-                  </Banner>
-                )}
-                {batchActionDetail?.progressError && (
-                  <Banner
-                    hierarchy={HIERARCHY.low}
-                    kind={KIND.warning}
-                    artwork={{ icon: MdErrorOutline }}
-                  >
-                    Could not load batch action progress.
-                  </Banner>
-                )}
-                <DomainBatchActionDetail
-                  domain={props.domain}
-                  cluster={props.cluster}
-                  workflowId={selectedWorkflowId}
-                  batchAction={batchActionDetail}
-                  loading={isLoadingBatchActionDetail}
+                    },
+                  ]}
                 />
-              </>
-            )
-          ))}
-      </styled.DetailPanel>
-    </styled.Container>
+              ) : (
+                selectedWorkflowId &&
+                (isLoadingBatchActionDetail || batchActionDetail) && (
+                  <>
+                    {batchActionDetailError && batchActionDetail && (
+                      <Banner
+                        hierarchy={HIERARCHY.low}
+                        kind={KIND.warning}
+                        artwork={{ icon: MdErrorOutline }}
+                        action={{
+                          label: 'Retry',
+                          onClick: () => refetchBatchActionDetail(),
+                        }}
+                      >
+                        Showing last known data. Could not refresh batch action
+                        details.
+                      </Banner>
+                    )}
+                    {batchActionDetail?.progressError && (
+                      <Banner
+                        hierarchy={HIERARCHY.low}
+                        kind={KIND.warning}
+                        artwork={{ icon: MdErrorOutline }}
+                      >
+                        Could not load batch action progress.
+                      </Banner>
+                    )}
+                    <DomainBatchActionDetail
+                      domain={props.domain}
+                      cluster={props.cluster}
+                      workflowId={selectedWorkflowId}
+                      batchAction={batchActionDetail}
+                      loading={isLoadingBatchActionDetail}
+                    />
+                  </>
+                )
+              ))}
+          </styled.DetailPanel>
+        </styled.Container>
+      )}
+    </GuidedTourProvider>
   );
 }

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -176,12 +176,14 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
 
   return (
     <GuidedTourProvider
-      tourId="batch-actions-overview"
+      tourId={isEmpty ? 'batch-actions-empty' : 'batch-actions-overview'}
       steps={
         isEmpty
           ? domainBatchActionsOverviewEmptyTourConfig
           : domainBatchActionsOverviewTourConfig
       }
+      // Don't auto-start the overview while a draft is open (e.g. deep link)
+      autoStart={!isDraftOpen}
     >
       {isEmpty ? (
         <DomainBatchActionsNoActionsPlaceholder onCreateNew={handleCreateNew} />


### PR DESCRIPTION
## What changed
- On first visit to the batch actions tab a tour will appear
- The tour changes depends if the batch actions list is empty or there are existing items

<img width="1386" height="611" alt="image" src="https://github.com/user-attachments/assets/8912f94e-b6d0-4c0a-bd2b-f9bf1ced68fd" />
<img width="937" height="436" alt="image" src="https://github.com/user-attachments/assets/e5ed45ba-e24e-4094-b26f-3deb4476c4ce" />
<img width="869" height="538" alt="image" src="https://github.com/user-attachments/assets/14359987-5bf4-4dc8-9c0b-dffaa176d0dc" />
-- No existing actions --
<img width="780" height="518" alt="image" src="https://github.com/user-attachments/assets/3a638a07-81f0-4925-b23b-8a00de2a5a43" />
<img width="1438" height="552" alt="image" src="https://github.com/user-attachments/assets/560f8627-acb0-499a-969b-813d32a380fe" />

-- Draft --
<img width="1131" height="537" alt="image" src="https://github.com/user-attachments/assets/b3c0f9f6-6ca1-4d4e-ac85-3c66ab29f720" />
<img width="1151" height="572" alt="image" src="https://github.com/user-attachments/assets/f10815c9-bc0a-450f-954b-d120dda3cbd0" />


