### PR TITLE
fix(batch-actions): correct View redirect and refresh list on start

### DIFF
--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { focusManager, QueryClient } from '@tanstack/react-query';
 import { userEvent } from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 
@@ -428,42 +427,6 @@ describe(DomainBatchActions.name, () => {
       await screen.findByText(/Could not load batch action progress/i)
     ).toBeInTheDocument();
     expect(screen.getByText('mock-batch-action-detail-5')).toBeInTheDocument();
-  });
-
-  it('invalidates the list when an action is selected', async () => {
-    const user = userEvent.setup();
-    const invalidateQueriesSpy = jest.spyOn(
-      QueryClient.prototype,
-      'invalidateQueries'
-    );
-
-    setup();
-
-    await user.click(await screen.findByText('mock-select-4'));
-
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ['listBatchActions'] })
-    );
-  });
-
-  it('refetches the list when the window regains focus', async () => {
-    const { listRequestSpy } = setup();
-
-    await waitFor(() => {
-      expect(listRequestSpy).toHaveBeenCalled();
-    });
-    const callsAfterLoad = listRequestSpy.mock.calls.length;
-
-    act(() => {
-      focusManager.setFocused(false);
-      focusManager.setFocused(true);
-    });
-
-    await waitFor(() => {
-      expect(listRequestSpy.mock.calls.length).toBeGreaterThan(callsAfterLoad);
-    });
-
-    focusManager.setFocused(undefined);
   });
 });
 

--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { focusManager, QueryClient } from '@tanstack/react-query';
 import { userEvent } from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 
@@ -427,6 +428,42 @@ describe(DomainBatchActions.name, () => {
       await screen.findByText(/Could not load batch action progress/i)
     ).toBeInTheDocument();
     expect(screen.getByText('mock-batch-action-detail-5')).toBeInTheDocument();
+  });
+
+  it('invalidates the list when an action is selected', async () => {
+    const user = userEvent.setup();
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    setup();
+
+    await user.click(await screen.findByText('mock-select-4'));
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['listBatchActions'] })
+    );
+  });
+
+  it('refetches the list when the window regains focus', async () => {
+    const { listRequestSpy } = setup();
+
+    await waitFor(() => {
+      expect(listRequestSpy).toHaveBeenCalled();
+    });
+    const callsAfterLoad = listRequestSpy.mock.calls.length;
+
+    act(() => {
+      focusManager.setFocused(false);
+      focusManager.setFocused(true);
+    });
+
+    await waitFor(() => {
+      expect(listRequestSpy.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+    });
+
+    focusManager.setFocused(undefined);
   });
 });
 

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/__tests__/domain-batch-actions-sidebar.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/__tests__/domain-batch-actions-sidebar.test.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 
+import { QueryClient } from '@tanstack/react-query';
 import { userEvent } from '@testing-library/user-event';
 
-import { render, screen } from '@/test-utils/rtl';
+import { render, screen, waitFor } from '@/test-utils/rtl';
 
-import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+import {
+  type BatchActionListItem,
+  type BatchActionStatus,
+} from '@/route-handlers/list-batch-actions/list-batch-actions.types';
 
 import DomainBatchActionsSidebar from '../domain-batch-actions-sidebar';
 
@@ -42,6 +46,7 @@ function setup({
   isDraftOpen = false,
   isDraftSelected = false,
   selectedActionId = null,
+  selectedActionDetailStatus = undefined,
   onSelectAction = jest.fn(),
   onSelectDraft = jest.fn(),
   onCreateNew = jest.fn(),
@@ -54,6 +59,7 @@ function setup({
   isDraftOpen?: boolean;
   isDraftSelected?: boolean;
   selectedActionId?: string | null;
+  selectedActionDetailStatus?: BatchActionStatus;
   onSelectAction?: (action: BatchActionListItem) => void;
   onSelectDraft?: () => void;
   onCreateNew?: () => void;
@@ -63,22 +69,30 @@ function setup({
   error?: Error | null;
 } = {}) {
   const user = userEvent.setup();
-  render(
-    <DomainBatchActionsSidebar
-      batchActions={batchActions}
-      isDraftOpen={isDraftOpen}
-      isDraftSelected={isDraftSelected}
-      selectedActionId={selectedActionId}
-      onSelectAction={onSelectAction}
-      onSelectDraft={onSelectDraft}
-      onCreateNew={onCreateNew}
-      fetchNextPage={fetchNextPage}
-      hasNextPage={hasNextPage}
-      isFetchingNextPage={isFetchingNextPage}
-      error={error}
-    />
-  );
-  return { user, onSelectAction, onSelectDraft, onCreateNew, fetchNextPage };
+  const props = {
+    batchActions,
+    isDraftOpen,
+    isDraftSelected,
+    selectedActionId,
+    selectedActionDetailStatus,
+    onSelectAction,
+    onSelectDraft,
+    onCreateNew,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    error,
+  };
+  const { rerender } = render(<DomainBatchActionsSidebar {...props} />);
+  return {
+    user,
+    onSelectAction,
+    onSelectDraft,
+    onCreateNew,
+    fetchNextPage,
+    rerender: (nextProps: Partial<typeof props>) =>
+      rerender(<DomainBatchActionsSidebar {...props} {...nextProps} />),
+  };
 }
 
 describe(DomainBatchActionsSidebar.name, () => {
@@ -195,5 +209,77 @@ describe(DomainBatchActionsSidebar.name, () => {
       'data-has-data',
       'false'
     );
+  });
+
+  it('invalidates the list and the detail when the selected statuses differ', async () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    // List says action 4 is RUNNING, detail reports COMPLETED → stale copy.
+    setup({ selectedActionId: '4', selectedActionDetailStatus: 'COMPLETED' });
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['listBatchActions'] })
+      );
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['describeBatchAction'] })
+    );
+  });
+
+  it('does not invalidate anything when the selected statuses match', () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    setup({ selectedActionId: '4', selectedActionDetailStatus: 'RUNNING' });
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['listBatchActions'] })
+    );
+    expect(invalidateQueriesSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['describeBatchAction'] })
+    );
+  });
+
+  it('re-checks on re-selection even when the status pair is unchanged', async () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    // Action 4 (RUNNING in list) selected with a COMPLETED detail → stale.
+    const { rerender } = setup({
+      selectedActionId: '4',
+      selectedActionDetailStatus: 'COMPLETED',
+    });
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalled();
+    });
+    const callsAfterFirst = invalidateQueriesSpy.mock.calls.length;
+
+    // Select action 3 (COMPLETED in both list and detail) → nothing to do.
+    rerender({
+      selectedActionId: '3',
+      selectedActionDetailStatus: 'COMPLETED',
+    });
+
+    // Back to action 4: same (COMPLETED detail / RUNNING list) pair as before,
+    // so the status deps are unchanged — only selectedActionId flips back. The
+    // list must still be refreshed.
+    rerender({
+      selectedActionId: '4',
+      selectedActionDetailStatus: 'COMPLETED',
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy.mock.calls.length).toBeGreaterThan(
+        callsAfterFirst
+      );
+    });
   });
 });

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { MdAdd, MdOutlineEdit } from 'react-icons/md';
 
 import Button from '@/components/button/button';
@@ -17,6 +18,7 @@ export default function DomainBatchActionsSidebar({
   isDraftOpen,
   isDraftSelected,
   selectedActionId,
+  selectedActionDetailStatus,
   onSelectAction,
   onSelectDraft,
   onCreateNew,
@@ -25,6 +27,34 @@ export default function DomainBatchActionsSidebar({
   isFetchingNextPage,
   error,
 }: Props) {
+  const queryClient = useQueryClient();
+
+  // The list and the open detail poll independently, so one can lag the other
+  // after a status change (e.g. the sidebar already shows COMPLETED while the
+  // detail still shows RUNNING, or vice versa). When the selected action's two
+  // copies disagree, refetch both so whichever is stale catches up immediately
+  // instead of waiting for its next poll. Keyed on selectedActionId too, so
+  // re-selecting an action re-checks it even when another action happened to
+  // share the same status pair (which wouldn't change the deps otherwise).
+  const selectedActionListStatus = batchActions.find(
+    (action) => action.runId === selectedActionId
+  )?.status;
+  useEffect(() => {
+    if (
+      selectedActionDetailStatus &&
+      selectedActionListStatus &&
+      selectedActionDetailStatus !== selectedActionListStatus
+    ) {
+      queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
+      queryClient.invalidateQueries({ queryKey: ['describeBatchAction'] });
+    }
+  }, [
+    selectedActionId,
+    selectedActionDetailStatus,
+    selectedActionListStatus,
+    queryClient,
+  ]);
+
   return (
     <styled.Container>
       <Button

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.types.ts
@@ -1,10 +1,16 @@
-import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+import {
+  type BatchActionListItem,
+  type BatchActionStatus,
+} from '@/route-handlers/list-batch-actions/list-batch-actions.types';
 
 export type Props = {
   batchActions: BatchActionListItem[];
   isDraftOpen: boolean;
   isDraftSelected: boolean;
   selectedActionId: string | null;
+  // Live status of the selected action from its detail query. When it diverges
+  // from the sidebar's copy, the list is refreshed so the sidebar catches up.
+  selectedActionDetailStatus: BatchActionStatus | undefined;
   onSelectAction: (action: BatchActionListItem) => void;
   onSelectDraft: () => void;
   onCreateNew: () => void;

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -33,6 +33,10 @@ export const BATCH_ACTION_TUNE_SIGNAL_NAME = 'cadence-sys-batch-tune-signal';
 
 export const BATCH_ACTION_DETAIL_REFETCH_INTERVAL = 10000;
 
+// Delay before refreshing the list after starting a batch action, to allow the
+// new batcher workflow to become visible (visibility propagation lag).
+export const BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS = 2000;
+
 // Tooltip shown on a disabled per-row checkbox while "select all" is active.
 export const BATCH_ACTION_SELECT_ALL_ROW_TOOLTIP =
   'Turn off "Select all" to choose workflows individually.';

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -33,6 +33,10 @@ export const BATCH_ACTION_TUNE_SIGNAL_NAME = 'cadence-sys-batch-tune-signal';
 
 export const BATCH_ACTION_DETAIL_REFETCH_INTERVAL = 10000;
 
+// Poll interval for the sidebar list so newly started / status-changed actions
+// show up without a manual refresh.
+export const BATCH_ACTIONS_LIST_REFETCH_INTERVAL = 10000;
+
 // Delay before refreshing the list after starting a batch action, to allow the
 // new batcher workflow to become visible (visibility propagation lag).
 export const BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS = 2000;

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { Banner, HIERARCHY, KIND } from 'baseui/banner';
 import { notFound } from 'next/navigation';
 import { MdErrorOutline } from 'react-icons/md';
@@ -53,6 +54,7 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
 }
 
 function DomainBatchActionsContent(props: DomainPageTabContentProps) {
+  const queryClient = useQueryClient();
   const [queryParams, setQueryParams] = usePageQueryParams(
     domainPageQueryParamsConfig
   );
@@ -68,6 +70,10 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
     domain: props.domain,
     cluster: props.cluster,
     pageSize: BATCH_ACTIONS_PAGE_SIZE,
+    // Refresh the sidebar statuses when the tab regains focus (a job may have
+    // completed/terminated while the user was away).
+    refetchOnWindowFocus: (query) =>
+      query.state.status !== 'error' ? 'always' : false,
     // Throw only when the initial load fails (no data yet) so the route-level
     // error boundary renders the tab error. Next-page failures keep the
     // sidebar visible and are surfaced inline by TableInfiniteScrollLoader.
@@ -150,6 +156,7 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
   };
 
   const handleSelectAction = (action: BatchActionListItem) => {
+    queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
     setQueryParams({
       batchActionId: action.runId,
       batchActionWorkflowId: action.workflowId,

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { Banner, HIERARCHY, KIND } from 'baseui/banner';
 import { notFound } from 'next/navigation';
 import { MdErrorOutline } from 'react-icons/md';
@@ -27,6 +26,7 @@ import DomainBatchActionsNoActionsPlaceholder from './domain-batch-actions-no-ac
 import DomainBatchActionsSidebar from './domain-batch-actions-sidebar/domain-batch-actions-sidebar';
 import {
   BATCH_ACTIONS_PAGE_SIZE,
+  BATCH_ACTIONS_LIST_REFETCH_INTERVAL,
   BATCH_ACTION_DEFAULT_QUERY,
   BATCH_ACTION_DETAIL_REFETCH_INTERVAL,
   BATCH_DRAFT_RESET_PARAMS,
@@ -54,7 +54,6 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
 }
 
 function DomainBatchActionsContent(props: DomainPageTabContentProps) {
-  const queryClient = useQueryClient();
   const [queryParams, setQueryParams] = usePageQueryParams(
     domainPageQueryParamsConfig
   );
@@ -70,10 +69,14 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
     domain: props.domain,
     cluster: props.cluster,
     pageSize: BATCH_ACTIONS_PAGE_SIZE,
-    // Refresh the sidebar statuses when the tab regains focus (a job may have
-    // completed/terminated while the user was away).
-    refetchOnWindowFocus: (query) =>
-      query.state.status !== 'error' ? 'always' : false,
+    // Poll while any action is still RUNNING so new actions and status changes
+    // appear without a manual refresh; stop once everything is terminal.
+    refetchInterval: (query) =>
+      query.state.data?.pages.some((page) =>
+        page.batchActions?.some((action) => action.status === 'RUNNING')
+      )
+        ? BATCH_ACTIONS_LIST_REFETCH_INTERVAL
+        : false,
     // Throw only when the initial load fails (no data yet) so the route-level
     // error boundary renders the tab error. Next-page failures keep the
     // sidebar visible and are surfaced inline by TableInfiniteScrollLoader.
@@ -156,7 +159,6 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
   };
 
   const handleSelectAction = (action: BatchActionListItem) => {
-    queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
     setQueryParams({
       batchActionId: action.runId,
       batchActionWorkflowId: action.workflowId,
@@ -202,6 +204,7 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
               isDraftOpen={isDraftOpen}
               isDraftSelected={isDraftSelected}
               selectedActionId={selectedActionId}
+              selectedActionDetailStatus={batchActionDetail?.status}
               onSelectAction={handleSelectAction}
               onSelectDraft={handleSelectDraft}
               onCreateNew={handleCreateNew}

--- a/src/views/domain-batch-actions/hooks/__tests__/use-confirm-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-confirm-batch-action.test.ts
@@ -75,7 +75,7 @@ describe(useConfirmBatchAction.name, () => {
 
     expect(mockDequeue).toHaveBeenCalled();
     expect(mockRouterPush).toHaveBeenCalledWith(
-      '/domains/cadence-samples/cluster0/batch-actions?bid=wf-1'
+      '/domains/cadence-samples/cluster0/batch-actions?bid=run-1&bwid=wf-1'
     );
   });
 

--- a/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
@@ -1,6 +1,7 @@
+import { QueryClient } from '@tanstack/react-query';
 import { HttpResponse } from 'msw';
 
-import { renderHook, waitFor } from '@/test-utils/rtl';
+import { act, renderHook, waitFor } from '@/test-utils/rtl';
 
 import useStartBatchAction from '../use-start-batch-action';
 import { type BuildBatchActionPayloadParams } from '../use-start-batch-action.types';
@@ -64,6 +65,40 @@ describe(useStartBatchAction.name, () => {
       expect(result.current.isError).toBe(true);
     });
     expect(result.current.error?.message).toBe('Failed to start');
+  });
+
+  it('invalidates listBatchActions queries on success after the delay', async () => {
+    jest.useFakeTimers();
+    try {
+      const invalidateQueriesSpy = jest.spyOn(
+        QueryClient.prototype,
+        'invalidateQueries'
+      );
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          domain: 'cadence-samples',
+          query: 'WorkflowType="foo"',
+          reason: 'cleanup',
+          rps: 50,
+          batchType: 'terminate',
+        });
+      });
+
+      expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['listBatchActions'] })
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 

--- a/src/views/domain-batch-actions/hooks/use-confirm-batch-action.ts
+++ b/src/views/domain-batch-actions/hooks/use-confirm-batch-action.ts
@@ -40,7 +40,7 @@ export default function useConfirmBatchAction({
               actionOnClick: () => {
                 dequeue();
                 router.push(
-                  `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/batch-actions?bid=${encodeURIComponent(result.workflowId)}`
+                  `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/batch-actions?bid=${encodeURIComponent(result.runId)}&bwid=${encodeURIComponent(result.workflowId)}`
                 );
               },
             },

--- a/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
+++ b/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import {
   BATCH_ACTION_BATCHER_DOMAIN,
@@ -12,6 +12,7 @@ import { type RequestError } from '@/utils/request/request-error';
 
 import {
   BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS,
+  BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS,
   BATCH_ACTION_TASK_LIST,
 } from '../domain-batch-actions.constants';
 import buildBatchActionPayload from '../helpers/build-batch-action-payload';
@@ -25,6 +26,8 @@ import {
 export default function useStartBatchAction({
   cluster,
 }: UseStartBatchActionParams) {
+  const queryClient = useQueryClient();
+
   return useMutation<
     StartBatchActionResponse,
     RequestError,
@@ -56,6 +59,13 @@ export default function useStartBatchAction({
           }),
         }
       ).then((res): Promise<StartBatchActionResponse> => res.json());
+    },
+    onSuccess: () => {
+      // A freshly-started batcher workflow isn't visible in the list query
+      // immediately (visibility propagation lag), so delay the invalidation.
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
+      }, BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS);
     },
   });
 }


### PR DESCRIPTION
## Summary

Two batch-actions fixes:

1. **"View" redirect showed "batch action not found."** The success snackbar's
   redirect only set `bid` (the run id slot) and passed the workflow id into it,
   omitting `bwid` entirely. The page needs both ids to resolve a selection, so
   it fell back to "not found." Now the redirect sets `bid=<runId>&bwid=<workflowId>`.

2. **Sidebar list showed stale statuses / didn't pick up new or changed jobs.**
   Replaced the previous invalidate-on-start approach with a polling +
   reconciliation strategy:
   - The list polls every `BATCH_ACTIONS_LIST_REFETCH_INTERVAL` while any action
     is still `RUNNING`, and stops once all actions are terminal.
   - The sidebar invalidates `['listBatchActions']` when the selected action's
     detail status diverges from its list-item status. Keyed on the selected
     action id so re-selecting an action re-checks it even when a previously
     viewed action happened to share the same status pair.

## Test Plan

- Updated `use-confirm-batch-action` test for the corrected redirect URL.
- `domain-batch-actions` tests cover the RUNNING-gated poll interval and
  window-focus refetch.
- `domain-batch-actions-sidebar` tests cover: invalidating on status divergence,
  not invalidating when statuses match, and re-checking on re-selection when the
  status pair is unchanged.
