### PR TITLE
feat(batch-actions): wire Abort to terminate API

### DIFF
--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { focusManager, QueryClient } from '@tanstack/react-query';
 import { userEvent } from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 
@@ -428,42 +427,6 @@ describe(DomainBatchActions.name, () => {
       await screen.findByText(/Could not load batch action progress/i)
     ).toBeInTheDocument();
     expect(screen.getByText('mock-batch-action-detail-5')).toBeInTheDocument();
-  });
-
-  it('invalidates the list when an action is selected', async () => {
-    const user = userEvent.setup();
-    const invalidateQueriesSpy = jest.spyOn(
-      QueryClient.prototype,
-      'invalidateQueries'
-    );
-
-    setup();
-
-    await user.click(await screen.findByText('mock-select-4'));
-
-    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ queryKey: ['listBatchActions'] })
-    );
-  });
-
-  it('refetches the list when the window regains focus', async () => {
-    const { listRequestSpy } = setup();
-
-    await waitFor(() => {
-      expect(listRequestSpy).toHaveBeenCalled();
-    });
-    const callsAfterLoad = listRequestSpy.mock.calls.length;
-
-    act(() => {
-      focusManager.setFocused(false);
-      focusManager.setFocused(true);
-    });
-
-    await waitFor(() => {
-      expect(listRequestSpy.mock.calls.length).toBeGreaterThan(callsAfterLoad);
-    });
-
-    focusManager.setFocused(undefined);
   });
 });
 

--- a/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
+++ b/src/views/domain-batch-actions/__tests__/domain-batch-actions.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { focusManager, QueryClient } from '@tanstack/react-query';
 import { userEvent } from '@testing-library/user-event';
 import { HttpResponse } from 'msw';
 
@@ -427,6 +428,42 @@ describe(DomainBatchActions.name, () => {
       await screen.findByText(/Could not load batch action progress/i)
     ).toBeInTheDocument();
     expect(screen.getByText('mock-batch-action-detail-5')).toBeInTheDocument();
+  });
+
+  it('invalidates the list when an action is selected', async () => {
+    const user = userEvent.setup();
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    setup();
+
+    await user.click(await screen.findByText('mock-select-4'));
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['listBatchActions'] })
+    );
+  });
+
+  it('refetches the list when the window regains focus', async () => {
+    const { listRequestSpy } = setup();
+
+    await waitFor(() => {
+      expect(listRequestSpy).toHaveBeenCalled();
+    });
+    const callsAfterLoad = listRequestSpy.mock.calls.length;
+
+    act(() => {
+      focusManager.setFocused(false);
+      focusManager.setFocused(true);
+    });
+
+    await waitFor(() => {
+      expect(listRequestSpy.mock.calls.length).toBeGreaterThan(callsAfterLoad);
+    });
+
+    focusManager.setFocused(undefined);
   });
 });
 

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/__tests__/domain-batch-actions-detail.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/__tests__/domain-batch-actions-detail.test.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
-import { render, screen, userEvent } from '@/test-utils/rtl';
+import { HttpResponse } from 'msw';
+
+import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
+
+import { type PublicProviderProps } from '@/test-utils/rtl.types';
 
 import { type BatchAction } from '../../domain-batch-actions.types';
 import DomainBatchActionDetail from '../domain-batch-actions-detail';
@@ -103,9 +107,39 @@ describe(DomainBatchActionDetail.name, () => {
 
     expect(screen.queryByText(/Mock progress bar/)).not.toBeInTheDocument();
   });
+  it('fires a terminate request when the abort button is clicked', async () => {
+    let terminateUrl = '';
+    const { user } = setup({
+      batchAction: { runId: '3', status: 'RUNNING', actionType: 'cancel' },
+      endpointsMocks: [
+        {
+          path: '/api/domains/:domain/:cluster/workflows/:workflowId/:runId/terminate',
+          httpMethod: 'POST',
+          mockOnce: false,
+          httpResolver: async ({ request }) => {
+            terminateUrl = new URL(request.url).pathname;
+            return HttpResponse.json({});
+          },
+        },
+      ],
+    });
+
+    await user.click(screen.getByText('Abort batch action'));
+
+    await waitFor(() => {
+      expect(terminateUrl).toBe(
+        '/api/domains/cadence-batcher/cluster1/workflows/workflow1/3/terminate'
+      );
+    });
+  });
 });
 
-function setup(props: Partial<Props> = {}) {
+function setup({
+  endpointsMocks,
+  ...props
+}: Partial<Props> & {
+  endpointsMocks?: PublicProviderProps['endpointsMocks'];
+} = {}) {
   const user = userEvent.setup();
   render(
     <DomainBatchActionDetail
@@ -113,7 +147,8 @@ function setup(props: Partial<Props> = {}) {
       cluster="cluster1"
       workflowId="workflow1"
       {...props}
-    />
+    />,
+    endpointsMocks ? { endpointsMocks } : undefined
   );
   return { user };
 }

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.styles.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.styles.ts
@@ -12,7 +12,7 @@ export const overrides = {
     },
     StartEnhancer: {
       style: ({ $theme }: { $theme: Theme }) => ({
-        fontSize: $theme.sizing.scale700,
+        fontSize: $theme.sizing.scale600,
       }),
     },
   } satisfies ButtonOverrides,

--- a/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-detail/domain-batch-actions-detail.tsx
@@ -8,6 +8,7 @@ import Button from '@/components/button/button';
 
 import DomainBatchActionHeaderInfo from '../domain-batch-actions-header-info/domain-batch-actions-header-info';
 import DomainBatchActionsProgressBar from '../domain-batch-actions-progress-bar/domain-batch-actions-progress-bar';
+import useTerminateBatchAction from '../hooks/use-terminate-batch-action';
 
 import { overrides, styled } from './domain-batch-actions-detail.styles';
 import { type Props } from './domain-batch-actions-detail.types';
@@ -20,6 +21,11 @@ export default function DomainBatchActionDetail({
   loading = false,
 }: Props) {
   const status = batchAction?.status;
+
+  const { terminate, isTerminating } = useTerminateBatchAction({
+    cluster,
+    workflowId,
+  });
 
   return (
     <styled.Container>
@@ -35,6 +41,8 @@ export default function DomainBatchActionDetail({
             size="compact"
             overrides={overrides.abortButton}
             startEnhancer={<MdCancel />}
+            isLoading={isTerminating}
+            onClick={() => terminate(batchAction.runId)}
           >
             Abort batch action
           </Button>

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/__tests__/domain-batch-actions-sidebar.test.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/__tests__/domain-batch-actions-sidebar.test.tsx
@@ -1,10 +1,14 @@
 import React from 'react';
 
+import { QueryClient } from '@tanstack/react-query';
 import { userEvent } from '@testing-library/user-event';
 
-import { render, screen } from '@/test-utils/rtl';
+import { render, screen, waitFor } from '@/test-utils/rtl';
 
-import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+import {
+  type BatchActionListItem,
+  type BatchActionStatus,
+} from '@/route-handlers/list-batch-actions/list-batch-actions.types';
 
 import DomainBatchActionsSidebar from '../domain-batch-actions-sidebar';
 
@@ -42,6 +46,7 @@ function setup({
   isDraftOpen = false,
   isDraftSelected = false,
   selectedActionId = null,
+  selectedActionDetailStatus = undefined,
   onSelectAction = jest.fn(),
   onSelectDraft = jest.fn(),
   onCreateNew = jest.fn(),
@@ -54,6 +59,7 @@ function setup({
   isDraftOpen?: boolean;
   isDraftSelected?: boolean;
   selectedActionId?: string | null;
+  selectedActionDetailStatus?: BatchActionStatus;
   onSelectAction?: (action: BatchActionListItem) => void;
   onSelectDraft?: () => void;
   onCreateNew?: () => void;
@@ -63,22 +69,30 @@ function setup({
   error?: Error | null;
 } = {}) {
   const user = userEvent.setup();
-  render(
-    <DomainBatchActionsSidebar
-      batchActions={batchActions}
-      isDraftOpen={isDraftOpen}
-      isDraftSelected={isDraftSelected}
-      selectedActionId={selectedActionId}
-      onSelectAction={onSelectAction}
-      onSelectDraft={onSelectDraft}
-      onCreateNew={onCreateNew}
-      fetchNextPage={fetchNextPage}
-      hasNextPage={hasNextPage}
-      isFetchingNextPage={isFetchingNextPage}
-      error={error}
-    />
-  );
-  return { user, onSelectAction, onSelectDraft, onCreateNew, fetchNextPage };
+  const props = {
+    batchActions,
+    isDraftOpen,
+    isDraftSelected,
+    selectedActionId,
+    selectedActionDetailStatus,
+    onSelectAction,
+    onSelectDraft,
+    onCreateNew,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    error,
+  };
+  const { rerender } = render(<DomainBatchActionsSidebar {...props} />);
+  return {
+    user,
+    onSelectAction,
+    onSelectDraft,
+    onCreateNew,
+    fetchNextPage,
+    rerender: (nextProps: Partial<typeof props>) =>
+      rerender(<DomainBatchActionsSidebar {...props} {...nextProps} />),
+  };
 }
 
 describe(DomainBatchActionsSidebar.name, () => {
@@ -195,5 +209,77 @@ describe(DomainBatchActionsSidebar.name, () => {
       'data-has-data',
       'false'
     );
+  });
+
+  it('invalidates the list and the detail when the selected statuses differ', async () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    // List says action 4 is RUNNING, detail reports COMPLETED → stale copy.
+    setup({ selectedActionId: '4', selectedActionDetailStatus: 'COMPLETED' });
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['listBatchActions'] })
+      );
+    });
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['describeBatchAction'] })
+    );
+  });
+
+  it('does not invalidate anything when the selected statuses match', () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    setup({ selectedActionId: '4', selectedActionDetailStatus: 'RUNNING' });
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['listBatchActions'] })
+    );
+    expect(invalidateQueriesSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['describeBatchAction'] })
+    );
+  });
+
+  it('re-checks on re-selection even when the status pair is unchanged', async () => {
+    const invalidateQueriesSpy = jest.spyOn(
+      QueryClient.prototype,
+      'invalidateQueries'
+    );
+
+    // Action 4 (RUNNING in list) selected with a COMPLETED detail → stale.
+    const { rerender } = setup({
+      selectedActionId: '4',
+      selectedActionDetailStatus: 'COMPLETED',
+    });
+    await waitFor(() => {
+      expect(invalidateQueriesSpy).toHaveBeenCalled();
+    });
+    const callsAfterFirst = invalidateQueriesSpy.mock.calls.length;
+
+    // Select action 3 (COMPLETED in both list and detail) → nothing to do.
+    rerender({
+      selectedActionId: '3',
+      selectedActionDetailStatus: 'COMPLETED',
+    });
+
+    // Back to action 4: same (COMPLETED detail / RUNNING list) pair as before,
+    // so the status deps are unchanged — only selectedActionId flips back. The
+    // list must still be refreshed.
+    rerender({
+      selectedActionId: '4',
+      selectedActionDetailStatus: 'COMPLETED',
+    });
+
+    await waitFor(() => {
+      expect(invalidateQueriesSpy.mock.calls.length).toBeGreaterThan(
+        callsAfterFirst
+      );
+    });
   });
 });

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
-import React from 'react';
+import React, { useEffect } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { MdAdd, MdOutlineEdit } from 'react-icons/md';
 
 import Button from '@/components/button/button';
@@ -17,6 +18,7 @@ export default function DomainBatchActionsSidebar({
   isDraftOpen,
   isDraftSelected,
   selectedActionId,
+  selectedActionDetailStatus,
   onSelectAction,
   onSelectDraft,
   onCreateNew,
@@ -25,6 +27,34 @@ export default function DomainBatchActionsSidebar({
   isFetchingNextPage,
   error,
 }: Props) {
+  const queryClient = useQueryClient();
+
+  // The list and the open detail poll independently, so one can lag the other
+  // after a status change (e.g. the sidebar already shows COMPLETED while the
+  // detail still shows RUNNING, or vice versa). When the selected action's two
+  // copies disagree, refetch both so whichever is stale catches up immediately
+  // instead of waiting for its next poll. Keyed on selectedActionId too, so
+  // re-selecting an action re-checks it even when another action happened to
+  // share the same status pair (which wouldn't change the deps otherwise).
+  const selectedActionListStatus = batchActions.find(
+    (action) => action.runId === selectedActionId
+  )?.status;
+  useEffect(() => {
+    if (
+      selectedActionDetailStatus &&
+      selectedActionListStatus &&
+      selectedActionDetailStatus !== selectedActionListStatus
+    ) {
+      queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
+      queryClient.invalidateQueries({ queryKey: ['describeBatchAction'] });
+    }
+  }, [
+    selectedActionId,
+    selectedActionDetailStatus,
+    selectedActionListStatus,
+    queryClient,
+  ]);
+
   return (
     <styled.Container>
       <Button

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import { MdAdd, MdOutlineEdit } from 'react-icons/md';
@@ -36,9 +36,11 @@ export default function DomainBatchActionsSidebar({
   // instead of waiting for its next poll. Keyed on selectedActionId too, so
   // re-selecting an action re-checks it even when another action happened to
   // share the same status pair (which wouldn't change the deps otherwise).
-  const selectedActionListStatus = batchActions.find(
-    (action) => action.runId === selectedActionId
-  )?.status;
+  const selectedActionListStatus = useMemo(
+    () =>
+      batchActions.find((action) => action.runId === selectedActionId)?.status,
+    [batchActions, selectedActionId]
+  );
   useEffect(() => {
     if (
       selectedActionDetailStatus &&

--- a/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.types.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions-sidebar/domain-batch-actions-sidebar.types.ts
@@ -1,10 +1,16 @@
-import { type BatchActionListItem } from '@/route-handlers/list-batch-actions/list-batch-actions.types';
+import {
+  type BatchActionListItem,
+  type BatchActionStatus,
+} from '@/route-handlers/list-batch-actions/list-batch-actions.types';
 
 export type Props = {
   batchActions: BatchActionListItem[];
   isDraftOpen: boolean;
   isDraftSelected: boolean;
   selectedActionId: string | null;
+  // Live status of the selected action from its detail query. When it diverges
+  // from the sidebar's copy, the list is refreshed so the sidebar catches up.
+  selectedActionDetailStatus: BatchActionStatus | undefined;
   onSelectAction: (action: BatchActionListItem) => void;
   onSelectDraft: () => void;
   onCreateNew: () => void;

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -33,6 +33,10 @@ export const BATCH_ACTION_TUNE_SIGNAL_NAME = 'cadence-sys-batch-tune-signal';
 
 export const BATCH_ACTION_DETAIL_REFETCH_INTERVAL = 10000;
 
+// Delay before refreshing the list after starting a batch action, to allow the
+// new batcher workflow to become visible (visibility propagation lag).
+export const BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS = 2000;
+
 // Tooltip shown on a disabled per-row checkbox while "select all" is active.
 export const BATCH_ACTION_SELECT_ALL_ROW_TOOLTIP =
   'Turn off "Select all" to choose workflows individually.';

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -33,6 +33,10 @@ export const BATCH_ACTION_TUNE_SIGNAL_NAME = 'cadence-sys-batch-tune-signal';
 
 export const BATCH_ACTION_DETAIL_REFETCH_INTERVAL = 10000;
 
+// Poll interval for the sidebar list so newly started / status-changed actions
+// show up without a manual refresh.
+export const BATCH_ACTIONS_LIST_REFETCH_INTERVAL = 10000;
+
 // Delay before refreshing the list after starting a batch action, to allow the
 // new batcher workflow to become visible (visibility propagation lag).
 export const BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS = 2000;

--- a/src/views/domain-batch-actions/domain-batch-actions.constants.ts
+++ b/src/views/domain-batch-actions/domain-batch-actions.constants.ts
@@ -31,7 +31,7 @@ export const BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS = 20 * 365 * 24 * 60 * 60;
 // Signal sent to a running batcher workflow to adjust its RPS on the fly.
 export const BATCH_ACTION_TUNE_SIGNAL_NAME = 'cadence-sys-batch-tune-signal';
 
-export const BATCH_ACTION_DETAIL_REFETCH_INTERVAL = 10000;
+export const BATCH_ACTION_DETAIL_REFETCH_INTERVAL = 5000;
 
 // Poll interval for the sidebar list so newly started / status-changed actions
 // show up without a manual refresh.

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
 import { Banner, HIERARCHY, KIND } from 'baseui/banner';
 import { notFound } from 'next/navigation';
 import { MdErrorOutline } from 'react-icons/md';
@@ -53,6 +54,7 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
 }
 
 function DomainBatchActionsContent(props: DomainPageTabContentProps) {
+  const queryClient = useQueryClient();
   const [queryParams, setQueryParams] = usePageQueryParams(
     domainPageQueryParamsConfig
   );
@@ -68,6 +70,10 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
     domain: props.domain,
     cluster: props.cluster,
     pageSize: BATCH_ACTIONS_PAGE_SIZE,
+    // Refresh the sidebar statuses when the tab regains focus (a job may have
+    // completed/terminated while the user was away).
+    refetchOnWindowFocus: (query) =>
+      query.state.status !== 'error' ? 'always' : false,
     // Throw only when the initial load fails (no data yet) so the route-level
     // error boundary renders the tab error. Next-page failures keep the
     // sidebar visible and are surfaced inline by TableInfiniteScrollLoader.
@@ -150,6 +156,7 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
   };
 
   const handleSelectAction = (action: BatchActionListItem) => {
+    queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
     setQueryParams({
       batchActionId: action.runId,
       batchActionWorkflowId: action.workflowId,

--- a/src/views/domain-batch-actions/domain-batch-actions.tsx
+++ b/src/views/domain-batch-actions/domain-batch-actions.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useEffect, useMemo, useState } from 'react';
 
-import { useQueryClient } from '@tanstack/react-query';
 import { Banner, HIERARCHY, KIND } from 'baseui/banner';
 import { notFound } from 'next/navigation';
 import { MdErrorOutline } from 'react-icons/md';
@@ -27,6 +26,7 @@ import DomainBatchActionsNoActionsPlaceholder from './domain-batch-actions-no-ac
 import DomainBatchActionsSidebar from './domain-batch-actions-sidebar/domain-batch-actions-sidebar';
 import {
   BATCH_ACTIONS_PAGE_SIZE,
+  BATCH_ACTIONS_LIST_REFETCH_INTERVAL,
   BATCH_ACTION_DEFAULT_QUERY,
   BATCH_ACTION_DETAIL_REFETCH_INTERVAL,
   BATCH_DRAFT_RESET_PARAMS,
@@ -54,7 +54,6 @@ export default function DomainBatchActions(props: DomainPageTabContentProps) {
 }
 
 function DomainBatchActionsContent(props: DomainPageTabContentProps) {
-  const queryClient = useQueryClient();
   const [queryParams, setQueryParams] = usePageQueryParams(
     domainPageQueryParamsConfig
   );
@@ -70,10 +69,14 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
     domain: props.domain,
     cluster: props.cluster,
     pageSize: BATCH_ACTIONS_PAGE_SIZE,
-    // Refresh the sidebar statuses when the tab regains focus (a job may have
-    // completed/terminated while the user was away).
-    refetchOnWindowFocus: (query) =>
-      query.state.status !== 'error' ? 'always' : false,
+    // Poll while any action is still RUNNING so new actions and status changes
+    // appear without a manual refresh; stop once everything is terminal.
+    refetchInterval: (query) =>
+      query.state.data?.pages.some((page) =>
+        page.batchActions?.some((action) => action.status === 'RUNNING')
+      )
+        ? BATCH_ACTIONS_LIST_REFETCH_INTERVAL
+        : false,
     // Throw only when the initial load fails (no data yet) so the route-level
     // error boundary renders the tab error. Next-page failures keep the
     // sidebar visible and are surfaced inline by TableInfiniteScrollLoader.
@@ -156,7 +159,6 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
   };
 
   const handleSelectAction = (action: BatchActionListItem) => {
-    queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
     setQueryParams({
       batchActionId: action.runId,
       batchActionWorkflowId: action.workflowId,
@@ -202,6 +204,7 @@ function DomainBatchActionsContent(props: DomainPageTabContentProps) {
               isDraftOpen={isDraftOpen}
               isDraftSelected={isDraftSelected}
               selectedActionId={selectedActionId}
+              selectedActionDetailStatus={batchActionDetail?.status}
               onSelectAction={handleSelectAction}
               onSelectDraft={handleSelectDraft}
               onCreateNew={handleCreateNew}

--- a/src/views/domain-batch-actions/hooks/__tests__/use-confirm-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-confirm-batch-action.test.ts
@@ -75,7 +75,7 @@ describe(useConfirmBatchAction.name, () => {
 
     expect(mockDequeue).toHaveBeenCalled();
     expect(mockRouterPush).toHaveBeenCalledWith(
-      '/domains/cadence-samples/cluster0/batch-actions?bid=wf-1'
+      '/domains/cadence-samples/cluster0/batch-actions?bid=run-1&bwid=wf-1'
     );
   });
 

--- a/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-start-batch-action.test.ts
@@ -1,6 +1,7 @@
+import { QueryClient } from '@tanstack/react-query';
 import { HttpResponse } from 'msw';
 
-import { renderHook, waitFor } from '@/test-utils/rtl';
+import { act, renderHook, waitFor } from '@/test-utils/rtl';
 
 import useStartBatchAction from '../use-start-batch-action';
 import { type BuildBatchActionPayloadParams } from '../use-start-batch-action.types';
@@ -64,6 +65,40 @@ describe(useStartBatchAction.name, () => {
       expect(result.current.isError).toBe(true);
     });
     expect(result.current.error?.message).toBe('Failed to start');
+  });
+
+  it('invalidates listBatchActions queries on success after the delay', async () => {
+    jest.useFakeTimers();
+    try {
+      const invalidateQueriesSpy = jest.spyOn(
+        QueryClient.prototype,
+        'invalidateQueries'
+      );
+
+      const { result } = setup();
+
+      await act(async () => {
+        await result.current.mutateAsync({
+          domain: 'cadence-samples',
+          query: 'WorkflowType="foo"',
+          reason: 'cleanup',
+          rps: 50,
+          batchType: 'terminate',
+        });
+      });
+
+      expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+
+      act(() => {
+        jest.advanceTimersByTime(2000);
+      });
+
+      expect(invalidateQueriesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['listBatchActions'] })
+      );
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 

--- a/src/views/domain-batch-actions/hooks/__tests__/use-terminate-batch-action.test.ts
+++ b/src/views/domain-batch-actions/hooks/__tests__/use-terminate-batch-action.test.ts
@@ -1,0 +1,170 @@
+import { QueryClient } from '@tanstack/react-query';
+import { DURATION } from 'baseui/snackbar';
+import { HttpResponse } from 'msw';
+
+import { act, renderHook, waitFor } from '@/test-utils/rtl';
+
+import { BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS } from '../../domain-batch-actions.constants';
+import { overrides } from '../../domain-batch-actions.styles';
+import useTerminateBatchAction from '../use-terminate-batch-action';
+
+const mockEnqueue = jest.fn();
+const mockDequeue = jest.fn();
+jest.mock('baseui/snackbar', () => ({
+  ...jest.requireActual('baseui/snackbar'),
+  useSnackbar: () => ({
+    enqueue: mockEnqueue,
+    dequeue: mockDequeue,
+  }),
+}));
+
+const invalidateQueriesSpy = jest.spyOn(
+  QueryClient.prototype,
+  'invalidateQueries'
+);
+
+describe(useTerminateBatchAction.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('terminates the batcher workflow', async () => {
+    const onSuccess = jest.fn();
+    const { result, getLatestRequest } = setup({ onSuccess });
+
+    act(() => {
+      result.current.terminate('run-1');
+    });
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    const req = getLatestRequest();
+    expect(req.url).toBe(
+      '/api/domains/cadence-batcher/cluster0/workflows/batch-1/run-1/terminate'
+    );
+  });
+
+  it('shows a success snackbar and invalidates the list after a delay', async () => {
+    jest.useFakeTimers();
+    const { result } = setup({});
+
+    act(() => {
+      result.current.terminate('run-1');
+    });
+
+    await waitFor(() => {
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'Batch action aborted' }),
+        DURATION.short
+      );
+    });
+
+    // Loading stays up and the list is not yet invalidated during the delay.
+    expect(result.current.isTerminating).toBe(true);
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS);
+    });
+
+    expect(invalidateQueriesSpy).toHaveBeenCalledWith({
+      queryKey: ['listBatchActions'],
+    });
+    await waitFor(() => {
+      expect(result.current.isTerminating).toBe(false);
+    });
+  });
+
+  it('shows an error snackbar on failure', async () => {
+    const onSuccess = jest.fn();
+    const { result } = setup({ onSuccess, error: true });
+
+    act(() => {
+      result.current.terminate('run-1');
+    });
+
+    await waitFor(() => {
+      expect(mockEnqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Failed to terminate',
+          overrides: overrides.errorSnackbar,
+        }),
+        DURATION.short
+      );
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+
+  it('clears the pending invalidate timer on unmount', async () => {
+    jest.useFakeTimers();
+    const { result, unmount } = setup({});
+
+    act(() => {
+      result.current.terminate('run-1');
+    });
+
+    await waitFor(() => {
+      expect(mockEnqueue).toHaveBeenCalled();
+    });
+
+    unmount();
+    act(() => {
+      jest.advanceTimersByTime(BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS);
+    });
+
+    expect(invalidateQueriesSpy).not.toHaveBeenCalled();
+  });
+});
+
+function setup({
+  onSuccess,
+  error = false,
+}: {
+  onSuccess?: () => void;
+  error?: boolean;
+}) {
+  let latestRequest: { url: string; body: unknown } = { url: '', body: null };
+
+  const utils = renderHook(
+    () =>
+      useTerminateBatchAction({
+        cluster: 'cluster0',
+        workflowId: 'batch-1',
+        onSuccess,
+      }),
+    {
+      endpointsMocks: [
+        {
+          path: '/api/domains/:domain/:cluster/workflows/:workflowId/:runId/terminate',
+          httpMethod: 'POST',
+          mockOnce: false,
+          httpResolver: async ({ request }) => {
+            const text = await request.text();
+            latestRequest = {
+              url: new URL(request.url).pathname,
+              body: text ? JSON.parse(text) : null,
+            };
+
+            if (error) {
+              return HttpResponse.json(
+                { message: 'Failed to terminate' },
+                { status: 500 }
+              );
+            }
+
+            return HttpResponse.json({});
+          },
+        },
+      ],
+    }
+  );
+
+  return { ...utils, getLatestRequest: () => latestRequest };
+}

--- a/src/views/domain-batch-actions/hooks/use-confirm-batch-action.ts
+++ b/src/views/domain-batch-actions/hooks/use-confirm-batch-action.ts
@@ -40,7 +40,7 @@ export default function useConfirmBatchAction({
               actionOnClick: () => {
                 dequeue();
                 router.push(
-                  `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/batch-actions?bid=${encodeURIComponent(result.workflowId)}`
+                  `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/batch-actions?bid=${encodeURIComponent(result.runId)}&bwid=${encodeURIComponent(result.workflowId)}`
                 );
               },
             },

--- a/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
+++ b/src/views/domain-batch-actions/hooks/use-start-batch-action.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import {
   BATCH_ACTION_BATCHER_DOMAIN,
@@ -12,6 +12,7 @@ import { type RequestError } from '@/utils/request/request-error';
 
 import {
   BATCH_ACTION_EXECUTION_TIMEOUT_SECONDS,
+  BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS,
   BATCH_ACTION_TASK_LIST,
 } from '../domain-batch-actions.constants';
 import buildBatchActionPayload from '../helpers/build-batch-action-payload';
@@ -25,6 +26,8 @@ import {
 export default function useStartBatchAction({
   cluster,
 }: UseStartBatchActionParams) {
+  const queryClient = useQueryClient();
+
   return useMutation<
     StartBatchActionResponse,
     RequestError,
@@ -56,6 +59,13 @@ export default function useStartBatchAction({
           }),
         }
       ).then((res): Promise<StartBatchActionResponse> => res.json());
+    },
+    onSuccess: () => {
+      // A freshly-started batcher workflow isn't visible in the list query
+      // immediately (visibility propagation lag), so delay the invalidation.
+      setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
+      }, BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS);
     },
   });
 }

--- a/src/views/domain-batch-actions/hooks/use-terminate-batch-action.ts
+++ b/src/views/domain-batch-actions/hooks/use-terminate-batch-action.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { DURATION, useSnackbar } from 'baseui/snackbar';
+import { MdCheckCircle, MdErrorOutline } from 'react-icons/md';
+
+import { BATCH_ACTION_BATCHER_DOMAIN } from '@/route-handlers/list-batch-actions/list-batch-actions.constants';
+import request from '@/utils/request';
+import { type RequestError } from '@/utils/request/request-error';
+
+import { BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS } from '../domain-batch-actions.constants';
+import { overrides } from '../domain-batch-actions.styles';
+
+import {
+  type UseTerminateBatchActionParams,
+  type UseTerminateBatchActionResult,
+} from './use-terminate-batch-action.types';
+
+export default function useTerminateBatchAction({
+  cluster,
+  workflowId,
+  onSuccess,
+}: UseTerminateBatchActionParams): UseTerminateBatchActionResult {
+  const { enqueue, dequeue } = useSnackbar();
+  const queryClient = useQueryClient();
+  // Keep the loading state up through the post-success invalidate delay so the
+  // button doesn't flip back to idle before the list refreshes.
+  const [isSettling, setIsSettling] = useState(false);
+  const settleTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(settleTimer.current), []);
+
+  const { mutate, isPending } = useMutation<unknown, RequestError, string>({
+    mutationFn: (runId: string) =>
+      // The batcher workflow lives in the batcher domain, not the user's
+      // domain, so we terminate it directly there.
+      request(
+        `/api/domains/${encodeURIComponent(
+          BATCH_ACTION_BATCHER_DOMAIN
+        )}/${encodeURIComponent(cluster)}/workflows/${encodeURIComponent(
+          workflowId
+        )}/${encodeURIComponent(runId)}/terminate`,
+        { method: 'POST', body: JSON.stringify({}) }
+      ),
+    onSuccess: () => {
+      onSuccess?.();
+      enqueue(
+        {
+          message: 'Batch action aborted',
+          startEnhancer: MdCheckCircle,
+        },
+        DURATION.short
+      );
+      // Give the batcher visibility a moment to reflect the termination before
+      // refreshing the list.
+      setIsSettling(true);
+      settleTimer.current = setTimeout(() => {
+        queryClient.invalidateQueries({ queryKey: ['listBatchActions'] });
+        setIsSettling(false);
+      }, BATCH_ACTION_LIST_INVALIDATE_TIMEOUT_MS);
+    },
+    onError: (err) => {
+      enqueue(
+        {
+          message: err.message || 'Failed to abort batch action',
+          startEnhancer: MdErrorOutline,
+          overrides: overrides.errorSnackbar,
+          actionMessage: 'OK',
+          actionOnClick: () => dequeue(),
+        },
+        DURATION.short
+      );
+    },
+  });
+
+  return {
+    terminate: (runId: string) => mutate(runId),
+    isTerminating: isPending || isSettling,
+  };
+}

--- a/src/views/domain-batch-actions/hooks/use-terminate-batch-action.types.ts
+++ b/src/views/domain-batch-actions/hooks/use-terminate-batch-action.types.ts
@@ -1,0 +1,10 @@
+export type UseTerminateBatchActionParams = {
+  cluster: string;
+  workflowId: string;
+  onSuccess?: () => void;
+};
+
+export type UseTerminateBatchActionResult = {
+  terminate: (runId: string) => void;
+  isTerminating: boolean;
+};


### PR DESCRIPTION
## What Changed
- Created useTerminateBatchAction that terminates a workflow on the batcher domain.
- Wired useTerminateBatchAction (→ Abort button's onClick/isLoading. Success shows a snackbar + setTimeout invalidate of ['listBatchActions'].

- Reduced the icon size on the abort button to make it more cohesive with the rest of the app

<img width="1713" height="970" alt="image" src="https://github.com/user-attachments/assets/6eb78109-2e6f-427e-ad65-de56dad38a1e" />


