### PR TITLE
feat(domain-page): move schedules tab after workflows

### DIFF
--- a/src/views/domain-page/config/domain-page-tabs.config.ts
+++ b/src/views/domain-page/config/domain-page-tabs.config.ts
@@ -40,6 +40,15 @@ const domainPageTabsConfig: DomainPageTabsConfig<
       actions: [{ kind: 'retry', label: 'Retry' }],
     }),
   },
+  schedules: {
+    title: 'Schedules',
+    artwork: MdCalendarMonth,
+    content: DomainSchedules,
+    getErrorConfig: () => ({
+      message: 'Failed to load schedules',
+      actions: [{ kind: 'retry', label: 'Retry' }],
+    }),
+  },
   'cron-list': {
     title: 'Cron',
     artwork: MdSchedule,
@@ -55,15 +64,6 @@ const domainPageTabsConfig: DomainPageTabsConfig<
     content: DomainPageMetadata,
     getErrorConfig: () => ({
       message: 'Failed to load metadata',
-      actions: [{ kind: 'retry', label: 'Retry' }],
-    }),
-  },
-  schedules: {
-    title: 'Schedules',
-    artwork: MdCalendarMonth,
-    content: DomainSchedules,
-    getErrorConfig: () => ({
-      message: 'Failed to load schedules',
       actions: [{ kind: 'retry', label: 'Retry' }],
     }),
   },

--- a/src/views/domain-page/domain-page-tabs/__tests__/domain-page-tabs.test.tsx
+++ b/src/views/domain-page/domain-page-tabs/__tests__/domain-page-tabs.test.tsx
@@ -41,6 +41,10 @@ jest.mock('../../config/domain-page-tabs.config', () => ({
     title: 'Workflows',
     artwork: () => <div data-testid="workflows-artwork" />,
   },
+  schedules: {
+    title: 'Schedules',
+    artwork: () => <div data-testid="schedules-artwork" />,
+  },
   'cron-list': {
     title: 'Cron',
     artwork: () => <div data-testid="cron-list-artwork" />,
@@ -48,10 +52,6 @@ jest.mock('../../config/domain-page-tabs.config', () => ({
   metadata: {
     title: 'Metadata',
     artwork: () => <div data-testid="metadata-artwork" />,
-  },
-  schedules: {
-    title: 'Schedules',
-    artwork: () => <div data-testid="schedules-artwork" />,
   },
   failovers: {
     title: 'Failovers',


### PR DESCRIPTION
## Summary
- Move the Schedules tab to appear directly after Workflows on the domain page tab bar.
- Keeps execution-related views grouped together for easier navigation.

## Test plan
<img width="1654" height="395" alt="Screenshot 2026-07-17 at 12 47 29" src="https://github.com/user-attachments/assets/7035c3c3-3e89-4eef-be47-05eb19744ab2" />
