### PR TITLE
fix(schedule-page): decode URL params in page layout and details

### DIFF
--- a/src/views/schedule-actions/schedule-actions.tsx
+++ b/src/views/schedule-actions/schedule-actions.tsx
@@ -11,7 +11,7 @@ import { MdArrowDropDown } from 'react-icons/md';
 
 import Button from '@/components/button/button';
 import useConfigValue from '@/hooks/use-config-value/use-config-value';
-import { type SchedulePageLayoutParams } from '@/views/schedule-page/schedule-page.types';
+import { type SchedulePageParams } from '@/views/schedule-page/schedule-page.types';
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
 
 import { type SelectableScheduleAction } from './config/schedule-actions.config';
@@ -21,7 +21,7 @@ import { overrides } from './schedule-actions.styles';
 import { type ErasedScheduleAction } from './schedule-actions.types';
 
 export default function ScheduleActions() {
-  const params = useParams<SchedulePageLayoutParams>();
+  const params = useParams<SchedulePageParams>();
   const scheduleDetailsParams = pick(params, 'cluster', 'scheduleId', 'domain');
 
   const {

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -14,12 +14,16 @@ import ScheduleDetailsPausedBanner from './schedule-details-paused-banner/schedu
 import ScheduleDetailsSection from './schedule-details-section/schedule-details-section';
 import { styled } from './schedule-details.styles';
 import { type Props } from './schedule-details.types';
+import decodeUrlParams from '@/utils/decode-url-params';
+import { SchedulePageTabsParams } from '../schedule-page/schedule-page-tabs/schedule-page-tabs.types';
 
 export default function ScheduleDetails({ params }: Props) {
+  const decodedParams = decodeUrlParams(params) as SchedulePageTabsParams;
+
   const { data, isLoading, isPending } = useDescribeSchedule({
-    domain: params.domain,
-    cluster: params.cluster,
-    scheduleId: params.scheduleId,
+    domain: decodedParams.domain,
+    cluster: decodedParams.cluster,
+    scheduleId: decodedParams.scheduleId,
     throwOnError: true,
   });
 
@@ -46,8 +50,8 @@ export default function ScheduleDetails({ params }: Props) {
             const rows = getRowsFromConfig(
               section.rowsConfig,
               formattedScheduleDetails,
-              params.scheduleId,
-              params.domain,
+              decodedParams.scheduleId,
+              decodedParams.domain,
               params.cluster
             );
             if (!rows.length) {
@@ -64,8 +68,8 @@ export default function ScheduleDetails({ params }: Props) {
           })}
           <ScheduleDetailsBackfillsTable
             backfills={formattedScheduleDetails.info?.ongoingBackfills ?? []}
-            domain={params.domain}
-            cluster={params.cluster}
+            domain={decodedParams.domain}
+            cluster={decodedParams.cluster}
           />
         </styled.DetailsSectionsContainer>
         <styled.JsonPanel>

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -3,7 +3,10 @@ import React from 'react';
 
 import PageSection from '@/components/page-section/page-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+import decodeUrlParams from '@/utils/decode-url-params';
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
+
+import { type SchedulePageTabsParams } from '../schedule-page/schedule-page-tabs/schedule-page-tabs.types';
 
 import scheduleDetailsSectionsConfig from './config/schedule-details-sections.config';
 import { formatScheduleDetails } from './helpers/format-schedule-details';
@@ -14,8 +17,6 @@ import ScheduleDetailsPausedBanner from './schedule-details-paused-banner/schedu
 import ScheduleDetailsSection from './schedule-details-section/schedule-details-section';
 import { styled } from './schedule-details.styles';
 import { type Props } from './schedule-details.types';
-import decodeUrlParams from '@/utils/decode-url-params';
-import { SchedulePageTabsParams } from '../schedule-page/schedule-page-tabs/schedule-page-tabs.types';
 
 export default function ScheduleDetails({ params }: Props) {
   const decodedParams = decodeUrlParams(params) as SchedulePageTabsParams;

--- a/src/views/schedule-details/schedule-details.tsx
+++ b/src/views/schedule-details/schedule-details.tsx
@@ -52,7 +52,7 @@ export default function ScheduleDetails({ params }: Props) {
               formattedScheduleDetails,
               decodedParams.scheduleId,
               decodedParams.domain,
-              params.cluster
+              decodedParams.cluster
             );
             if (!rows.length) {
               return null;

--- a/src/views/schedule-page/schedule-page-header-cluster-selector/schedule-page-header-cluster-selector.types.ts
+++ b/src/views/schedule-page/schedule-page-header-cluster-selector/schedule-page-header-cluster-selector.types.ts
@@ -1,5 +1,5 @@
 import { type SchedulePageTabsParams } from '../schedule-page-tabs/schedule-page-tabs.types';
-import { type SchedulePageLayoutParams } from '../schedule-page.types';
+import { type SchedulePageParams } from '../schedule-page.types';
 
 export type Props = {
   domain: string;
@@ -10,4 +10,4 @@ export type BuildSchedulePageClusterPathParams = Pick<
   SchedulePageTabsParams,
   'domain' | 'scheduleId' | 'scheduleTab'
 > &
-  Pick<SchedulePageLayoutParams, 'cluster'>;
+  Pick<SchedulePageParams, 'cluster'>;

--- a/src/views/schedule-page/schedule-page-header-status-tag/schedule-page-header-status-tag.types.ts
+++ b/src/views/schedule-page/schedule-page-header-status-tag/schedule-page-header-status-tag.types.ts
@@ -1,3 +1,3 @@
-import { type SchedulePageLayoutParams } from '../schedule-page.types';
+import { type SchedulePageParams } from '../schedule-page.types';
 
-export type Props = SchedulePageLayoutParams;
+export type Props = SchedulePageParams;

--- a/src/views/schedule-page/schedule-page.tsx
+++ b/src/views/schedule-page/schedule-page.tsx
@@ -1,14 +1,16 @@
+import decodeUrlParams from '@/utils/decode-url-params';
 import SchedulePageHeader from './schedule-page-header/schedule-page-header';
 import SchedulePageTabs from './schedule-page-tabs/schedule-page-tabs';
-import { type Props } from './schedule-page.types';
+import { SchedulePageParams, type Props } from './schedule-page.types';
 
 export default function SchedulePage({ params, children }: Props) {
+  const decodedParams = decodeUrlParams(params) as SchedulePageParams;
   return (
     <>
       <SchedulePageHeader
-        domain={params.domain}
-        cluster={params.cluster}
-        scheduleId={params.scheduleId}
+        domain={decodedParams.domain}
+        cluster={decodedParams.cluster}
+        scheduleId={decodedParams.scheduleId}
       />
       <SchedulePageTabs />
       {children}

--- a/src/views/schedule-page/schedule-page.tsx
+++ b/src/views/schedule-page/schedule-page.tsx
@@ -1,7 +1,8 @@
 import decodeUrlParams from '@/utils/decode-url-params';
+
 import SchedulePageHeader from './schedule-page-header/schedule-page-header';
 import SchedulePageTabs from './schedule-page-tabs/schedule-page-tabs';
-import { SchedulePageParams, type Props } from './schedule-page.types';
+import { type SchedulePageParams, type Props } from './schedule-page.types';
 
 export default function SchedulePage({ params, children }: Props) {
   const decodedParams = decodeUrlParams(params) as SchedulePageParams;

--- a/src/views/schedule-page/schedule-page.types.ts
+++ b/src/views/schedule-page/schedule-page.types.ts
@@ -1,12 +1,12 @@
 import type React from 'react';
 
-export type SchedulePageLayoutParams = {
+export type SchedulePageParams = {
   domain: string;
   cluster: string;
   scheduleId: string;
 };
 
 export type Props = {
-  params: SchedulePageLayoutParams;
+  params: SchedulePageParams;
   children: React.ReactNode;
 };


### PR DESCRIPTION
## Summary

Schedule page tabs and the cluster selector already decode route params before use. This change applies the same `decodeUrlParams` handling in `SchedulePage` and `ScheduleDetails` so encoded domain and schedule IDs resolve correctly when passed to API hooks and child components.

## Changes

- Decode route params in `SchedulePage` before passing them to `SchedulePageHeader`.
- Decode route params in `ScheduleDetails` before `useDescribeSchedule` and detail section props.
- Rename `SchedulePageLayoutParams` to `SchedulePageParams` for consistency.

## Testing

Before:
<img width="1986" height="1090" alt="Screenshot 2026-07-17 at 13 07 48" src="https://github.com/user-attachments/assets/405bfdd9-cf2a-4f1a-9f5c-34b5b1b5442e" />


After: 
<img width="1785" height="1077" alt="Screenshot 2026-07-17 at 13 05 50" src="https://github.com/user-attachments/assets/f63fae9c-59a6-4426-95fb-5afa6afb3965" />



Made with [Cursor](https://cursor.com)