### PR TITLE
feat(schedule-runs): add runtime cell

### DIFF
--- a/src/views/schedule-page/config/schedule-page-tabs.config.ts
+++ b/src/views/schedule-page/config/schedule-page-tabs.config.ts
@@ -1,8 +1,7 @@
-import { createElement } from 'react';
-
 import { MdCalendarMonth, MdTimeline } from 'react-icons/md';
 
 import ScheduleDetails from '@/views/schedule-details/schedule-details';
+import ScheduleRuns from '@/views/schedule-runs/schedule-runs';
 
 import getSchedulePageTabErrorConfig from '../helpers/get-schedule-page-tab-error-config';
 import { type SchedulePageTabsConfig } from '../schedule-page-tabs/schedule-page-tabs.types';
@@ -17,7 +16,7 @@ const schedulePageTabsConfig: SchedulePageTabsConfig<'details' | 'runs'> = {
   runs: {
     title: 'Runs',
     artwork: MdTimeline,
-    content: () => createElement('div', {}, 'Runs content'),
+    content: ScheduleRuns,
     getErrorConfig: (error, params) =>
       getSchedulePageTabErrorConfig(
         error,

--- a/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import { type Props as FormattedDateProps } from '@/components/formatted-date/formatted-date.types';
+
+import ScheduleRunsRuntimeCell from '../schedule-runs-runtime-cell';
+import { type Props } from '../schedule-runs-runtime-cell.types';
+
+jest.mock('@/components/formatted-date/formatted-date', () =>
+  jest.fn(({ timestampMs }: FormattedDateProps) => <time>{timestampMs}</time>)
+);
+
+describe(ScheduleRunsRuntimeCell.name, () => {
+  it('renders a running execution', () => {
+    setup({ startTime: 100, closeTime: undefined });
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('100').parentElement).toHaveTextContent(
+      /→\s*Running…/
+    );
+  });
+
+  it('renders a closed execution', () => {
+    setup({ startTime: 100, closeTime: 200 });
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+    expect(screen.queryByText('Running…')).not.toBeInTheDocument();
+  });
+
+  it('renders a fallback when the start time is missing', () => {
+    setup({ startTime: 0, closeTime: undefined });
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+});
+
+function setup(props: Props) {
+  render(<ScheduleRunsRuntimeCell {...props} />);
+}

--- a/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
@@ -14,9 +14,7 @@ describe(ScheduleRunsRuntimeCell.name, () => {
     setup({ startTime: 100, closeTime: undefined });
 
     expect(screen.getByText('100')).toBeInTheDocument();
-    expect(screen.getByText('100').parentElement).toHaveTextContent(
-      /→\s*Running…/
-    );
+    expect(screen.getByText('Running…')).toBeInTheDocument();
   });
 
   it('renders a closed execution', () => {
@@ -30,7 +28,7 @@ describe(ScheduleRunsRuntimeCell.name, () => {
   it('renders a fallback when the start time is missing', () => {
     setup({ startTime: 0, closeTime: undefined });
 
-    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
   });
 });
 

--- a/src/views/schedule-runs/__tests__/schedule-runs-status-cell.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-status-cell.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import {
+  WORKFLOW_STATUSES,
+  WORKFLOW_STATUS_NAMES,
+} from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
+import { type Props as WorkflowStatusTagProps } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
+
+import ScheduleRunsStatusCell from '../schedule-runs-status-cell';
+import { type Props } from '../schedule-runs-status-cell.types';
+
+jest.mock('@/views/shared/workflow-status-tag/workflow-status-tag', () =>
+  jest.fn(({ status }: WorkflowStatusTagProps) => (
+    <span>{WORKFLOW_STATUS_NAMES[status]}</span>
+  ))
+);
+
+describe(ScheduleRunsStatusCell.name, () => {
+  it.each(Object.values(WORKFLOW_STATUSES))(
+    'renders accessible text for %s',
+    (status) => {
+      setup(status);
+      expect(
+        screen.getByText(WORKFLOW_STATUS_NAMES[status])
+      ).toBeInTheDocument();
+    }
+  );
+
+  it('renders a safe fallback for an unknown status', () => {
+    setup('UNKNOWN' as Props['status']);
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+});
+
+function setup(status: Props['status']) {
+  render(<ScheduleRunsStatusCell status={status} />);
+}

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -8,6 +8,7 @@ import {
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 
+import { type Props as StatusCellProps } from '../schedule-runs-status-cell.types';
 import ScheduleRunsTable from '../schedule-runs-table';
 import { type Props } from '../schedule-runs-table.types';
 
@@ -21,6 +22,9 @@ jest.mock('@/components/link/link', () =>
   jest.fn(({ href, children }: LinkProps) => (
     <a href={href.toString()}>{children}</a>
   ))
+);
+jest.mock('../schedule-runs-status-cell', () =>
+  jest.fn(({ status }: StatusCellProps) => <>{status}</>)
 );
 jest.mock('@/components/table/table', () =>
   jest.fn(({ data, columns, endMessageProps }: MockTableProps) => (

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -8,6 +8,7 @@ import {
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 
+import { type Props as RuntimeCellProps } from '../schedule-runs-runtime-cell.types';
 import ScheduleRunsTable from '../schedule-runs-table';
 import { type Props } from '../schedule-runs-table.types';
 
@@ -20,6 +21,11 @@ type MockTableProps = {
 jest.mock('@/components/link/link', () =>
   jest.fn(({ href, children }: LinkProps) => (
     <a href={href.toString()}>{children}</a>
+  ))
+);
+jest.mock('../schedule-runs-runtime-cell', () =>
+  jest.fn(({ startTime, closeTime }: RuntimeCellProps) => (
+    <>{`${startTime} → ${closeTime}`}</>
   ))
 );
 jest.mock('@/components/table/table', () =>

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -66,6 +66,16 @@ describe(ScheduleRunsTable.name, () => {
   it('renders the base columns and an encoded run link', () => {
     setup();
 
+    expect(
+      screen.getAllByRole('columnheader').map((column) => column.textContent)
+    ).toEqual([
+      'Workflow ID',
+      'Status',
+      'Run ID',
+      'Backfill',
+      'Schedule time',
+      'Run time (Start/Close)',
+    ]);
     expect(screen.getByRole('link', { name: 'run/id?' })).toHaveAttribute(
       'href',
       '/domains/test-domain/test-cluster/workflows/workflow%2Fid/run%2Fid%3F'

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type Props as LinkProps } from '@/components/link/link.types';
+import {
+  type EndMessageProps,
+  type TableConfig,
+} from '@/components/table/table.types';
+import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+import ScheduleRunsTable from '../schedule-runs-table';
+import { type Props } from '../schedule-runs-table.types';
+
+type MockTableProps = {
+  data: Array<WorkflowListItem>;
+  columns: TableConfig<WorkflowListItem>;
+  endMessageProps: Extract<EndMessageProps, { kind: 'infinite-scroll' }>;
+};
+
+jest.mock('@/components/link/link', () =>
+  jest.fn(({ href, children }: LinkProps) => (
+    <a href={href.toString()}>{children}</a>
+  ))
+);
+jest.mock('@/components/table/table', () =>
+  jest.fn(({ data, columns, endMessageProps }: MockTableProps) => (
+    <table>
+      <thead>
+        <tr>
+          {columns.map(({ id, name }) => (
+            <th key={id}>{name}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row) => (
+          <tr key={row.runID}>
+            {columns.map((column) => (
+              <td key={column.id}>
+                <column.renderCell {...row} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+      <tfoot>
+        <tr>
+          <td>
+            <button onClick={endMessageProps.fetchNextPage}>
+              {endMessageProps.isFetchingNextPage
+                ? 'Loading more'
+                : endMessageProps.error
+                  ? 'Retry'
+                  : endMessageProps.hasNextPage
+                    ? 'Load more'
+                    : 'End of results'}
+            </button>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  ))
+);
+
+describe(ScheduleRunsTable.name, () => {
+  it('renders the base columns and an encoded run link', () => {
+    setup();
+
+    expect(screen.getByRole('link', { name: 'run/id?' })).toHaveAttribute(
+      'href',
+      '/domains/test-domain/test-cluster/workflows/workflow%2Fid/run%2Fid%3F'
+    );
+    ['2026-07-19T10:00:00Z', '100 → 200'].forEach((value) =>
+      expect(screen.getByText(value)).toBeInTheDocument()
+    );
+  });
+
+  it('loads the next page while retaining existing rows', async () => {
+    const user = userEvent.setup();
+    const { fetchNextPage } = setup();
+
+    await user.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('workflow/id')).toBeInTheDocument();
+  });
+
+  it('renders distinct loading, error, and end states', () => {
+    const { rerender, props } = setup({ isFetchingNextPage: true });
+    expect(screen.getByRole('button', { name: 'Loading more' })).toBeVisible();
+
+    rerender(
+      <ScheduleRunsTable
+        {...props}
+        isFetchingNextPage={false}
+        error={new Error('Request failed')}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeVisible();
+
+    rerender(
+      <ScheduleRunsTable
+        {...props}
+        isFetchingNextPage={false}
+        hasNextPage={false}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'End of results' })
+    ).toBeVisible();
+  });
+});
+
+function setup(overrides: Partial<Props> = {}) {
+  const fetchNextPage = jest.fn();
+  const props: Props = {
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+    workflows: [
+      getMockWorkflowListItem({
+        workflowID: 'workflow/id',
+        runID: 'run/id?',
+        startTime: 100,
+        closeTime: 200,
+        status: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
+        searchAttributes: {
+          CadenceScheduleIsBackfill: { data: btoa('true') },
+          CadenceScheduleTime: { data: btoa('"2026-07-19T10:00:00Z"') },
+        },
+      }),
+    ],
+    error: null,
+    hasNextPage: true,
+    fetchNextPage,
+    isFetchingNextPage: false,
+    ...overrides,
+  };
+  const renderResult = render(<ScheduleRunsTable {...props} />);
+  return { ...renderResult, props, fetchNextPage };
+}

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -30,7 +30,11 @@ jest.mock('@/components/error-panel/error-panel', () =>
 );
 jest.mock('../schedule-runs-table', () =>
   jest.fn(({ workflows }: ScheduleRunsTableProps) => (
-    <div>{workflows.map(({ workflowID }) => workflowID).join(',')}</div>
+    <div>
+      {workflows.length
+        ? workflows.map(({ workflowID }) => workflowID).join(',')
+        : 'No results'}
+    </div>
   ))
 );
 describe(ScheduleRuns.name, () => {
@@ -65,6 +69,7 @@ describe(ScheduleRuns.name, () => {
     setup({
       hookResult: {
         data: undefined,
+        workflows: [],
         error: new RequestError('Request failed', '/workflows', 500),
       },
     });
@@ -83,7 +88,7 @@ describe(ScheduleRuns.name, () => {
       },
     });
 
-    expect(screen.getByText('No schedule runs found')).toBeInTheDocument();
+    expect(screen.getByText('No results')).toBeInTheDocument();
   });
 });
 

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -7,6 +7,7 @@ import { RequestError } from '@/utils/request/request-error';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 
 import ScheduleRuns from '../schedule-runs';
+import { type Props as ScheduleRunsTableProps } from '../schedule-runs-table.types';
 
 const mockRefetch = jest.fn();
 const mockUseListWorkflows = jest.mocked(useListWorkflows);
@@ -27,12 +28,17 @@ jest.mock('@/components/error-panel/error-panel', () =>
     </div>
   ))
 );
+jest.mock('../schedule-runs-table', () =>
+  jest.fn(({ workflows }: ScheduleRunsTableProps) => (
+    <div>{workflows.map(({ workflowID }) => workflowID).join(',')}</div>
+  ))
+);
 describe(ScheduleRuns.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('queries the schedule and renders only the first page as JSON', () => {
+  it('queries the schedule and renders all loaded pages in the table', () => {
     const scheduleId = String.raw`schedule"\id`;
     setup({ scheduleId });
 
@@ -45,7 +51,7 @@ describe(ScheduleRuns.name, () => {
       query: String.raw`CadenceScheduleID = "schedule\"\\id"`,
     });
     expect(screen.getByText(/first-page-workflow/)).toBeInTheDocument();
-    expect(screen.queryByText(/second-page-workflow/)).not.toBeInTheDocument();
+    expect(screen.getByText(/second-page-workflow/)).toBeInTheDocument();
   });
 
   it('renders the initial loading state', () => {
@@ -73,10 +79,7 @@ describe(ScheduleRuns.name, () => {
   it('renders an empty state when the first page has no runs', () => {
     setup({
       hookResult: {
-        data: {
-          pages: [{ workflows: [], nextPage: '' }],
-          pageParams: [undefined],
-        },
+        workflows: [],
       },
     });
 
@@ -93,27 +96,31 @@ function setup({
   scheduleId?: string;
   hookResult?: Partial<HookResult>;
 } = {}) {
+  const workflows = [
+    getMockWorkflowListItem({ workflowID: 'first-page-workflow' }),
+    getMockWorkflowListItem({ workflowID: 'second-page-workflow' }),
+  ];
   mockUseListWorkflows.mockReturnValue({
     data: {
       pages: [
         {
-          workflows: [
-            getMockWorkflowListItem({ workflowID: 'first-page-workflow' }),
-          ],
+          workflows: [workflows[0]],
           nextPage: 'next-page',
         },
         {
-          workflows: [
-            getMockWorkflowListItem({ workflowID: 'second-page-workflow' }),
-          ],
+          workflows: [workflows[1]],
           nextPage: '',
         },
       ],
       pageParams: [undefined, 'next-page'],
     },
+    workflows,
     error: null,
     isLoading: false,
     refetch: mockRefetch,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+    isFetchingNextPage: false,
     ...hookResult,
   } as unknown as HookResult);
 

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type Props as ErrorPanelProps } from '@/components/error-panel/error-panel.types';
+import { type Props as PanelSectionProps } from '@/components/panel-section/panel-section.types';
+import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
+import { RequestError } from '@/utils/request/request-error';
+import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
+
+import ScheduleRuns from '../schedule-runs';
+
+const mockRefetch = jest.fn();
+const mockUseListWorkflows = jest.mocked(useListWorkflows);
+
+jest.mock('@/views/shared/hooks/use-list-workflows');
+jest.mock(
+  '@/components/section-loading-indicator/section-loading-indicator',
+  () => jest.fn(() => <div>Loading schedule runs</div>)
+);
+jest.mock('@/components/panel-section/panel-section', () =>
+  jest.fn(({ children }: PanelSectionProps) => <section>{children}</section>)
+);
+jest.mock('@/components/error-panel/error-panel', () =>
+  jest.fn(({ message, reset }: ErrorPanelProps) => (
+    <div>
+      {message}
+      {reset && <button onClick={reset}>Retry</button>}
+    </div>
+  ))
+);
+describe(ScheduleRuns.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries the schedule and renders only the first page as JSON', () => {
+    const scheduleId = String.raw`schedule"\id`;
+    setup({ scheduleId });
+
+    expect(mockUseListWorkflows).toHaveBeenCalledWith({
+      domain: 'test-domain',
+      cluster: 'test-cluster',
+      listType: 'default',
+      pageSize: 20,
+      inputType: 'query',
+      query: String.raw`CadenceScheduleID = "schedule\"\\id"`,
+    });
+    expect(screen.getByText(/first-page-workflow/)).toBeInTheDocument();
+    expect(screen.queryByText(/second-page-workflow/)).not.toBeInTheDocument();
+  });
+
+  it('renders the initial loading state', () => {
+    setup({ hookResult: { data: undefined, isLoading: true } });
+
+    expect(screen.getByText('Loading schedule runs')).toBeInTheDocument();
+  });
+
+  it('renders a retryable request error', async () => {
+    const user = userEvent.setup();
+    setup({
+      hookResult: {
+        data: undefined,
+        error: new RequestError('Request failed', '/workflows', 500),
+      },
+    });
+
+    expect(
+      screen.getByText('Failed to load schedule runs')
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an empty state when the first page has no runs', () => {
+    setup({
+      hookResult: {
+        data: {
+          pages: [{ workflows: [], nextPage: '' }],
+          pageParams: [undefined],
+        },
+      },
+    });
+
+    expect(screen.getByText('No schedule runs found')).toBeInTheDocument();
+  });
+});
+
+type HookResult = ReturnType<typeof useListWorkflows>;
+
+function setup({
+  scheduleId = 'test-schedule',
+  hookResult = {},
+}: {
+  scheduleId?: string;
+  hookResult?: Partial<HookResult>;
+} = {}) {
+  mockUseListWorkflows.mockReturnValue({
+    data: {
+      pages: [
+        {
+          workflows: [
+            getMockWorkflowListItem({ workflowID: 'first-page-workflow' }),
+          ],
+          nextPage: 'next-page',
+        },
+        {
+          workflows: [
+            getMockWorkflowListItem({ workflowID: 'second-page-workflow' }),
+          ],
+          nextPage: '',
+        },
+      ],
+      pageParams: [undefined, 'next-page'],
+    },
+    error: null,
+    isLoading: false,
+    refetch: mockRefetch,
+    ...hookResult,
+  } as unknown as HookResult);
+
+  render(
+    <ScheduleRuns
+      params={{
+        domain: 'test-domain',
+        cluster: 'test-cluster',
+        scheduleId,
+        scheduleTab: 'runs',
+      }}
+    />
+  );
+}

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -11,6 +11,18 @@ export default function getScheduleRunsTableConfig(
 ): TableConfig<WorkflowListItem> {
   return [
     {
+      name: 'Workflow ID',
+      id: 'WorkflowID',
+      renderCell: (row: WorkflowListItem) => row.workflowID,
+      width: '20%',
+    },
+    {
+      name: 'Status',
+      id: 'CloseStatus',
+      renderCell: (row: WorkflowListItem) => row.status,
+      width: '10%',
+    },
+    {
       name: 'Run ID',
       id: 'RunID',
       renderCell: (row: WorkflowListItem) =>
@@ -21,12 +33,6 @@ export default function getScheduleRunsTableConfig(
           },
           row.runID
         ),
-      width: '20%',
-    },
-    {
-      name: 'Workflow ID',
-      id: 'WorkflowID',
-      renderCell: (row: WorkflowListItem) => row.workflowID,
       width: '20%',
     },
     {
@@ -51,12 +57,6 @@ export default function getScheduleRunsTableConfig(
       renderCell: (row: WorkflowListItem) =>
         `${row.startTime} → ${row.closeTime ?? 'Running'}`,
       width: '23%',
-    },
-    {
-      name: 'Status',
-      id: 'CloseStatus',
-      renderCell: (row: WorkflowListItem) => row.status,
-      width: '10%',
     },
   ];
 }

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -5,6 +5,8 @@ import { type TableConfig } from '@/components/table/table.types';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 import getSearchAttributeValue from '@/views/shared/workflows-list/helpers/get-search-attribute-value';
 
+import ScheduleRunsStatusCell from '../schedule-runs-status-cell';
+
 export default function getScheduleRunsTableConfig(
   domain: string,
   cluster: string
@@ -19,7 +21,7 @@ export default function getScheduleRunsTableConfig(
     {
       name: 'Status',
       id: 'CloseStatus',
-      renderCell: (row: WorkflowListItem) => row.status,
+      renderCell: ScheduleRunsStatusCell,
       width: '10%',
     },
     {

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -5,6 +5,8 @@ import { type TableConfig } from '@/components/table/table.types';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 import getSearchAttributeValue from '@/views/shared/workflows-list/helpers/get-search-attribute-value';
 
+import ScheduleRunsRuntimeCell from '../schedule-runs-runtime-cell';
+
 export default function getScheduleRunsTableConfig(
   domain: string,
   cluster: string
@@ -48,8 +50,7 @@ export default function getScheduleRunsTableConfig(
     {
       name: 'Run time (Start/Close)',
       id: 'RunTime',
-      renderCell: (row: WorkflowListItem) =>
-        `${row.startTime} → ${row.closeTime ?? 'Running'}`,
+      renderCell: ScheduleRunsRuntimeCell,
       width: '23%',
     },
     {

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -1,0 +1,62 @@
+import { createElement } from 'react';
+
+import Link from '@/components/link/link';
+import { type TableConfig } from '@/components/table/table.types';
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+import getSearchAttributeValue from '@/views/shared/workflows-list/helpers/get-search-attribute-value';
+
+export default function getScheduleRunsTableConfig(
+  domain: string,
+  cluster: string
+): TableConfig<WorkflowListItem> {
+  return [
+    {
+      name: 'Run ID',
+      id: 'RunID',
+      renderCell: (row: WorkflowListItem) =>
+        createElement(
+          Link,
+          {
+            href: `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows/${encodeURIComponent(row.workflowID)}/${encodeURIComponent(row.runID)}`,
+          },
+          row.runID
+        ),
+      width: '20%',
+    },
+    {
+      name: 'Workflow ID',
+      id: 'WorkflowID',
+      renderCell: (row: WorkflowListItem) => row.workflowID,
+      width: '20%',
+    },
+    {
+      name: 'Backfill',
+      id: 'CadenceScheduleIsBackfill',
+      renderCell: (row: WorkflowListItem) =>
+        String(
+          getSearchAttributeValue(row, 'CadenceScheduleIsBackfill') ?? '-'
+        ),
+      width: '10%',
+    },
+    {
+      name: 'Schedule time',
+      id: 'CadenceScheduleTime',
+      renderCell: (row: WorkflowListItem) =>
+        String(getSearchAttributeValue(row, 'CadenceScheduleTime') ?? '-'),
+      width: '17%',
+    },
+    {
+      name: 'Run time (Start/Close)',
+      id: 'RunTime',
+      renderCell: (row: WorkflowListItem) =>
+        `${row.startTime} → ${row.closeTime ?? 'Running'}`,
+      width: '23%',
+    },
+    {
+      name: 'Status',
+      id: 'CloseStatus',
+      renderCell: (row: WorkflowListItem) => row.status,
+      width: '10%',
+    },
+  ];
+}

--- a/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
+++ b/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
@@ -1,0 +1,5 @@
+import escapeVisibilityQueryValue from '@/utils/visibility/escape-visibility-query-value';
+
+export default function getScheduleRunsQuery(scheduleId: string): string {
+  return `CadenceScheduleID = "${escapeVisibilityQueryValue(scheduleId)}"`;
+}

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
@@ -1,0 +1,13 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  Container: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      alignItems: 'center',
+      display: 'flex',
+      gap: $theme.sizing.scale200,
+    })
+  ),
+};

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
@@ -1,13 +1,20 @@
-import { styled as createStyled, type Theme } from 'baseui';
-import { type StyleObject } from 'styletron-react';
+import { type Theme } from 'baseui';
 
-export const styled = {
-  Container: createStyled(
-    'div',
-    ({ $theme }: { $theme: Theme }): StyleObject => ({
-      alignItems: 'center',
-      display: 'flex',
-      gap: $theme.sizing.scale200,
-    })
-  ),
-};
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  runtimeContainer: (theme: Theme) => ({
+    display: 'flex',
+    gap: theme.sizing.scale400,
+    alignItems: 'center',
+  }),
+  missingDateContainer: (theme: Theme) => ({
+    color: theme.colors.contentSecondary,
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =
+  cssStylesObj;

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
@@ -1,0 +1,18 @@
+import FormattedDate from '@/components/formatted-date/formatted-date';
+
+import { styled } from './schedule-runs-runtime-cell.styles';
+import { type Props } from './schedule-runs-runtime-cell.types';
+
+export default function ScheduleRunsRuntimeCell({
+  startTime,
+  closeTime,
+}: Props) {
+  if (!startTime) return '-';
+
+  return (
+    <styled.Container>
+      <FormattedDate timestampMs={startTime} /> →
+      {closeTime ? <FormattedDate timestampMs={closeTime} /> : 'Running…'}
+    </styled.Container>
+  );
+}

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
@@ -1,18 +1,30 @@
-import FormattedDate from '@/components/formatted-date/formatted-date';
+import { MdArrowForward } from 'react-icons/md';
 
-import { styled } from './schedule-runs-runtime-cell.styles';
+import FormattedDate from '@/components/formatted-date/formatted-date';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import { cssStyles } from './schedule-runs-runtime-cell.styles';
 import { type Props } from './schedule-runs-runtime-cell.types';
 
 export default function ScheduleRunsRuntimeCell({
   startTime,
   closeTime,
 }: Props) {
-  if (!startTime) return '-';
+  const { cls, theme } = useStyletronClasses(cssStyles);
+
+  if (!startTime) {
+    return <div className={cls.missingDateContainer}>None</div>;
+  }
 
   return (
-    <styled.Container>
-      <FormattedDate timestampMs={startTime} /> →
-      {closeTime ? <FormattedDate timestampMs={closeTime} /> : 'Running…'}
-    </styled.Container>
+    <div className={cls.runtimeContainer}>
+      <FormattedDate timestampMs={startTime} />
+      <MdArrowForward color={theme.colors.contentSecondary} aria-hidden />
+      {closeTime ? (
+        <FormattedDate timestampMs={closeTime} />
+      ) : (
+        <div className={cls.missingDateContainer}>Running…</div>
+      )}
+    </div>
   );
 }

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.types.ts
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.types.ts
@@ -1,0 +1,3 @@
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+export type Props = Pick<WorkflowListItem, 'startTime' | 'closeTime'>;

--- a/src/views/schedule-runs/schedule-runs-status-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-status-cell.tsx
@@ -1,0 +1,12 @@
+import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
+import WorkflowStatusTag from '@/views/shared/workflow-status-tag/workflow-status-tag';
+
+import { type Props } from './schedule-runs-status-cell.types';
+
+export default function ScheduleRunsStatusCell({ status }: Props) {
+  return isWorkflowStatus(status) ? (
+    <WorkflowStatusTag status={status} />
+  ) : (
+    'Unknown'
+  );
+}

--- a/src/views/schedule-runs/schedule-runs-status-cell.types.ts
+++ b/src/views/schedule-runs/schedule-runs-status-cell.types.ts
@@ -1,0 +1,3 @@
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+export type Props = Pick<WorkflowListItem, 'status'>;

--- a/src/views/schedule-runs/schedule-runs-table.tsx
+++ b/src/views/schedule-runs/schedule-runs-table.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Table from '@/components/table/table';
+
+import getScheduleRunsTableConfig from './config/schedule-runs-table.config';
+import { type Props } from './schedule-runs-table.types';
+
+export default function ScheduleRunsTable({
+  domain,
+  cluster,
+  workflows,
+  error,
+  hasNextPage,
+  fetchNextPage,
+  isFetchingNextPage,
+}: Props) {
+  return (
+    <Table
+      data={workflows}
+      columns={getScheduleRunsTableConfig(domain, cluster)}
+      shouldShowResults={workflows.length > 0}
+      endMessageProps={{
+        kind: 'infinite-scroll',
+        hasData: workflows.length > 0,
+        error,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+      }}
+    />
+  );
+}

--- a/src/views/schedule-runs/schedule-runs-table.types.ts
+++ b/src/views/schedule-runs/schedule-runs-table.types.ts
@@ -1,0 +1,11 @@
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+export type Props = {
+  domain: string;
+  cluster: string;
+  workflows: Array<WorkflowListItem>;
+  error: Error | null;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+  isFetchingNextPage: boolean;
+};

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -32,7 +32,7 @@ export default function ScheduleRuns({ params }: Props) {
     return <SectionLoadingIndicator />;
   }
 
-  if (error) {
+  if (error && workflows.length === 0) {
     return (
       <PanelSection>
         <ErrorPanel
@@ -41,14 +41,6 @@ export default function ScheduleRuns({ params }: Props) {
           reset={refetch}
           actions={[{ kind: 'retry', label: 'Retry' }]}
         />
-      </PanelSection>
-    );
-  }
-
-  if (workflows.length === 0) {
-    return (
-      <PanelSection>
-        <ErrorPanel message="No schedule runs found" omitLogging />
       </PanelSection>
     );
   }

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -6,10 +6,19 @@ import SectionLoadingIndicator from '@/components/section-loading-indicator/sect
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 
 import getScheduleRunsQuery from './helpers/get-schedule-runs-query';
+import ScheduleRunsTable from './schedule-runs-table';
 import { type Props } from './schedule-runs.types';
 
 export default function ScheduleRuns({ params }: Props) {
-  const { data, error, isLoading, refetch } = useListWorkflows({
+  const {
+    workflows,
+    error,
+    isLoading,
+    refetch,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useListWorkflows({
     domain: params.domain,
     cluster: params.cluster,
     listType: 'default',
@@ -17,7 +26,6 @@ export default function ScheduleRuns({ params }: Props) {
     inputType: 'query',
     query: getScheduleRunsQuery(params.scheduleId),
   });
-  const workflows = data?.pages[0]?.workflows ?? [];
 
   if (isLoading) {
     return <SectionLoadingIndicator />;
@@ -44,5 +52,15 @@ export default function ScheduleRuns({ params }: Props) {
     );
   }
 
-  return JSON.stringify(workflows);
+  return (
+    <ScheduleRunsTable
+      domain={params.domain}
+      cluster={params.cluster}
+      workflows={workflows}
+      error={error}
+      hasNextPage={hasNextPage}
+      fetchNextPage={fetchNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+    />
+  );
 }

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+import PanelSection from '@/components/panel-section/panel-section';
+import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
+
+import getScheduleRunsQuery from './helpers/get-schedule-runs-query';
+import { type Props } from './schedule-runs.types';
+
+export default function ScheduleRuns({ params }: Props) {
+  const { data, error, isLoading, refetch } = useListWorkflows({
+    domain: params.domain,
+    cluster: params.cluster,
+    listType: 'default',
+    pageSize: 20,
+    inputType: 'query',
+    query: getScheduleRunsQuery(params.scheduleId),
+  });
+  const workflows = data?.pages[0]?.workflows ?? [];
+
+  if (isLoading) {
+    return <SectionLoadingIndicator />;
+  }
+
+  if (error) {
+    return (
+      <PanelSection>
+        <ErrorPanel
+          message="Failed to load schedule runs"
+          error={error}
+          reset={refetch}
+          actions={[{ kind: 'retry', label: 'Retry' }]}
+        />
+      </PanelSection>
+    );
+  }
+
+  if (workflows.length === 0) {
+    return (
+      <PanelSection>
+        <ErrorPanel message="No schedule runs found" omitLogging />
+      </PanelSection>
+    );
+  }
+
+  return JSON.stringify(workflows);
+}

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import ErrorPanel from '@/components/error-panel/error-panel';
+import PageSection from '@/components/page-section/page-section';
 import PanelSection from '@/components/panel-section/panel-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
@@ -44,5 +45,5 @@ export default function ScheduleRuns({ params }: Props) {
     );
   }
 
-  return JSON.stringify(workflows);
+  return <PageSection>{JSON.stringify(workflows)}</PageSection>;
 }

--- a/src/views/schedule-runs/schedule-runs.types.ts
+++ b/src/views/schedule-runs/schedule-runs.types.ts
@@ -1,0 +1,3 @@
+import { type SchedulePageTabContentProps } from '@/views/schedule-page/schedule-page-tabs/schedule-page-tabs.types';
+
+export type Props = SchedulePageTabContentProps;


### PR DESCRIPTION
## Summary

- Add the specialized Start/Close runtime cell to the schedule-runs table.
- Format both timestamps as dates and match the Failover Information transition styling.
- Depends on #1449.

## Changes

- Render `start → Running…` for open executions and `start → close` for closed executions.
- Reuse the shared formatted-date component for both timestamps.
- Use the same themed arrow icon, spacing, alignment, and secondary fallback color as Failover Information.
- Render `None` when the start timestamp is unavailable.
- Add focused coverage for running, closed, and incomplete executions.

## Test plan

- [x] `npm run test:unit:browser schedule-runs-runtime-cell.test.tsx schedule-runs-table.test.tsx`
- [x] `npm run typecheck`
- [x] `npx eslint "src/views/schedule-runs/schedule-runs-runtime-cell.tsx" "src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts" "src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx"`

## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- [x] [Schedules Create Form](https://github.com/cadence-workflow/cadence-web/pull/1390)
- [x] [Schedules Details](https://github.com/cadence-workflow/cadence-web/pull/1394)
- [x] Schedules Actions
- Schedule Runs
  - #1448
  - #1449
  - #1450
  - #1451
  - #1452