### PR TITLE
feat(schedule-runs): add run type filter

### DIFF
--- a/src/components/list-filter/__tests__/list-filter.test.tsx
+++ b/src/components/list-filter/__tests__/list-filter.test.tsx
@@ -53,9 +53,20 @@ describe(ListFilter.name, () => {
 
     expect(mockOnChangeValue).toHaveBeenCalledWith(undefined);
   });
+
+  it('can disable clearing the filter', () => {
+    setup({ override: 'opt2', clearable: false });
+    expect(screen.queryByLabelText('Clear value')).not.toBeInTheDocument();
+  });
 });
 
-function setup({ override }: { override?: MockListFilterOption }) {
+function setup({
+  override,
+  clearable,
+}: {
+  override?: MockListFilterOption;
+  clearable?: boolean;
+}) {
   const mockOnChangeValue = jest.fn();
   const user = userEvent.setup();
 
@@ -66,6 +77,7 @@ function setup({ override }: { override?: MockListFilterOption }) {
       value={override ?? undefined}
       onChangeValue={mockOnChangeValue}
       labelMap={MOCK_LIST_FILTER_LABELS}
+      clearable={clearable}
     />
   );
 

--- a/src/components/list-filter/list-filter.tsx
+++ b/src/components/list-filter/list-filter.tsx
@@ -14,6 +14,7 @@ export default function ListFilter<T extends string>({
   labelMap,
   label,
   placeholder,
+  clearable,
 }: Props<T>) {
   const options = getOptionsFromLabelMap(labelMap);
   const optionValue = value
@@ -34,6 +35,7 @@ export default function ListFilter<T extends string>({
           )
         }
         placeholder={placeholder}
+        clearable={clearable}
       />
     </FormControl>
   );

--- a/src/components/list-filter/list-filter.types.ts
+++ b/src/components/list-filter/list-filter.types.ts
@@ -4,4 +4,5 @@ export type Props<T extends string> = {
   labelMap: Record<T, string>;
   label: string;
   placeholder: string;
+  clearable?: boolean;
 };

--- a/src/views/schedule-page/config/__tests__/schedule-page-query-params.config.test.ts
+++ b/src/views/schedule-page/config/__tests__/schedule-page-query-params.config.test.ts
@@ -1,0 +1,17 @@
+import getPageQueryParamsValues from '@/hooks/use-page-query-params/helpers/get-page-query-params-values';
+
+import schedulePageQueryParamsConfig from '../schedule-page-query-params.config';
+
+describe('schedulePageQueryParamsConfig', () => {
+  it('restores a relative Schedule time range from the URL', () => {
+    expect(
+      getPageQueryParamsValues(schedulePageQueryParamsConfig, {
+        'runs-start': 'now-30d',
+        'runs-end': 'now',
+      })
+    ).toEqual({
+      scheduleRunsTimeStart: 'now-30d',
+      scheduleRunsTimeEnd: 'now',
+    });
+  });
+});

--- a/src/views/schedule-page/config/__tests__/schedule-page-query-params.config.test.ts
+++ b/src/views/schedule-page/config/__tests__/schedule-page-query-params.config.test.ts
@@ -9,9 +9,11 @@ describe('schedulePageQueryParamsConfig', () => {
         'runs-start': 'now-30d',
         'runs-end': 'now',
       })
-    ).toEqual({
-      scheduleRunsTimeStart: 'now-30d',
-      scheduleRunsTimeEnd: 'now',
-    });
+    ).toEqual(
+      expect.objectContaining({
+        scheduleRunsTimeStart: 'now-30d',
+        scheduleRunsTimeEnd: 'now',
+      })
+    );
   });
 });

--- a/src/views/schedule-page/config/schedule-page-query-params.config.ts
+++ b/src/views/schedule-page/config/schedule-page-query-params.config.ts
@@ -2,7 +2,7 @@ import { type DateFilterValue } from '@/components/date-filter/date-filter.types
 import parseDateFilterValue from '@/components/date-filter/helpers/parse-date-filter-value';
 import { type PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
 
-const scheduleRunsQueryParamsConfig: [
+const schedulePageQueryParamsConfig: [
   PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,
   PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue>,
 ] = [
@@ -20,4 +20,4 @@ const scheduleRunsQueryParamsConfig: [
   },
 ] as const;
 
-export default scheduleRunsQueryParamsConfig;
+export default schedulePageQueryParamsConfig;

--- a/src/views/schedule-page/config/schedule-page-query-params.config.ts
+++ b/src/views/schedule-page/config/schedule-page-query-params.config.ts
@@ -6,10 +6,9 @@ import {
 } from '@/hooks/use-page-query-params/use-page-query-params.types';
 import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
+import { type ScheduleRunsRunType } from '@/views/schedule-runs/schedule-runs.types';
 
-import { type ScheduleRunsRunType } from '../schedule-runs.types';
-
-const scheduleRunsQueryParamsConfig: [
+const schedulePageQueryParamsConfig: [
   PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,
   PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue>,
   PageQueryParamMultiValue<
@@ -46,4 +45,4 @@ const scheduleRunsQueryParamsConfig: [
   },
 ] as const;
 
-export default scheduleRunsQueryParamsConfig;
+export default schedulePageQueryParamsConfig;

--- a/src/views/schedule-page/config/schedule-page-query-params.config.ts
+++ b/src/views/schedule-page/config/schedule-page-query-params.config.ts
@@ -7,7 +7,7 @@ import {
 import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
-const scheduleRunsQueryParamsConfig: [
+const schedulePageQueryParamsConfig: [
   PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,
   PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue>,
   PageQueryParamMultiValue<
@@ -36,4 +36,4 @@ const scheduleRunsQueryParamsConfig: [
   },
 ] as const;
 
-export default scheduleRunsQueryParamsConfig;
+export default schedulePageQueryParamsConfig;

--- a/src/views/schedule-page/config/schedule-page-query-params.config.ts
+++ b/src/views/schedule-page/config/schedule-page-query-params.config.ts
@@ -4,9 +4,9 @@ import {
   type PageQueryParamMultiValue,
   type PageQueryParam,
 } from '@/hooks/use-page-query-params/use-page-query-params.types';
+import { type ScheduleRunsRunType } from '@/views/schedule-runs/schedule-runs.types';
 import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
-import { type ScheduleRunsRunType } from '@/views/schedule-runs/schedule-runs.types';
 
 const schedulePageQueryParamsConfig: [
   PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,

--- a/src/views/schedule-page/config/schedule-page-query-params.config.ts
+++ b/src/views/schedule-page/config/schedule-page-query-params.config.ts
@@ -14,7 +14,8 @@ const schedulePageQueryParamsConfig: [
   {
     key: 'scheduleRunsTimeEnd',
     queryParamKey: 'runs-end',
-    parseValue: parseDateFilterValue,
+    parseValue: (value) =>
+      value === 'now' ? 'now' : parseDateFilterValue(value),
   },
 ] as const;
 

--- a/src/views/schedule-page/config/schedule-page-query-params.config.ts
+++ b/src/views/schedule-page/config/schedule-page-query-params.config.ts
@@ -3,20 +3,18 @@ import parseDateFilterValue from '@/components/date-filter/helpers/parse-date-fi
 import { type PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
 
 const schedulePageQueryParamsConfig: [
-  PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,
-  PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue>,
+  PageQueryParam<'scheduleRunsTimeStart', DateFilterValue | undefined>,
+  PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue | undefined>,
 ] = [
   {
     key: 'scheduleRunsTimeStart',
     queryParamKey: 'runs-start',
-    defaultValue: 'now-7d',
-    parseValue: (value) => parseDateFilterValue(value) ?? 'now-7d',
+    parseValue: parseDateFilterValue,
   },
   {
     key: 'scheduleRunsTimeEnd',
     queryParamKey: 'runs-end',
-    defaultValue: 'now',
-    parseValue: (value) => parseDateFilterValue(value) ?? 'now',
+    parseValue: parseDateFilterValue,
   },
 ] as const;
 

--- a/src/views/schedule-page/config/schedule-page-tabs.config.ts
+++ b/src/views/schedule-page/config/schedule-page-tabs.config.ts
@@ -1,8 +1,7 @@
-import { createElement } from 'react';
-
 import { MdCalendarMonth, MdTimeline } from 'react-icons/md';
 
 import ScheduleDetails from '@/views/schedule-details/schedule-details';
+import ScheduleRuns from '@/views/schedule-runs/schedule-runs';
 
 import getSchedulePageTabErrorConfig from '../helpers/get-schedule-page-tab-error-config';
 import { type SchedulePageTabsConfig } from '../schedule-page-tabs/schedule-page-tabs.types';
@@ -17,7 +16,7 @@ const schedulePageTabsConfig: SchedulePageTabsConfig<'details' | 'runs'> = {
   runs: {
     title: 'Runs',
     artwork: MdTimeline,
-    content: () => createElement('div', {}, 'Runs content'),
+    content: ScheduleRuns,
     getErrorConfig: (error, params) =>
       getSchedulePageTabErrorConfig(
         error,

--- a/src/views/schedule-runs/__tests__/schedule-runs-header.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-header.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import usePageFilters from '@/components/page-filters/hooks/use-page-filters';
+
+import ScheduleRunsHeader from '../schedule-runs-header';
+
+const mockUsePageFilters = jest.mocked(usePageFilters);
+
+jest.mock('@/components/page-filters/hooks/use-page-filters');
+jest.mock(
+  '@/components/page-filters/page-filters-toggle/page-filters-toggle',
+  () => jest.fn(({ onClick }) => <button onClick={onClick}>Filters</button>)
+);
+jest.mock(
+  '@/components/page-filters/page-filters-fields/page-filters-fields',
+  () => jest.fn(() => <div>Schedule time filter</div>)
+);
+
+describe(ScheduleRunsHeader.name, () => {
+  it('toggles the collapsible filter panel', async () => {
+    const user = userEvent.setup();
+    mockUsePageFilters.mockReturnValue({
+      resetAllFilters: jest.fn(),
+      activeFiltersCount: 0,
+      queryParams: {},
+      setQueryParams: jest.fn(),
+    });
+    render(<ScheduleRunsHeader />);
+
+    expect(screen.queryByText('Schedule time filter')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    expect(screen.getByText('Schedule time filter')).toBeInTheDocument();
+  });
+});

--- a/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import { type Props as FormattedDateProps } from '@/components/formatted-date/formatted-date.types';
+
+import ScheduleRunsRuntimeCell from '../schedule-runs-runtime-cell';
+import { type Props } from '../schedule-runs-runtime-cell.types';
+
+jest.mock('@/components/formatted-date/formatted-date', () =>
+  jest.fn(({ timestampMs }: FormattedDateProps) => <time>{timestampMs}</time>)
+);
+
+describe(ScheduleRunsRuntimeCell.name, () => {
+  it('renders a running execution', () => {
+    setup({ startTime: 100, closeTime: undefined });
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('100').parentElement).toHaveTextContent(
+      /→\s*Running…/
+    );
+  });
+
+  it('renders a closed execution', () => {
+    setup({ startTime: 100, closeTime: 200 });
+
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('200')).toBeInTheDocument();
+    expect(screen.queryByText('Running…')).not.toBeInTheDocument();
+  });
+
+  it('renders a fallback when the start time is missing', () => {
+    setup({ startTime: 0, closeTime: undefined });
+
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+});
+
+function setup(props: Props) {
+  render(<ScheduleRunsRuntimeCell {...props} />);
+}

--- a/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
@@ -14,9 +14,7 @@ describe(ScheduleRunsRuntimeCell.name, () => {
     setup({ startTime: 100, closeTime: undefined });
 
     expect(screen.getByText('100')).toBeInTheDocument();
-    expect(screen.getByText('100').parentElement).toHaveTextContent(
-      /→\s*Running…/
-    );
+    expect(screen.getByText('Running…')).toBeInTheDocument();
   });
 
   it('renders a closed execution', () => {
@@ -30,7 +28,7 @@ describe(ScheduleRunsRuntimeCell.name, () => {
   it('renders a fallback when the start time is missing', () => {
     setup({ startTime: 0, closeTime: undefined });
 
-    expect(screen.getByText('-')).toBeInTheDocument();
+    expect(screen.getByText('None')).toBeInTheDocument();
   });
 });
 

--- a/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-runtime-cell.test.tsx
@@ -6,7 +6,9 @@ import ScheduleRunsRuntimeCell from '../schedule-runs-runtime-cell';
 import { type Props } from '../schedule-runs-runtime-cell.types';
 
 jest.mock('@/components/formatted-date/formatted-date', () =>
-  jest.fn(({ timestampMs }: FormattedDateProps) => <time>{timestampMs}</time>)
+  jest.fn(({ timestampMs }: FormattedDateProps) => (
+    <time>{timestampMs ?? 'Ongoing'}</time>
+  ))
 );
 
 describe(ScheduleRunsRuntimeCell.name, () => {
@@ -14,7 +16,7 @@ describe(ScheduleRunsRuntimeCell.name, () => {
     setup({ startTime: 100, closeTime: undefined });
 
     expect(screen.getByText('100')).toBeInTheDocument();
-    expect(screen.getByText('Running…')).toBeInTheDocument();
+    expect(screen.getByText('Ongoing')).toBeInTheDocument();
   });
 
   it('renders a closed execution', () => {
@@ -22,7 +24,7 @@ describe(ScheduleRunsRuntimeCell.name, () => {
 
     expect(screen.getByText('100')).toBeInTheDocument();
     expect(screen.getByText('200')).toBeInTheDocument();
-    expect(screen.queryByText('Running…')).not.toBeInTheDocument();
+    expect(screen.queryByText('Ongoing')).not.toBeInTheDocument();
   });
 
   it('renders a fallback when the start time is missing', () => {

--- a/src/views/schedule-runs/__tests__/schedule-runs-status-cell.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-status-cell.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import {
+  WORKFLOW_STATUSES,
+  WORKFLOW_STATUS_NAMES,
+} from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
+import { type Props as WorkflowStatusTagProps } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
+
+import ScheduleRunsStatusCell from '../schedule-runs-status-cell';
+import { type Props } from '../schedule-runs-status-cell.types';
+
+jest.mock('@/views/shared/workflow-status-tag/workflow-status-tag', () =>
+  jest.fn(({ status }: WorkflowStatusTagProps) => (
+    <span>{WORKFLOW_STATUS_NAMES[status]}</span>
+  ))
+);
+
+describe(ScheduleRunsStatusCell.name, () => {
+  it.each(Object.values(WORKFLOW_STATUSES))(
+    'renders accessible text for %s',
+    (status) => {
+      setup(status);
+      expect(
+        screen.getByText(WORKFLOW_STATUS_NAMES[status])
+      ).toBeInTheDocument();
+    }
+  );
+
+  it('renders a safe fallback for an unknown status', () => {
+    setup('UNKNOWN' as Props['status']);
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+  });
+});
+
+function setup(status: Props['status']) {
+  render(<ScheduleRunsStatusCell status={status} />);
+}

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -8,6 +8,7 @@ import {
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 
+import { type Props as StatusCellProps } from '../schedule-runs-status-cell.types';
 import ScheduleRunsTable from '../schedule-runs-table';
 import { type Props } from '../schedule-runs-table.types';
 
@@ -21,6 +22,9 @@ jest.mock('@/components/link/link', () =>
   jest.fn(({ href, children }: LinkProps) => (
     <a href={href.toString()}>{children}</a>
   ))
+);
+jest.mock('../schedule-runs-status-cell', () =>
+  jest.fn(({ status }: StatusCellProps) => <>{status}</>)
 );
 jest.mock('@/components/table/table', () =>
   jest.fn(({ data, columns, endMessageProps }: MockTableProps) => (

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -8,6 +8,7 @@ import {
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 
+import { type Props as RuntimeCellProps } from '../schedule-runs-runtime-cell.types';
 import ScheduleRunsTable from '../schedule-runs-table';
 import { type Props } from '../schedule-runs-table.types';
 
@@ -20,6 +21,11 @@ type MockTableProps = {
 jest.mock('@/components/link/link', () =>
   jest.fn(({ href, children }: LinkProps) => (
     <a href={href.toString()}>{children}</a>
+  ))
+);
+jest.mock('../schedule-runs-runtime-cell', () =>
+  jest.fn(({ startTime, closeTime }: RuntimeCellProps) => (
+    <>{`${startTime} → ${closeTime}`}</>
   ))
 );
 jest.mock('@/components/table/table', () =>

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -66,6 +66,16 @@ describe(ScheduleRunsTable.name, () => {
   it('renders the base columns and an encoded run link', () => {
     setup();
 
+    expect(
+      screen.getAllByRole('columnheader').map((column) => column.textContent)
+    ).toEqual([
+      'Workflow ID',
+      'Status',
+      'Run ID',
+      'Backfill',
+      'Schedule time',
+      'Run time (Start/Close)',
+    ]);
     expect(screen.getByRole('link', { name: 'run/id?' })).toHaveAttribute(
       'href',
       '/domains/test-domain/test-cluster/workflows/workflow%2Fid/run%2Fid%3F'

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type Props as LinkProps } from '@/components/link/link.types';
+import {
+  type EndMessageProps,
+  type TableConfig,
+} from '@/components/table/table.types';
+import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+import ScheduleRunsTable from '../schedule-runs-table';
+import { type Props } from '../schedule-runs-table.types';
+
+type MockTableProps = {
+  data: Array<WorkflowListItem>;
+  columns: TableConfig<WorkflowListItem>;
+  endMessageProps: Extract<EndMessageProps, { kind: 'infinite-scroll' }>;
+};
+
+jest.mock('@/components/link/link', () =>
+  jest.fn(({ href, children }: LinkProps) => (
+    <a href={href.toString()}>{children}</a>
+  ))
+);
+jest.mock('@/components/table/table', () =>
+  jest.fn(({ data, columns, endMessageProps }: MockTableProps) => (
+    <table>
+      <thead>
+        <tr>
+          {columns.map(({ id, name }) => (
+            <th key={id}>{name}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row) => (
+          <tr key={row.runID}>
+            {columns.map((column) => (
+              <td key={column.id}>
+                <column.renderCell {...row} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+      <tfoot>
+        <tr>
+          <td>
+            <button onClick={endMessageProps.fetchNextPage}>
+              {endMessageProps.isFetchingNextPage
+                ? 'Loading more'
+                : endMessageProps.error
+                  ? 'Retry'
+                  : endMessageProps.hasNextPage
+                    ? 'Load more'
+                    : 'End of results'}
+            </button>
+          </td>
+        </tr>
+      </tfoot>
+    </table>
+  ))
+);
+
+describe(ScheduleRunsTable.name, () => {
+  it('renders the base columns and an encoded run link', () => {
+    setup();
+
+    expect(screen.getByRole('link', { name: 'run/id?' })).toHaveAttribute(
+      'href',
+      '/domains/test-domain/test-cluster/workflows/workflow%2Fid/run%2Fid%3F'
+    );
+    ['2026-07-19T10:00:00Z', '100 → 200'].forEach((value) =>
+      expect(screen.getByText(value)).toBeInTheDocument()
+    );
+  });
+
+  it('loads the next page while retaining existing rows', async () => {
+    const user = userEvent.setup();
+    const { fetchNextPage } = setup();
+
+    await user.click(screen.getByRole('button', { name: 'Load more' }));
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('workflow/id')).toBeInTheDocument();
+  });
+
+  it('renders distinct loading, error, and end states', () => {
+    const { rerender, props } = setup({ isFetchingNextPage: true });
+    expect(screen.getByRole('button', { name: 'Loading more' })).toBeVisible();
+
+    rerender(
+      <ScheduleRunsTable
+        {...props}
+        isFetchingNextPage={false}
+        error={new Error('Request failed')}
+      />
+    );
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeVisible();
+
+    rerender(
+      <ScheduleRunsTable
+        {...props}
+        isFetchingNextPage={false}
+        hasNextPage={false}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: 'End of results' })
+    ).toBeVisible();
+  });
+});
+
+function setup(overrides: Partial<Props> = {}) {
+  const fetchNextPage = jest.fn();
+  const props: Props = {
+    domain: 'test-domain',
+    cluster: 'test-cluster',
+    workflows: [
+      getMockWorkflowListItem({
+        workflowID: 'workflow/id',
+        runID: 'run/id?',
+        startTime: 100,
+        closeTime: 200,
+        status: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
+        searchAttributes: {
+          CadenceScheduleIsBackfill: { data: btoa('true') },
+          CadenceScheduleTime: { data: btoa('"2026-07-19T10:00:00Z"') },
+        },
+      }),
+    ],
+    error: null,
+    hasNextPage: true,
+    fetchNextPage,
+    isFetchingNextPage: false,
+    ...overrides,
+  };
+  const renderResult = render(<ScheduleRunsTable {...props} />);
+  return { ...renderResult, props, fetchNextPage };
+}

--- a/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs-table.test.tsx
@@ -8,6 +8,7 @@ import {
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 
+import { type Props as RuntimeCellProps } from '../schedule-runs-runtime-cell.types';
 import { type Props as StatusCellProps } from '../schedule-runs-status-cell.types';
 import ScheduleRunsTable from '../schedule-runs-table';
 import { type Props } from '../schedule-runs-table.types';
@@ -21,6 +22,11 @@ type MockTableProps = {
 jest.mock('@/components/link/link', () =>
   jest.fn(({ href, children }: LinkProps) => (
     <a href={href.toString()}>{children}</a>
+  ))
+);
+jest.mock('../schedule-runs-runtime-cell', () =>
+  jest.fn(({ startTime, closeTime }: RuntimeCellProps) => (
+    <>{`${startTime} → ${closeTime}`}</>
   ))
 );
 jest.mock('../schedule-runs-status-cell', () =>

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -7,6 +7,7 @@ import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-par
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { RequestError } from '@/utils/request/request-error';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
+import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
 import ScheduleRuns from '../schedule-runs';
 import { type Props as ScheduleRunsTableProps } from '../schedule-runs-table.types';
@@ -60,16 +61,21 @@ describe(ScheduleRuns.name, () => {
     expect(screen.getByText(/second-page-workflow/)).toBeInTheDocument();
   });
 
-  it('queries the selected Schedule time range', () => {
+  it('combines Schedule time and workflow status filters', () => {
     setup({
       timeStart: new Date('2026-07-12T10:00:00Z'),
       timeEnd: new Date('2026-07-19T10:00:00Z'),
+      statuses: [
+        'WORKFLOW_EXECUTION_CLOSE_STATUS_FAILED',
+        'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID',
+      ],
     });
 
     expect(mockUseListWorkflows).toHaveBeenCalledWith(
       expect.objectContaining({
         query:
           'CadenceScheduleID = "test-schedule" AND ' +
+          '(CloseStatus = 1 OR CloseTime = missing) AND ' +
           'CadenceScheduleTime > "2026-07-12T10:00:00.000Z" AND ' +
           'CadenceScheduleTime <= "2026-07-19T10:00:00.000Z"',
       })
@@ -126,17 +132,20 @@ function setup({
   scheduleId = 'test-schedule',
   timeStart = 'now-7d',
   timeEnd = 'now',
+  statuses,
   hookResult = {},
 }: {
   scheduleId?: string;
   timeStart?: DateFilterValue;
   timeEnd?: DateFilterValue;
+  statuses?: Array<WorkflowStatus>;
   hookResult?: Partial<HookResult>;
 } = {}) {
   mockUsePageQueryParams.mockReturnValue([
     {
       scheduleRunsTimeStart: timeStart,
       scheduleRunsTimeEnd: timeEnd,
+      scheduleRunsStatuses: statuses,
     },
     jest.fn(),
   ]);

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -30,7 +30,11 @@ jest.mock('@/components/error-panel/error-panel', () =>
 );
 jest.mock('../schedule-runs-table', () =>
   jest.fn(({ workflows }: ScheduleRunsTableProps) => (
-    <div>{workflows.map(({ workflowID }) => workflowID).join(',')}</div>
+    <div>
+      {workflows.length
+        ? workflows.map(({ workflowID }) => workflowID).join(',')
+        : 'No results'}
+    </div>
   ))
 );
 describe(ScheduleRuns.name, () => {
@@ -65,6 +69,7 @@ describe(ScheduleRuns.name, () => {
     setup({
       hookResult: {
         data: undefined,
+        workflows: [],
         error: new RequestError('Request failed', '/workflows', 500),
       },
     });
@@ -83,7 +88,7 @@ describe(ScheduleRuns.name, () => {
       },
     });
 
-    expect(screen.getByText('No schedule runs found')).toBeInTheDocument();
+    expect(screen.getByText('No results')).toBeInTheDocument();
   });
 });
 

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -124,8 +124,8 @@ type HookResult = ReturnType<typeof useListWorkflows>;
 
 function setup({
   scheduleId = 'test-schedule',
-  timeStart = 'now-7d',
-  timeEnd = 'now',
+  timeStart,
+  timeEnd,
   hookResult = {},
 }: {
   scheduleId?: string;

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -95,7 +95,7 @@ describe(ScheduleRuns.name, () => {
     expect(mockUseListWorkflows).toHaveBeenCalledWith(
       expect.objectContaining({
         query: expect.stringContaining(
-          `CadenceScheduleIsBackfill = ${expectedValue}`
+          `CadenceScheduleIsBackfill = "${expectedValue}"`
         ),
       })
     );

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -11,6 +11,7 @@ import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow
 
 import ScheduleRuns from '../schedule-runs';
 import { type Props as ScheduleRunsTableProps } from '../schedule-runs-table.types';
+import { type ScheduleRunsRunType } from '../schedule-runs.types';
 
 const mockRefetch = jest.fn();
 const mockUsePageQueryParams = jest.mocked(usePageQueryParams);
@@ -82,6 +83,20 @@ describe(ScheduleRuns.name, () => {
     );
   });
 
+  it.each([
+    ['backfill', 'true'],
+    ['regular', 'false'],
+  ] as const)('queries %s runs', (runType, expectedValue) => {
+    setup({ runType });
+    expect(mockUseListWorkflows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining(
+          `CadenceScheduleIsBackfill = ${expectedValue}`
+        ),
+      })
+    );
+  });
+
   it('renders the initial loading state', () => {
     setup({ hookResult: { data: undefined, isLoading: true } });
 
@@ -133,12 +148,14 @@ function setup({
   timeStart = 'now-7d',
   timeEnd = 'now',
   statuses,
+  runType = 'all',
   hookResult = {},
 }: {
   scheduleId?: string;
   timeStart?: DateFilterValue;
   timeEnd?: DateFilterValue;
   statuses?: Array<WorkflowStatus>;
+  runType?: ScheduleRunsRunType;
   hookResult?: Partial<HookResult>;
 } = {}) {
   mockUsePageQueryParams.mockReturnValue([
@@ -146,6 +163,7 @@ function setup({
       scheduleRunsTimeStart: timeStart,
       scheduleRunsTimeEnd: timeEnd,
       scheduleRunsStatuses: statuses,
+      scheduleRunsRunType: runType,
     },
     jest.fn(),
   ]);

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -7,6 +7,7 @@ import { RequestError } from '@/utils/request/request-error';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 
 import ScheduleRuns from '../schedule-runs';
+import { type Props as ScheduleRunsTableProps } from '../schedule-runs-table.types';
 
 const mockRefetch = jest.fn();
 const mockUseListWorkflows = jest.mocked(useListWorkflows);
@@ -27,12 +28,17 @@ jest.mock('@/components/error-panel/error-panel', () =>
     </div>
   ))
 );
+jest.mock('../schedule-runs-table', () =>
+  jest.fn(({ workflows }: ScheduleRunsTableProps) => (
+    <div>{workflows.map(({ workflowID }) => workflowID).join(',')}</div>
+  ))
+);
 describe(ScheduleRuns.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('queries the schedule and renders only the first page as JSON', () => {
+  it('queries the schedule and renders all loaded pages in the table', () => {
     const scheduleId = String.raw`schedule"\id`;
     setup({ scheduleId });
 
@@ -45,7 +51,7 @@ describe(ScheduleRuns.name, () => {
       query: String.raw`CadenceScheduleID = "schedule\"\\id"`,
     });
     expect(screen.getByText(/first-page-workflow/)).toBeInTheDocument();
-    expect(screen.queryByText(/second-page-workflow/)).not.toBeInTheDocument();
+    expect(screen.getByText(/second-page-workflow/)).toBeInTheDocument();
   });
 
   it('renders the initial loading state', () => {
@@ -73,10 +79,7 @@ describe(ScheduleRuns.name, () => {
   it('renders an empty state when the first page has no runs', () => {
     setup({
       hookResult: {
-        data: {
-          pages: [{ workflows: [], nextPage: '' }],
-          pageParams: [undefined],
-        },
+        workflows: [],
       },
     });
 
@@ -93,27 +96,31 @@ function setup({
   scheduleId?: string;
   hookResult?: Partial<HookResult>;
 } = {}) {
+  const workflows = [
+    getMockWorkflowListItem({ workflowID: 'first-page-workflow' }),
+    getMockWorkflowListItem({ workflowID: 'second-page-workflow' }),
+  ];
   mockUseListWorkflows.mockReturnValue({
     data: {
       pages: [
         {
-          workflows: [
-            getMockWorkflowListItem({ workflowID: 'first-page-workflow' }),
-          ],
+          workflows: [workflows[0]],
           nextPage: 'next-page',
         },
         {
-          workflows: [
-            getMockWorkflowListItem({ workflowID: 'second-page-workflow' }),
-          ],
+          workflows: [workflows[1]],
           nextPage: '',
         },
       ],
       pageParams: [undefined, 'next-page'],
     },
+    workflows,
     error: null,
     isLoading: false,
     refetch: mockRefetch,
+    hasNextPage: false,
+    fetchNextPage: jest.fn(),
+    isFetchingNextPage: false,
     ...hookResult,
   } as unknown as HookResult);
 

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, userEvent } from '@/test-utils/rtl';
+
+import { type Props as ErrorPanelProps } from '@/components/error-panel/error-panel.types';
+import { type Props as PanelSectionProps } from '@/components/panel-section/panel-section.types';
+import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
+import { RequestError } from '@/utils/request/request-error';
+import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
+
+import ScheduleRuns from '../schedule-runs';
+
+const mockRefetch = jest.fn();
+const mockUseListWorkflows = jest.mocked(useListWorkflows);
+
+jest.mock('@/views/shared/hooks/use-list-workflows');
+jest.mock(
+  '@/components/section-loading-indicator/section-loading-indicator',
+  () => jest.fn(() => <div>Loading schedule runs</div>)
+);
+jest.mock('@/components/panel-section/panel-section', () =>
+  jest.fn(({ children }: PanelSectionProps) => <section>{children}</section>)
+);
+jest.mock('@/components/error-panel/error-panel', () =>
+  jest.fn(({ message, reset }: ErrorPanelProps) => (
+    <div>
+      {message}
+      {reset && <button onClick={reset}>Retry</button>}
+    </div>
+  ))
+);
+describe(ScheduleRuns.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('queries the schedule and renders only the first page as JSON', () => {
+    const scheduleId = String.raw`schedule"\id`;
+    setup({ scheduleId });
+
+    expect(mockUseListWorkflows).toHaveBeenCalledWith({
+      domain: 'test-domain',
+      cluster: 'test-cluster',
+      listType: 'default',
+      pageSize: 20,
+      inputType: 'query',
+      query: String.raw`CadenceScheduleID = "schedule\"\\id"`,
+    });
+    expect(screen.getByText(/first-page-workflow/)).toBeInTheDocument();
+    expect(screen.queryByText(/second-page-workflow/)).not.toBeInTheDocument();
+  });
+
+  it('renders the initial loading state', () => {
+    setup({ hookResult: { data: undefined, isLoading: true } });
+
+    expect(screen.getByText('Loading schedule runs')).toBeInTheDocument();
+  });
+
+  it('renders a retryable request error', async () => {
+    const user = userEvent.setup();
+    setup({
+      hookResult: {
+        data: undefined,
+        error: new RequestError('Request failed', '/workflows', 500),
+      },
+    });
+
+    expect(
+      screen.getByText('Failed to load schedule runs')
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders an empty state when the first page has no runs', () => {
+    setup({
+      hookResult: {
+        data: {
+          pages: [{ workflows: [], nextPage: '' }],
+          pageParams: [undefined],
+        },
+      },
+    });
+
+    expect(screen.getByText('No schedule runs found')).toBeInTheDocument();
+  });
+});
+
+type HookResult = ReturnType<typeof useListWorkflows>;
+
+function setup({
+  scheduleId = 'test-schedule',
+  hookResult = {},
+}: {
+  scheduleId?: string;
+  hookResult?: Partial<HookResult>;
+} = {}) {
+  mockUseListWorkflows.mockReturnValue({
+    data: {
+      pages: [
+        {
+          workflows: [
+            getMockWorkflowListItem({ workflowID: 'first-page-workflow' }),
+          ],
+          nextPage: 'next-page',
+        },
+        {
+          workflows: [
+            getMockWorkflowListItem({ workflowID: 'second-page-workflow' }),
+          ],
+          nextPage: '',
+        },
+      ],
+      pageParams: [undefined, 'next-page'],
+    },
+    error: null,
+    isLoading: false,
+    refetch: mockRefetch,
+    ...hookResult,
+  } as unknown as HookResult);
+
+  render(
+    <ScheduleRuns
+      params={{
+        domain: 'test-domain',
+        cluster: 'test-cluster',
+        scheduleId,
+        scheduleTab: 'runs',
+      }}
+    />
+  );
+}

--- a/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
+++ b/src/views/schedule-runs/__tests__/schedule-runs.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, userEvent } from '@/test-utils/rtl';
 
+import { type DateFilterValue } from '@/components/date-filter/date-filter.types';
 import { type Props as ErrorPanelProps } from '@/components/error-panel/error-panel.types';
 import { type Props as PanelSectionProps } from '@/components/panel-section/panel-section.types';
+import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
 import { getMockWorkflowListItem } from '@/route-handlers/list-workflows/__fixtures__/mock-workflow-list-items';
 import { RequestError } from '@/utils/request/request-error';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
@@ -10,8 +12,10 @@ import ScheduleRuns from '../schedule-runs';
 import { type Props as ScheduleRunsTableProps } from '../schedule-runs-table.types';
 
 const mockRefetch = jest.fn();
+const mockUsePageQueryParams = jest.mocked(usePageQueryParams);
 const mockUseListWorkflows = jest.mocked(useListWorkflows);
 
+jest.mock('@/hooks/use-page-query-params/use-page-query-params');
 jest.mock('@/views/shared/hooks/use-list-workflows');
 jest.mock(
   '@/components/section-loading-indicator/section-loading-indicator',
@@ -33,6 +37,9 @@ jest.mock('../schedule-runs-table', () =>
     <div>{workflows.map(({ workflowID }) => workflowID).join(',')}</div>
   ))
 );
+jest.mock('../schedule-runs-header', () =>
+  jest.fn(() => <div>Schedule run filters</div>)
+);
 describe(ScheduleRuns.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -42,16 +49,31 @@ describe(ScheduleRuns.name, () => {
     const scheduleId = String.raw`schedule"\id`;
     setup({ scheduleId });
 
-    expect(mockUseListWorkflows).toHaveBeenCalledWith({
-      domain: 'test-domain',
-      cluster: 'test-cluster',
-      listType: 'default',
-      pageSize: 20,
-      inputType: 'query',
-      query: String.raw`CadenceScheduleID = "schedule\"\\id"`,
-    });
+    expect(mockUseListWorkflows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: expect.stringContaining(
+          String.raw`CadenceScheduleID = "schedule\"\\id"`
+        ),
+      })
+    );
     expect(screen.getByText(/first-page-workflow/)).toBeInTheDocument();
     expect(screen.getByText(/second-page-workflow/)).toBeInTheDocument();
+  });
+
+  it('queries the selected Schedule time range', () => {
+    setup({
+      timeStart: new Date('2026-07-12T10:00:00Z'),
+      timeEnd: new Date('2026-07-19T10:00:00Z'),
+    });
+
+    expect(mockUseListWorkflows).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query:
+          'CadenceScheduleID = "test-schedule" AND ' +
+          'CadenceScheduleTime > "2026-07-12T10:00:00.000Z" AND ' +
+          'CadenceScheduleTime <= "2026-07-19T10:00:00.000Z"',
+      })
+    );
   });
 
   it('renders the initial loading state', () => {
@@ -65,6 +87,7 @@ describe(ScheduleRuns.name, () => {
     setup({
       hookResult: {
         data: undefined,
+        workflows: [],
         error: new RequestError('Request failed', '/workflows', 500),
       },
     });
@@ -85,17 +108,38 @@ describe(ScheduleRuns.name, () => {
 
     expect(screen.getByText('No schedule runs found')).toBeInTheDocument();
   });
+
+  it('distinguishes filtered no-results', () => {
+    setup({
+      timeStart: new Date('2026-07-12T10:00:00Z'),
+      hookResult: { workflows: [] },
+    });
+    expect(
+      screen.getByText('No schedule runs match your filters')
+    ).toBeInTheDocument();
+  });
 });
 
 type HookResult = ReturnType<typeof useListWorkflows>;
 
 function setup({
   scheduleId = 'test-schedule',
+  timeStart = 'now-7d',
+  timeEnd = 'now',
   hookResult = {},
 }: {
   scheduleId?: string;
+  timeStart?: DateFilterValue;
+  timeEnd?: DateFilterValue;
   hookResult?: Partial<HookResult>;
 } = {}) {
+  mockUsePageQueryParams.mockReturnValue([
+    {
+      scheduleRunsTimeStart: timeStart,
+      scheduleRunsTimeEnd: timeEnd,
+    },
+    jest.fn(),
+  ]);
   const workflows = [
     getMockWorkflowListItem({ workflowID: 'first-page-workflow' }),
     getMockWorkflowListItem({ workflowID: 'second-page-workflow' }),
@@ -121,6 +165,7 @@ function setup({
     hasNextPage: false,
     fetchNextPage: jest.fn(),
     isFetchingNextPage: false,
+    isFetching: false,
     ...hookResult,
   } as unknown as HookResult);
 

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -4,12 +4,11 @@ import DateFilter from '@/components/date-filter/date-filter';
 import { type DateFilterValue } from '@/components/date-filter/date-filter.types';
 import stringifyDateFilterValue from '@/components/date-filter/helpers/stringify-date-filter-value';
 import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
-
-import type scheduleRunsQueryParamsConfig from './schedule-runs-query-params.config';
+import type schedulePageQueryParamsConfig from '@/views/schedule-page/config/schedule-page-query-params.config';
 
 const scheduleRunsFiltersConfig: [
   PageFilterConfig<
-    typeof scheduleRunsQueryParamsConfig,
+    typeof schedulePageQueryParamsConfig,
     {
       scheduleRunsTimeStart: DateFilterValue;
       scheduleRunsTimeEnd: DateFilterValue;

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -6,12 +6,11 @@ import stringifyDateFilterValue from '@/components/date-filter/helpers/stringify
 import ListFilter from '@/components/list-filter/list-filter';
 import MultiSelectFilter from '@/components/multi-select-filter/multi-select-filter';
 import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
+import type schedulePageQueryParamsConfig from '@/views/schedule-page/config/schedule-page-query-params.config';
 import { WORKFLOW_STATUS_NAMES } from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
 import { type ScheduleRunsRunType } from '../schedule-runs.types';
-
-import type scheduleRunsQueryParamsConfig from './schedule-runs-query-params.config';
 
 const RUN_TYPE_LABELS: Record<ScheduleRunsRunType, string> = {
   all: 'All runs',
@@ -21,18 +20,18 @@ const RUN_TYPE_LABELS: Record<ScheduleRunsRunType, string> = {
 
 const scheduleRunsFiltersConfig: [
   PageFilterConfig<
-    typeof scheduleRunsQueryParamsConfig,
+    typeof schedulePageQueryParamsConfig,
     { scheduleRunsStatuses: Array<WorkflowStatus> | undefined }
   >,
   PageFilterConfig<
-    typeof scheduleRunsQueryParamsConfig,
+    typeof schedulePageQueryParamsConfig,
     {
       scheduleRunsTimeStart: DateFilterValue;
       scheduleRunsTimeEnd: DateFilterValue;
     }
   >,
   PageFilterConfig<
-    typeof scheduleRunsQueryParamsConfig,
+    typeof schedulePageQueryParamsConfig,
     { scheduleRunsRunType: ScheduleRunsRunType }
   >,
 ] = [

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -14,8 +14,8 @@ import { type ScheduleRunsRunType } from '../schedule-runs.types';
 
 const RUN_TYPE_LABELS: Record<ScheduleRunsRunType, string> = {
   all: 'All',
-  backfill: 'Backfill runs',
-  regular: 'Regular runs',
+  backfill: 'Backfill',
+  regular: 'Regular',
 };
 
 const scheduleRunsFiltersConfig: [

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -10,8 +10,8 @@ const scheduleRunsFiltersConfig: [
   PageFilterConfig<
     typeof schedulePageQueryParamsConfig,
     {
-      scheduleRunsTimeStart: DateFilterValue;
-      scheduleRunsTimeEnd: DateFilterValue;
+      scheduleRunsTimeStart: DateFilterValue | undefined;
+      scheduleRunsTimeEnd: DateFilterValue | undefined;
     }
   >,
 ] = [
@@ -22,10 +22,12 @@ const scheduleRunsFiltersConfig: [
       scheduleRunsTimeEnd: value.scheduleRunsTimeEnd,
     }),
     formatValue: (value) => ({
-      scheduleRunsTimeStart: stringifyDateFilterValue(
-        value.scheduleRunsTimeStart
-      ),
-      scheduleRunsTimeEnd: stringifyDateFilterValue(value.scheduleRunsTimeEnd),
+      scheduleRunsTimeStart: value.scheduleRunsTimeStart
+        ? stringifyDateFilterValue(value.scheduleRunsTimeStart)
+        : undefined,
+      scheduleRunsTimeEnd: value.scheduleRunsTimeEnd
+        ? stringifyDateFilterValue(value.scheduleRunsTimeEnd)
+        : undefined,
     }),
     component: ({ value, setValue }) =>
       createElement(DateFilter, {
@@ -37,8 +39,8 @@ const scheduleRunsFiltersConfig: [
         },
         onChangeDates: ({ start, end }) =>
           setValue({
-            scheduleRunsTimeStart: start ?? 'now-7d',
-            scheduleRunsTimeEnd: end ?? 'now',
+            scheduleRunsTimeStart: start,
+            scheduleRunsTimeEnd: end,
           }),
       }),
   },

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -1,0 +1,48 @@
+import { createElement } from 'react';
+
+import DateFilter from '@/components/date-filter/date-filter';
+import { type DateFilterValue } from '@/components/date-filter/date-filter.types';
+import stringifyDateFilterValue from '@/components/date-filter/helpers/stringify-date-filter-value';
+import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
+
+import type scheduleRunsQueryParamsConfig from './schedule-runs-query-params.config';
+
+const scheduleRunsFiltersConfig: [
+  PageFilterConfig<
+    typeof scheduleRunsQueryParamsConfig,
+    {
+      scheduleRunsTimeStart: DateFilterValue;
+      scheduleRunsTimeEnd: DateFilterValue;
+    }
+  >,
+] = [
+  {
+    id: 'schedule-time',
+    getValue: (value) => ({
+      scheduleRunsTimeStart: value.scheduleRunsTimeStart,
+      scheduleRunsTimeEnd: value.scheduleRunsTimeEnd,
+    }),
+    formatValue: (value) => ({
+      scheduleRunsTimeStart: stringifyDateFilterValue(
+        value.scheduleRunsTimeStart
+      ),
+      scheduleRunsTimeEnd: stringifyDateFilterValue(value.scheduleRunsTimeEnd),
+    }),
+    component: ({ value, setValue }) =>
+      createElement(DateFilter, {
+        label: 'Schedule time',
+        placeholder: 'Select schedule time',
+        dates: {
+          start: value.scheduleRunsTimeStart,
+          end: value.scheduleRunsTimeEnd,
+        },
+        onChangeDates: ({ start, end }) =>
+          setValue({
+            scheduleRunsTimeStart: start ?? 'now-7d',
+            scheduleRunsTimeEnd: end ?? 'now',
+          }),
+      }),
+  },
+] as const;
+
+export default scheduleRunsFiltersConfig;

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -5,18 +5,17 @@ import { type DateFilterValue } from '@/components/date-filter/date-filter.types
 import stringifyDateFilterValue from '@/components/date-filter/helpers/stringify-date-filter-value';
 import MultiSelectFilter from '@/components/multi-select-filter/multi-select-filter';
 import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
+import type schedulePageQueryParamsConfig from '@/views/schedule-page/config/schedule-page-query-params.config';
 import { WORKFLOW_STATUS_NAMES } from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
-import type scheduleRunsQueryParamsConfig from './schedule-runs-query-params.config';
-
 const scheduleRunsFiltersConfig: [
   PageFilterConfig<
-    typeof scheduleRunsQueryParamsConfig,
+    typeof schedulePageQueryParamsConfig,
     { scheduleRunsStatuses: Array<WorkflowStatus> | undefined }
   >,
   PageFilterConfig<
-    typeof scheduleRunsQueryParamsConfig,
+    typeof schedulePageQueryParamsConfig,
     {
       scheduleRunsTimeStart: DateFilterValue;
       scheduleRunsTimeEnd: DateFilterValue;

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -3,12 +3,21 @@ import { createElement } from 'react';
 import DateFilter from '@/components/date-filter/date-filter';
 import { type DateFilterValue } from '@/components/date-filter/date-filter.types';
 import stringifyDateFilterValue from '@/components/date-filter/helpers/stringify-date-filter-value';
+import ListFilter from '@/components/list-filter/list-filter';
 import MultiSelectFilter from '@/components/multi-select-filter/multi-select-filter';
 import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
 import { WORKFLOW_STATUS_NAMES } from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
+import { type ScheduleRunsRunType } from '../schedule-runs.types';
+
 import type scheduleRunsQueryParamsConfig from './schedule-runs-query-params.config';
+
+const RUN_TYPE_LABELS: Record<ScheduleRunsRunType, string> = {
+  all: 'All runs',
+  backfill: 'Backfill runs',
+  regular: 'Regular runs',
+};
 
 const scheduleRunsFiltersConfig: [
   PageFilterConfig<
@@ -21,6 +30,10 @@ const scheduleRunsFiltersConfig: [
       scheduleRunsTimeStart: DateFilterValue;
       scheduleRunsTimeEnd: DateFilterValue;
     }
+  >,
+  PageFilterConfig<
+    typeof scheduleRunsQueryParamsConfig,
+    { scheduleRunsRunType: ScheduleRunsRunType }
   >,
 ] = [
   {
@@ -66,6 +79,22 @@ const scheduleRunsFiltersConfig: [
             scheduleRunsTimeStart: start ?? 'now-7d',
             scheduleRunsTimeEnd: end ?? 'now',
           }),
+      }),
+  },
+  {
+    id: 'run-type',
+    getValue: (value) => ({
+      scheduleRunsRunType: value.scheduleRunsRunType,
+    }),
+    formatValue: (value) => value,
+    component: ({ value, setValue }) =>
+      createElement(ListFilter<ScheduleRunsRunType>, {
+        label: 'Run type',
+        placeholder: 'All runs',
+        value: value.scheduleRunsRunType,
+        onChangeValue: (runType) =>
+          setValue({ scheduleRunsRunType: runType ?? 'all' }),
+        labelMap: RUN_TYPE_LABELS,
       }),
   },
 ] as const;

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -3,11 +3,18 @@ import { createElement } from 'react';
 import DateFilter from '@/components/date-filter/date-filter';
 import { type DateFilterValue } from '@/components/date-filter/date-filter.types';
 import stringifyDateFilterValue from '@/components/date-filter/helpers/stringify-date-filter-value';
+import MultiSelectFilter from '@/components/multi-select-filter/multi-select-filter';
 import { type PageFilterConfig } from '@/components/page-filters/page-filters.types';
+import { WORKFLOW_STATUS_NAMES } from '@/views/shared/workflow-status-tag/workflow-status-tag.constants';
+import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
 import type scheduleRunsQueryParamsConfig from './schedule-runs-query-params.config';
 
 const scheduleRunsFiltersConfig: [
+  PageFilterConfig<
+    typeof scheduleRunsQueryParamsConfig,
+    { scheduleRunsStatuses: Array<WorkflowStatus> | undefined }
+  >,
   PageFilterConfig<
     typeof scheduleRunsQueryParamsConfig,
     {
@@ -16,6 +23,24 @@ const scheduleRunsFiltersConfig: [
     }
   >,
 ] = [
+  {
+    id: 'statuses',
+    getValue: (value) => ({
+      scheduleRunsStatuses: value.scheduleRunsStatuses,
+    }),
+    formatValue: (value) => value,
+    component: ({ value, setValue }) =>
+      createElement(MultiSelectFilter<WorkflowStatus>, {
+        label: 'Workflow status',
+        placeholder: 'Show all statuses',
+        values: value.scheduleRunsStatuses ?? [],
+        onChangeValues: (statuses) =>
+          setValue({
+            scheduleRunsStatuses: statuses.length ? statuses : undefined,
+          }),
+        optionsLabelMap: WORKFLOW_STATUS_NAMES,
+      }),
+  },
   {
     id: 'schedule-time',
     getValue: (value) => ({

--- a/src/views/schedule-runs/config/schedule-runs-filters.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-filters.config.ts
@@ -13,7 +13,7 @@ import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow
 import { type ScheduleRunsRunType } from '../schedule-runs.types';
 
 const RUN_TYPE_LABELS: Record<ScheduleRunsRunType, string> = {
-  all: 'All runs',
+  all: 'All',
   backfill: 'Backfill runs',
   regular: 'Regular runs',
 };
@@ -96,6 +96,7 @@ const scheduleRunsFiltersConfig: [
         onChangeValue: (runType) =>
           setValue({ scheduleRunsRunType: runType ?? 'all' }),
         labelMap: RUN_TYPE_LABELS,
+        clearable: false,
       }),
   },
 ] as const;

--- a/src/views/schedule-runs/config/schedule-runs-query-params.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-query-params.config.ts
@@ -1,0 +1,23 @@
+import { type DateFilterValue } from '@/components/date-filter/date-filter.types';
+import parseDateFilterValue from '@/components/date-filter/helpers/parse-date-filter-value';
+import { type PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
+
+const scheduleRunsQueryParamsConfig: [
+  PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,
+  PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue>,
+] = [
+  {
+    key: 'scheduleRunsTimeStart',
+    queryParamKey: 'runs-start',
+    defaultValue: 'now-7d',
+    parseValue: (value) => parseDateFilterValue(value) ?? 'now-7d',
+  },
+  {
+    key: 'scheduleRunsTimeEnd',
+    queryParamKey: 'runs-end',
+    defaultValue: 'now',
+    parseValue: (value) => parseDateFilterValue(value) ?? 'now',
+  },
+] as const;
+
+export default scheduleRunsQueryParamsConfig;

--- a/src/views/schedule-runs/config/schedule-runs-query-params.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-query-params.config.ts
@@ -1,10 +1,19 @@
 import { type DateFilterValue } from '@/components/date-filter/date-filter.types';
 import parseDateFilterValue from '@/components/date-filter/helpers/parse-date-filter-value';
-import { type PageQueryParam } from '@/hooks/use-page-query-params/use-page-query-params.types';
+import {
+  type PageQueryParamMultiValue,
+  type PageQueryParam,
+} from '@/hooks/use-page-query-params/use-page-query-params.types';
+import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
+import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
 const scheduleRunsQueryParamsConfig: [
   PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,
   PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue>,
+  PageQueryParamMultiValue<
+    'scheduleRunsStatuses',
+    Array<WorkflowStatus> | undefined
+  >,
 ] = [
   {
     key: 'scheduleRunsTimeStart',
@@ -17,6 +26,13 @@ const scheduleRunsQueryParamsConfig: [
     queryParamKey: 'runs-end',
     defaultValue: 'now',
     parseValue: (value) => parseDateFilterValue(value) ?? 'now',
+  },
+  {
+    key: 'scheduleRunsStatuses',
+    queryParamKey: 'runs-status',
+    isMultiValue: true,
+    parseValue: (values) =>
+      values.every(isWorkflowStatus) ? values : undefined,
   },
 ] as const;
 

--- a/src/views/schedule-runs/config/schedule-runs-query-params.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-query-params.config.ts
@@ -7,6 +7,8 @@ import {
 import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
+import { type ScheduleRunsRunType } from '../schedule-runs.types';
+
 const scheduleRunsQueryParamsConfig: [
   PageQueryParam<'scheduleRunsTimeStart', DateFilterValue>,
   PageQueryParam<'scheduleRunsTimeEnd', DateFilterValue>,
@@ -14,6 +16,7 @@ const scheduleRunsQueryParamsConfig: [
     'scheduleRunsStatuses',
     Array<WorkflowStatus> | undefined
   >,
+  PageQueryParam<'scheduleRunsRunType', ScheduleRunsRunType>,
 ] = [
   {
     key: 'scheduleRunsTimeStart',
@@ -33,6 +36,13 @@ const scheduleRunsQueryParamsConfig: [
     isMultiValue: true,
     parseValue: (values) =>
       values.every(isWorkflowStatus) ? values : undefined,
+  },
+  {
+    key: 'scheduleRunsRunType',
+    queryParamKey: 'runs-type',
+    defaultValue: 'all',
+    parseValue: (value) =>
+      value === 'backfill' || value === 'regular' ? value : 'all',
   },
 ] as const;
 

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -11,6 +11,18 @@ export default function getScheduleRunsTableConfig(
 ): TableConfig<WorkflowListItem> {
   return [
     {
+      name: 'Workflow ID',
+      id: 'WorkflowID',
+      renderCell: (row: WorkflowListItem) => row.workflowID,
+      width: '20%',
+    },
+    {
+      name: 'Status',
+      id: 'CloseStatus',
+      renderCell: (row: WorkflowListItem) => row.status,
+      width: '10%',
+    },
+    {
       name: 'Run ID',
       id: 'RunID',
       renderCell: (row: WorkflowListItem) =>
@@ -21,12 +33,6 @@ export default function getScheduleRunsTableConfig(
           },
           row.runID
         ),
-      width: '20%',
-    },
-    {
-      name: 'Workflow ID',
-      id: 'WorkflowID',
-      renderCell: (row: WorkflowListItem) => row.workflowID,
       width: '20%',
     },
     {
@@ -51,12 +57,6 @@ export default function getScheduleRunsTableConfig(
       renderCell: (row: WorkflowListItem) =>
         `${row.startTime} → ${row.closeTime ?? 'Running'}`,
       width: '23%',
-    },
-    {
-      name: 'Status',
-      id: 'CloseStatus',
-      renderCell: (row: WorkflowListItem) => row.status,
-      width: '10%',
     },
   ];
 }

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -5,6 +5,8 @@ import { type TableConfig } from '@/components/table/table.types';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 import getSearchAttributeValue from '@/views/shared/workflows-list/helpers/get-search-attribute-value';
 
+import ScheduleRunsStatusCell from '../schedule-runs-status-cell';
+
 export default function getScheduleRunsTableConfig(
   domain: string,
   cluster: string
@@ -19,7 +21,7 @@ export default function getScheduleRunsTableConfig(
     {
       name: 'Status',
       id: 'CloseStatus',
-      renderCell: (row: WorkflowListItem) => row.status,
+      renderCell: ScheduleRunsStatusCell,
       width: '10%',
     },
     {

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -5,6 +5,8 @@ import { type TableConfig } from '@/components/table/table.types';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 import getSearchAttributeValue from '@/views/shared/workflows-list/helpers/get-search-attribute-value';
 
+import ScheduleRunsRuntimeCell from '../schedule-runs-runtime-cell';
+
 export default function getScheduleRunsTableConfig(
   domain: string,
   cluster: string
@@ -48,8 +50,7 @@ export default function getScheduleRunsTableConfig(
     {
       name: 'Run time (Start/Close)',
       id: 'RunTime',
-      renderCell: (row: WorkflowListItem) =>
-        `${row.startTime} → ${row.closeTime ?? 'Running'}`,
+      renderCell: ScheduleRunsRuntimeCell,
       width: '23%',
     },
     {

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -1,0 +1,62 @@
+import { createElement } from 'react';
+
+import Link from '@/components/link/link';
+import { type TableConfig } from '@/components/table/table.types';
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+import getSearchAttributeValue from '@/views/shared/workflows-list/helpers/get-search-attribute-value';
+
+export default function getScheduleRunsTableConfig(
+  domain: string,
+  cluster: string
+): TableConfig<WorkflowListItem> {
+  return [
+    {
+      name: 'Run ID',
+      id: 'RunID',
+      renderCell: (row: WorkflowListItem) =>
+        createElement(
+          Link,
+          {
+            href: `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows/${encodeURIComponent(row.workflowID)}/${encodeURIComponent(row.runID)}`,
+          },
+          row.runID
+        ),
+      width: '20%',
+    },
+    {
+      name: 'Workflow ID',
+      id: 'WorkflowID',
+      renderCell: (row: WorkflowListItem) => row.workflowID,
+      width: '20%',
+    },
+    {
+      name: 'Backfill',
+      id: 'CadenceScheduleIsBackfill',
+      renderCell: (row: WorkflowListItem) =>
+        String(
+          getSearchAttributeValue(row, 'CadenceScheduleIsBackfill') ?? '-'
+        ),
+      width: '10%',
+    },
+    {
+      name: 'Schedule time',
+      id: 'CadenceScheduleTime',
+      renderCell: (row: WorkflowListItem) =>
+        String(getSearchAttributeValue(row, 'CadenceScheduleTime') ?? '-'),
+      width: '17%',
+    },
+    {
+      name: 'Run time (Start/Close)',
+      id: 'RunTime',
+      renderCell: (row: WorkflowListItem) =>
+        `${row.startTime} → ${row.closeTime ?? 'Running'}`,
+      width: '23%',
+    },
+    {
+      name: 'Status',
+      id: 'CloseStatus',
+      renderCell: (row: WorkflowListItem) => row.status,
+      width: '10%',
+    },
+  ];
+}

--- a/src/views/schedule-runs/config/schedule-runs-table.config.ts
+++ b/src/views/schedule-runs/config/schedule-runs-table.config.ts
@@ -5,6 +5,7 @@ import { type TableConfig } from '@/components/table/table.types';
 import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
 import getSearchAttributeValue from '@/views/shared/workflows-list/helpers/get-search-attribute-value';
 
+import ScheduleRunsRuntimeCell from '../schedule-runs-runtime-cell';
 import ScheduleRunsStatusCell from '../schedule-runs-status-cell';
 
 export default function getScheduleRunsTableConfig(
@@ -56,8 +57,7 @@ export default function getScheduleRunsTableConfig(
     {
       name: 'Run time (Start/Close)',
       id: 'RunTime',
-      renderCell: (row: WorkflowListItem) =>
-        `${row.startTime} → ${row.closeTime ?? 'Running'}`,
+      renderCell: ScheduleRunsRuntimeCell,
       width: '23%',
     },
   ];

--- a/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
+++ b/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
@@ -2,12 +2,15 @@ import escapeVisibilityQueryValue from '@/utils/visibility/escape-visibility-que
 import getVisibilityQuery from '@/utils/visibility/get-visibility-query';
 import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
+import { type ScheduleRunsRunType } from '../schedule-runs.types';
+
 export default function getScheduleRunsQuery(
   scheduleId: string,
   filters?: {
     timeRangeStart?: string;
     timeRangeEnd?: string;
     statuses?: Array<WorkflowStatus>;
+    runType?: ScheduleRunsRunType;
   }
 ): string {
   const clauses = [
@@ -24,6 +27,11 @@ export default function getScheduleRunsQuery(
   }
   if (filters?.timeRangeEnd) {
     clauses.push(`CadenceScheduleTime <= "${filters.timeRangeEnd}"`);
+  }
+  if (filters?.runType !== undefined && filters.runType !== 'all') {
+    clauses.push(
+      `CadenceScheduleIsBackfill = ${filters.runType === 'backfill'}`
+    );
   }
   return clauses.join(' AND ');
 }

--- a/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
+++ b/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
@@ -1,5 +1,20 @@
 import escapeVisibilityQueryValue from '@/utils/visibility/escape-visibility-query-value';
 
-export default function getScheduleRunsQuery(scheduleId: string): string {
-  return `CadenceScheduleID = "${escapeVisibilityQueryValue(scheduleId)}"`;
+export default function getScheduleRunsQuery(
+  scheduleId: string,
+  filters?: {
+    timeRangeStart?: string;
+    timeRangeEnd?: string;
+  }
+): string {
+  const clauses = [
+    `CadenceScheduleID = "${escapeVisibilityQueryValue(scheduleId)}"`,
+  ];
+  if (filters?.timeRangeStart) {
+    clauses.push(`CadenceScheduleTime > "${filters.timeRangeStart}"`);
+  }
+  if (filters?.timeRangeEnd) {
+    clauses.push(`CadenceScheduleTime <= "${filters.timeRangeEnd}"`);
+  }
+  return clauses.join(' AND ');
 }

--- a/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
+++ b/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
@@ -1,0 +1,5 @@
+import escapeVisibilityQueryValue from '@/utils/visibility/escape-visibility-query-value';
+
+export default function getScheduleRunsQuery(scheduleId: string): string {
+  return `CadenceScheduleID = "${escapeVisibilityQueryValue(scheduleId)}"`;
+}

--- a/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
+++ b/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
@@ -30,7 +30,7 @@ export default function getScheduleRunsQuery(
   }
   if (filters?.runType !== undefined && filters.runType !== 'all') {
     clauses.push(
-      `CadenceScheduleIsBackfill = ${filters.runType === 'backfill'}`
+      `CadenceScheduleIsBackfill = "${filters.runType === 'backfill'}"`
     );
   }
   return clauses.join(' AND ');

--- a/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
+++ b/src/views/schedule-runs/helpers/get-schedule-runs-query.ts
@@ -1,15 +1,24 @@
 import escapeVisibilityQueryValue from '@/utils/visibility/escape-visibility-query-value';
+import getVisibilityQuery from '@/utils/visibility/get-visibility-query';
+import { type WorkflowStatus } from '@/views/shared/workflow-status-tag/workflow-status-tag.types';
 
 export default function getScheduleRunsQuery(
   scheduleId: string,
   filters?: {
     timeRangeStart?: string;
     timeRangeEnd?: string;
+    statuses?: Array<WorkflowStatus>;
   }
 ): string {
   const clauses = [
     `CadenceScheduleID = "${escapeVisibilityQueryValue(scheduleId)}"`,
   ];
+  const statusQuery = getVisibilityQuery({
+    workflowStatuses: filters?.statuses,
+    timeColumn: 'StartTime',
+    includeOrderBy: false,
+  });
+  if (statusQuery) clauses.push(statusQuery);
   if (filters?.timeRangeStart) {
     clauses.push(`CadenceScheduleTime > "${filters.timeRangeStart}"`);
   }

--- a/src/views/schedule-runs/schedule-runs-header.tsx
+++ b/src/views/schedule-runs/schedule-runs-header.tsx
@@ -3,16 +3,16 @@ import { useState } from 'react';
 import usePageFilters from '@/components/page-filters/hooks/use-page-filters';
 import PageFiltersFields from '@/components/page-filters/page-filters-fields/page-filters-fields';
 import PageFiltersToggle from '@/components/page-filters/page-filters-toggle/page-filters-toggle';
+import schedulePageQueryParamsConfig from '@/views/schedule-page/config/schedule-page-query-params.config';
 
 import scheduleRunsFiltersConfig from './config/schedule-runs-filters.config';
-import scheduleRunsQueryParamsConfig from './config/schedule-runs-query-params.config';
 
 export default function ScheduleRunsHeader() {
   const [areFiltersShown, setAreFiltersShown] = useState(false);
   const { resetAllFilters, activeFiltersCount, queryParams, setQueryParams } =
     usePageFilters({
       pageFiltersConfig: scheduleRunsFiltersConfig,
-      pageQueryParamsConfig: scheduleRunsQueryParamsConfig,
+      pageQueryParamsConfig: schedulePageQueryParamsConfig,
     });
 
   return (

--- a/src/views/schedule-runs/schedule-runs-header.tsx
+++ b/src/views/schedule-runs/schedule-runs-header.tsx
@@ -1,0 +1,35 @@
+import { useState } from 'react';
+
+import usePageFilters from '@/components/page-filters/hooks/use-page-filters';
+import PageFiltersFields from '@/components/page-filters/page-filters-fields/page-filters-fields';
+import PageFiltersToggle from '@/components/page-filters/page-filters-toggle/page-filters-toggle';
+
+import scheduleRunsFiltersConfig from './config/schedule-runs-filters.config';
+import scheduleRunsQueryParamsConfig from './config/schedule-runs-query-params.config';
+
+export default function ScheduleRunsHeader() {
+  const [areFiltersShown, setAreFiltersShown] = useState(false);
+  const { resetAllFilters, activeFiltersCount, queryParams, setQueryParams } =
+    usePageFilters({
+      pageFiltersConfig: scheduleRunsFiltersConfig,
+      pageQueryParamsConfig: scheduleRunsQueryParamsConfig,
+    });
+
+  return (
+    <>
+      <PageFiltersToggle
+        isActive={areFiltersShown || activeFiltersCount > 0}
+        onClick={() => setAreFiltersShown((value) => !value)}
+        activeFiltersCount={activeFiltersCount}
+      />
+      {areFiltersShown && (
+        <PageFiltersFields
+          pageFiltersConfig={scheduleRunsFiltersConfig}
+          resetAllFilters={resetAllFilters}
+          queryParams={queryParams}
+          setQueryParams={setQueryParams}
+        />
+      )}
+    </>
+  );
+}

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
@@ -1,0 +1,13 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  Container: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      alignItems: 'center',
+      display: 'flex',
+      gap: $theme.sizing.scale200,
+    })
+  ),
+};

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
@@ -10,9 +10,19 @@ const cssStylesObj = {
     display: 'flex',
     gap: theme.sizing.scale400,
     alignItems: 'center',
+    whiteSpace: 'nowrap',
+  }),
+  dateContainer: () => ({
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
+  }),
+  arrowIcon: () => ({
+    flexShrink: 0,
   }),
   missingDateContainer: (theme: Theme) => ({
     color: theme.colors.contentSecondary,
+    flexShrink: 0,
+    whiteSpace: 'nowrap',
   }),
 } satisfies StyletronCSSObject;
 

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.styles.ts
@@ -1,13 +1,20 @@
-import { styled as createStyled, type Theme } from 'baseui';
-import { type StyleObject } from 'styletron-react';
+import { type Theme } from 'baseui';
 
-export const styled = {
-  Container: createStyled(
-    'div',
-    ({ $theme }: { $theme: Theme }): StyleObject => ({
-      alignItems: 'center',
-      display: 'flex',
-      gap: $theme.sizing.scale200,
-    })
-  ),
-};
+import type {
+  StyletronCSSObject,
+  StyletronCSSObjectOf,
+} from '@/hooks/use-styletron-classes';
+
+const cssStylesObj = {
+  runtimeContainer: (theme: Theme) => ({
+    display: 'flex',
+    gap: theme.sizing.scale400,
+    alignItems: 'center',
+  }),
+  missingDateContainer: (theme: Theme) => ({
+    color: theme.colors.contentSecondary,
+  }),
+} satisfies StyletronCSSObject;
+
+export const cssStyles: StyletronCSSObjectOf<typeof cssStylesObj> =
+  cssStylesObj;

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
@@ -1,0 +1,18 @@
+import FormattedDate from '@/components/formatted-date/formatted-date';
+
+import { styled } from './schedule-runs-runtime-cell.styles';
+import { type Props } from './schedule-runs-runtime-cell.types';
+
+export default function ScheduleRunsRuntimeCell({
+  startTime,
+  closeTime,
+}: Props) {
+  if (!startTime) return '-';
+
+  return (
+    <styled.Container>
+      <FormattedDate timestampMs={startTime} /> →
+      {closeTime ? <FormattedDate timestampMs={closeTime} /> : 'Running…'}
+    </styled.Container>
+  );
+}

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
@@ -18,10 +18,18 @@ export default function ScheduleRunsRuntimeCell({
 
   return (
     <div className={cls.runtimeContainer}>
-      <FormattedDate timestampMs={startTime} />
-      <MdArrowForward color={theme.colors.contentSecondary} aria-hidden />
+      <div className={cls.dateContainer}>
+        <FormattedDate timestampMs={startTime} />
+      </div>
+      <MdArrowForward
+        className={cls.arrowIcon}
+        color={theme.colors.contentSecondary}
+        aria-hidden
+      />
       {closeTime ? (
-        <FormattedDate timestampMs={closeTime} />
+        <div className={cls.dateContainer}>
+          <FormattedDate timestampMs={closeTime} />
+        </div>
       ) : (
         <div className={cls.missingDateContainer}>Running…</div>
       )}

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
@@ -26,13 +26,9 @@ export default function ScheduleRunsRuntimeCell({
         color={theme.colors.contentSecondary}
         aria-hidden
       />
-      {closeTime ? (
-        <div className={cls.dateContainer}>
-          <FormattedDate timestampMs={closeTime} />
-        </div>
-      ) : (
-        <div className={cls.missingDateContainer}>Running…</div>
-      )}
+      <div className={cls.dateContainer}>
+        <FormattedDate timestampMs={closeTime} />
+      </div>
     </div>
   );
 }

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.tsx
@@ -1,18 +1,30 @@
-import FormattedDate from '@/components/formatted-date/formatted-date';
+import { MdArrowForward } from 'react-icons/md';
 
-import { styled } from './schedule-runs-runtime-cell.styles';
+import FormattedDate from '@/components/formatted-date/formatted-date';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import { cssStyles } from './schedule-runs-runtime-cell.styles';
 import { type Props } from './schedule-runs-runtime-cell.types';
 
 export default function ScheduleRunsRuntimeCell({
   startTime,
   closeTime,
 }: Props) {
-  if (!startTime) return '-';
+  const { cls, theme } = useStyletronClasses(cssStyles);
+
+  if (!startTime) {
+    return <div className={cls.missingDateContainer}>None</div>;
+  }
 
   return (
-    <styled.Container>
-      <FormattedDate timestampMs={startTime} /> →
-      {closeTime ? <FormattedDate timestampMs={closeTime} /> : 'Running…'}
-    </styled.Container>
+    <div className={cls.runtimeContainer}>
+      <FormattedDate timestampMs={startTime} />
+      <MdArrowForward color={theme.colors.contentSecondary} aria-hidden />
+      {closeTime ? (
+        <FormattedDate timestampMs={closeTime} />
+      ) : (
+        <div className={cls.missingDateContainer}>Running…</div>
+      )}
+    </div>
   );
 }

--- a/src/views/schedule-runs/schedule-runs-runtime-cell.types.ts
+++ b/src/views/schedule-runs/schedule-runs-runtime-cell.types.ts
@@ -1,0 +1,3 @@
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+export type Props = Pick<WorkflowListItem, 'startTime' | 'closeTime'>;

--- a/src/views/schedule-runs/schedule-runs-status-cell.tsx
+++ b/src/views/schedule-runs/schedule-runs-status-cell.tsx
@@ -1,0 +1,12 @@
+import isWorkflowStatus from '@/views/shared/workflow-status-tag/helpers/is-workflow-status';
+import WorkflowStatusTag from '@/views/shared/workflow-status-tag/workflow-status-tag';
+
+import { type Props } from './schedule-runs-status-cell.types';
+
+export default function ScheduleRunsStatusCell({ status }: Props) {
+  return isWorkflowStatus(status) ? (
+    <WorkflowStatusTag status={status} />
+  ) : (
+    'Unknown'
+  );
+}

--- a/src/views/schedule-runs/schedule-runs-status-cell.types.ts
+++ b/src/views/schedule-runs/schedule-runs-status-cell.types.ts
@@ -1,0 +1,3 @@
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+export type Props = Pick<WorkflowListItem, 'status'>;

--- a/src/views/schedule-runs/schedule-runs-table.tsx
+++ b/src/views/schedule-runs/schedule-runs-table.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Table from '@/components/table/table';
+
+import getScheduleRunsTableConfig from './config/schedule-runs-table.config';
+import { type Props } from './schedule-runs-table.types';
+
+export default function ScheduleRunsTable({
+  domain,
+  cluster,
+  workflows,
+  error,
+  hasNextPage,
+  fetchNextPage,
+  isFetchingNextPage,
+}: Props) {
+  return (
+    <Table
+      data={workflows}
+      columns={getScheduleRunsTableConfig(domain, cluster)}
+      shouldShowResults={workflows.length > 0}
+      endMessageProps={{
+        kind: 'infinite-scroll',
+        hasData: workflows.length > 0,
+        error,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+      }}
+    />
+  );
+}

--- a/src/views/schedule-runs/schedule-runs-table.types.ts
+++ b/src/views/schedule-runs/schedule-runs-table.types.ts
@@ -1,0 +1,11 @@
+import { type WorkflowListItem } from '@/route-handlers/list-workflows/list-workflows.types';
+
+export type Props = {
+  domain: string;
+  cluster: string;
+  workflows: Array<WorkflowListItem>;
+  error: Error | null;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+  isFetchingNextPage: boolean;
+};

--- a/src/views/schedule-runs/schedule-runs.styles.ts
+++ b/src/views/schedule-runs/schedule-runs.styles.ts
@@ -1,0 +1,13 @@
+import { styled as createStyled, type Theme } from 'baseui';
+import { type StyleObject } from 'styletron-react';
+
+export const styled = {
+  Root: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: $theme.sizing.scale900,
+    })
+  ),
+};

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -22,14 +22,18 @@ export default function ScheduleRuns({ params }: Props) {
   const timeRange = useMemo(() => {
     const now = dayjs();
     return {
-      timeRangeStart: getDayjsFromDateFilterValue(
-        queryParams.scheduleRunsTimeStart,
-        now
-      ).toISOString(),
-      timeRangeEnd: getDayjsFromDateFilterValue(
-        queryParams.scheduleRunsTimeEnd,
-        now
-      ).toISOString(),
+      timeRangeStart: queryParams.scheduleRunsTimeStart
+        ? getDayjsFromDateFilterValue(
+            queryParams.scheduleRunsTimeStart,
+            now
+          ).toISOString()
+        : undefined,
+      timeRangeEnd: queryParams.scheduleRunsTimeEnd
+        ? getDayjsFromDateFilterValue(
+            queryParams.scheduleRunsTimeEnd,
+            now
+          ).toISOString()
+        : undefined,
     };
   }, [queryParams.scheduleRunsTimeEnd, queryParams.scheduleRunsTimeStart]);
   const {
@@ -50,8 +54,7 @@ export default function ScheduleRuns({ params }: Props) {
     query: getScheduleRunsQuery(params.scheduleId, timeRange),
   });
   const hasActiveFilters = Boolean(
-    queryParams.scheduleRunsTimeStart !== 'now-7d' ||
-      queryParams.scheduleRunsTimeEnd !== 'now'
+    queryParams.scheduleRunsTimeStart || queryParams.scheduleRunsTimeEnd
   );
 
   if (isLoading) {

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -32,7 +32,7 @@ export default function ScheduleRuns({ params }: Props) {
     return <SectionLoadingIndicator />;
   }
 
-  if (error) {
+  if (error && workflows.length === 0) {
     return (
       <PanelSection>
         <ErrorPanel
@@ -41,14 +41,6 @@ export default function ScheduleRuns({ params }: Props) {
           reset={refetch}
           actions={[{ kind: 'retry', label: 'Retry' }]}
         />
-      </PanelSection>
-    );
-  }
-
-  if (workflows.length === 0) {
-    return (
-      <PanelSection>
-        <ErrorPanel message="No schedule runs found" omitLogging />
       </PanelSection>
     );
   }

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -1,15 +1,35 @@
 'use client';
+import { useMemo } from 'react';
 
+import getDayjsFromDateFilterValue from '@/components/date-filter/helpers/get-dayjs-from-date-filter-value';
 import ErrorPanel from '@/components/error-panel/error-panel';
 import PanelSection from '@/components/panel-section/panel-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
+import dayjs from '@/utils/datetime/dayjs';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 
+import scheduleRunsQueryParamsConfig from './config/schedule-runs-query-params.config';
 import getScheduleRunsQuery from './helpers/get-schedule-runs-query';
+import ScheduleRunsHeader from './schedule-runs-header';
 import ScheduleRunsTable from './schedule-runs-table';
 import { type Props } from './schedule-runs.types';
 
 export default function ScheduleRuns({ params }: Props) {
+  const [queryParams] = usePageQueryParams(scheduleRunsQueryParamsConfig);
+  const timeRange = useMemo(() => {
+    const now = dayjs();
+    return {
+      timeRangeStart: getDayjsFromDateFilterValue(
+        queryParams.scheduleRunsTimeStart,
+        now
+      ).toISOString(),
+      timeRangeEnd: getDayjsFromDateFilterValue(
+        queryParams.scheduleRunsTimeEnd,
+        now
+      ).toISOString(),
+    };
+  }, [queryParams.scheduleRunsTimeEnd, queryParams.scheduleRunsTimeStart]);
   const {
     workflows,
     error,
@@ -18,20 +38,24 @@ export default function ScheduleRuns({ params }: Props) {
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
+    isFetching,
   } = useListWorkflows({
     domain: params.domain,
     cluster: params.cluster,
     listType: 'default',
     pageSize: 20,
     inputType: 'query',
-    query: getScheduleRunsQuery(params.scheduleId),
+    query: getScheduleRunsQuery(params.scheduleId, timeRange),
   });
+  const hasActiveFilters = Boolean(
+    queryParams.scheduleRunsTimeStart !== 'now-7d' ||
+      queryParams.scheduleRunsTimeEnd !== 'now'
+  );
 
   if (isLoading) {
     return <SectionLoadingIndicator />;
   }
-
-  if (error) {
+  if (error && workflows.length === 0) {
     return (
       <PanelSection>
         <ErrorPanel
@@ -44,23 +68,33 @@ export default function ScheduleRuns({ params }: Props) {
     );
   }
 
-  if (workflows.length === 0) {
-    return (
-      <PanelSection>
-        <ErrorPanel message="No schedule runs found" omitLogging />
-      </PanelSection>
-    );
-  }
-
   return (
-    <ScheduleRunsTable
-      domain={params.domain}
-      cluster={params.cluster}
-      workflows={workflows}
-      error={error}
-      hasNextPage={hasNextPage}
-      fetchNextPage={fetchNextPage}
-      isFetchingNextPage={isFetchingNextPage}
-    />
+    <>
+      <ScheduleRunsHeader />
+      {workflows.length === 0 ? (
+        <PanelSection>
+          <ErrorPanel
+            message={
+              hasActiveFilters
+                ? 'No schedule runs match your filters'
+                : 'No schedule runs found'
+            }
+            omitLogging
+          />
+        </PanelSection>
+      ) : (
+        <ScheduleRunsTable
+          domain={params.domain}
+          cluster={params.cluster}
+          workflows={workflows}
+          error={error}
+          hasNextPage={hasNextPage}
+          fetchNextPage={fetchNextPage}
+          isFetchingNextPage={
+            isFetchingNextPage || (isFetching && workflows.length > 0)
+          }
+        />
+      )}
+    </>
   );
 }

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -6,10 +6,19 @@ import SectionLoadingIndicator from '@/components/section-loading-indicator/sect
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 
 import getScheduleRunsQuery from './helpers/get-schedule-runs-query';
+import ScheduleRunsTable from './schedule-runs-table';
 import { type Props } from './schedule-runs.types';
 
 export default function ScheduleRuns({ params }: Props) {
-  const { data, error, isLoading, refetch } = useListWorkflows({
+  const {
+    workflows,
+    error,
+    isLoading,
+    refetch,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useListWorkflows({
     domain: params.domain,
     cluster: params.cluster,
     listType: 'default',
@@ -17,7 +26,6 @@ export default function ScheduleRuns({ params }: Props) {
     inputType: 'query',
     query: getScheduleRunsQuery(params.scheduleId),
   });
-  const workflows = data?.pages[0]?.workflows ?? [];
 
   if (isLoading) {
     return <SectionLoadingIndicator />;
@@ -44,5 +52,15 @@ export default function ScheduleRuns({ params }: Props) {
     );
   }
 
-  return JSON.stringify(workflows);
+  return (
+    <ScheduleRunsTable
+      domain={params.domain}
+      cluster={params.cluster}
+      workflows={workflows}
+      error={error}
+      hasNextPage={hasNextPage}
+      fetchNextPage={fetchNextPage}
+      isFetchingNextPage={isFetchingNextPage}
+    />
+  );
 }

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+import PanelSection from '@/components/panel-section/panel-section';
+import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
+
+import getScheduleRunsQuery from './helpers/get-schedule-runs-query';
+import { type Props } from './schedule-runs.types';
+
+export default function ScheduleRuns({ params }: Props) {
+  const { data, error, isLoading, refetch } = useListWorkflows({
+    domain: params.domain,
+    cluster: params.cluster,
+    listType: 'default',
+    pageSize: 20,
+    inputType: 'query',
+    query: getScheduleRunsQuery(params.scheduleId),
+  });
+  const workflows = data?.pages[0]?.workflows ?? [];
+
+  if (isLoading) {
+    return <SectionLoadingIndicator />;
+  }
+
+  if (error) {
+    return (
+      <PanelSection>
+        <ErrorPanel
+          message="Failed to load schedule runs"
+          error={error}
+          reset={refetch}
+          actions={[{ kind: 'retry', label: 'Retry' }]}
+        />
+      </PanelSection>
+    );
+  }
+
+  if (workflows.length === 0) {
+    return (
+      <PanelSection>
+        <ErrorPanel message="No schedule runs found" omitLogging />
+      </PanelSection>
+    );
+  }
+
+  return JSON.stringify(workflows);
+}

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -48,10 +48,12 @@ export default function ScheduleRuns({ params }: Props) {
     query: getScheduleRunsQuery(params.scheduleId, {
       ...timeRange,
       statuses: queryParams.scheduleRunsStatuses,
+      runType: queryParams.scheduleRunsRunType,
     }),
   });
   const hasActiveFilters = Boolean(
     queryParams.scheduleRunsStatuses?.length ||
+      queryParams.scheduleRunsRunType !== 'all' ||
       queryParams.scheduleRunsTimeStart !== 'now-7d' ||
       queryParams.scheduleRunsTimeEnd !== 'now'
   );

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import ErrorPanel from '@/components/error-panel/error-panel';
+import PageSection from '@/components/page-section/page-section';
 import PanelSection from '@/components/panel-section/panel-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
@@ -44,5 +45,5 @@ export default function ScheduleRuns({ params }: Props) {
     );
   }
 
-  return JSON.stringify(workflows);
+  return <PageSection>{JSON.stringify(workflows)}</PageSection>;
 }

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -7,16 +7,16 @@ import PanelSection from '@/components/panel-section/panel-section';
 import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
 import usePageQueryParams from '@/hooks/use-page-query-params/use-page-query-params';
 import dayjs from '@/utils/datetime/dayjs';
+import schedulePageQueryParamsConfig from '@/views/schedule-page/config/schedule-page-query-params.config';
 import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 
-import scheduleRunsQueryParamsConfig from './config/schedule-runs-query-params.config';
 import getScheduleRunsQuery from './helpers/get-schedule-runs-query';
 import ScheduleRunsHeader from './schedule-runs-header';
 import ScheduleRunsTable from './schedule-runs-table';
 import { type Props } from './schedule-runs.types';
 
 export default function ScheduleRuns({ params }: Props) {
-  const [queryParams] = usePageQueryParams(scheduleRunsQueryParamsConfig);
+  const [queryParams] = usePageQueryParams(schedulePageQueryParamsConfig);
   const timeRange = useMemo(() => {
     const now = dayjs();
     return {

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -45,10 +45,14 @@ export default function ScheduleRuns({ params }: Props) {
     listType: 'default',
     pageSize: 20,
     inputType: 'query',
-    query: getScheduleRunsQuery(params.scheduleId, timeRange),
+    query: getScheduleRunsQuery(params.scheduleId, {
+      ...timeRange,
+      statuses: queryParams.scheduleRunsStatuses,
+    }),
   });
   const hasActiveFilters = Boolean(
-    queryParams.scheduleRunsTimeStart !== 'now-7d' ||
+    queryParams.scheduleRunsStatuses?.length ||
+      queryParams.scheduleRunsTimeStart !== 'now-7d' ||
       queryParams.scheduleRunsTimeEnd !== 'now'
   );
 

--- a/src/views/schedule-runs/schedule-runs.tsx
+++ b/src/views/schedule-runs/schedule-runs.tsx
@@ -14,6 +14,7 @@ import useListWorkflows from '@/views/shared/hooks/use-list-workflows';
 import getScheduleRunsQuery from './helpers/get-schedule-runs-query';
 import ScheduleRunsHeader from './schedule-runs-header';
 import ScheduleRunsTable from './schedule-runs-table';
+import { styled } from './schedule-runs.styles';
 import { type Props } from './schedule-runs.types';
 
 export default function ScheduleRuns({ params }: Props) {
@@ -71,31 +72,33 @@ export default function ScheduleRuns({ params }: Props) {
 
   return (
     <PageSection>
-      <ScheduleRunsHeader />
-      {workflows.length === 0 ? (
-        <PanelSection>
-          <ErrorPanel
-            message={
-              hasActiveFilters
-                ? 'No schedule runs match your filters'
-                : 'No schedule runs found'
+      <styled.Root>
+        <ScheduleRunsHeader />
+        {workflows.length === 0 ? (
+          <PanelSection>
+            <ErrorPanel
+              message={
+                hasActiveFilters
+                  ? 'No schedule runs match your filters'
+                  : 'No schedule runs found'
+              }
+              omitLogging
+            />
+          </PanelSection>
+        ) : (
+          <ScheduleRunsTable
+            domain={params.domain}
+            cluster={params.cluster}
+            workflows={workflows}
+            error={error}
+            hasNextPage={hasNextPage}
+            fetchNextPage={fetchNextPage}
+            isFetchingNextPage={
+              isFetchingNextPage || (isFetching && workflows.length > 0)
             }
-            omitLogging
           />
-        </PanelSection>
-      ) : (
-        <ScheduleRunsTable
-          domain={params.domain}
-          cluster={params.cluster}
-          workflows={workflows}
-          error={error}
-          hasNextPage={hasNextPage}
-          fetchNextPage={fetchNextPage}
-          isFetchingNextPage={
-            isFetchingNextPage || (isFetching && workflows.length > 0)
-          }
-        />
-      )}
+        )}
+      </styled.Root>
     </PageSection>
   );
 }

--- a/src/views/schedule-runs/schedule-runs.types.ts
+++ b/src/views/schedule-runs/schedule-runs.types.ts
@@ -1,3 +1,5 @@
 import { type SchedulePageTabContentProps } from '@/views/schedule-page/schedule-page-tabs/schedule-page-tabs.types';
 
 export type Props = SchedulePageTabContentProps;
+
+export type ScheduleRunsRunType = 'all' | 'backfill' | 'regular';

--- a/src/views/schedule-runs/schedule-runs.types.ts
+++ b/src/views/schedule-runs/schedule-runs.types.ts
@@ -1,0 +1,3 @@
+import { type SchedulePageTabContentProps } from '@/views/schedule-page/schedule-page-tabs/schedule-page-tabs.types';
+
+export type Props = SchedulePageTabContentProps;

--- a/src/views/shared/hooks/use-list-workflows.ts
+++ b/src/views/shared/hooks/use-list-workflows.ts
@@ -1,7 +1,7 @@
 'use client';
 import { useMemo } from 'react';
 
-import { useInfiniteQuery } from '@tanstack/react-query';
+import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query';
 import queryString from 'query-string';
 
 import {
@@ -71,6 +71,7 @@ export default function useListWorkflows({
       return lastPage.nextPage;
     },
     retry: false,
+    placeholderData: keepPreviousData,
     refetchOnWindowFocus: (query) => query.state.status !== 'error',
     gcTime: 0,
   });


### PR DESCRIPTION
## Summary

- Add the final URL-backed Run type filter to the schedule-runs filter panel.
- Support All, Backfill, and Regular without changing the mandatory schedule scope.
- Depends on #1456.

## Changes

- Add a non-clearable Run type select with All, Backfill, and Regular labels.
- Persist the selection as `runs-type`, defaulting invalid or absent values to All.
- Map Backfill and Regular to the Cadence-compatible quoted boolean predicates `CadenceScheduleIsBackfill = "true"` and `"false"`; omit the clause for All.
- Include Run type in reset, active-filter, empty-result, and pagination-reset behavior.
- Add focused assertions for Backfill and Regular query clauses and non-clearable list filters.

## Test plan

- [x] `npm run test:unit:browser list-filter.test.tsx schedule-page-query-params.config.test.ts schedule-runs`
- [x] `npm run typecheck`
- [x] `npx eslint "src/components/list-filter/**/*.ts" "src/components/list-filter/**/*.tsx" "src/views/schedule-runs/**/*.ts" "src/views/schedule-runs/**/*.tsx"`

## Feature plans

- [x] [Schedules List](https://github.com/cadence-workflow/cadence-web/pull/1295)
- [x] [Schedules Create Form](https://github.com/cadence-workflow/cadence-web/pull/1390)
- [x] [Schedules Details](https://github.com/cadence-workflow/cadence-web/pull/1394)
- [x] Schedules Actions
- Schedule Runs
  - #1448
  - #1449
  - #1450
  - #1451
  - #1454
  - #1455
  - #1456
  - #1457