### PR TITLE
feat(workflow-summary): add schedule details

### DIFF
--- a/src/views/workflow-summary/__tests__/workflow-summary.test.tsx
+++ b/src/views/workflow-summary/__tests__/workflow-summary.test.tsx
@@ -24,6 +24,11 @@ jest.mock(
   () => jest.fn(() => <div>MockWorkflowSummaryDiagnosticsBanner</div>)
 );
 
+jest.mock(
+  '../workflow-summary-schedule-details/workflow-summary-schedule-details',
+  () => jest.fn(() => <div>MockWorkflowSummaryScheduleDetails</div>)
+);
+
 describe('WorkflowSummary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -85,6 +90,9 @@ describe('WorkflowSummary', () => {
 
     expect(
       await screen.findByText('MockWorkflowSummaryDiagnosticsBanner')
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText('MockWorkflowSummaryScheduleDetails')
     ).toBeInTheDocument();
   });
 });

--- a/src/views/workflow-summary/config/workflow-summary-schedule-details.config.ts
+++ b/src/views/workflow-summary/config/workflow-summary-schedule-details.config.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
 
 import Link from '@/components/link/link';
+import escapeVisibilityQueryValue from '@/utils/visibility/escape-visibility-query-value';
 
 import { type WorkflowSummaryScheduleDetailsConfig } from '../workflow-summary-schedule-details/workflow-summary-schedule-details.types';
 
@@ -35,16 +36,18 @@ const workflowSummaryScheduleDetailsConfig: WorkflowSummaryScheduleDetailsConfig
     {
       key: 'backfillId',
       getLabel: () => 'Backfill ID',
-      getValue: ({ cluster, domain, searchAttributes }) => {
+      getValue: ({ cluster, domain, scheduleId, searchAttributes }) => {
         const backfillId = searchAttributes?.CadenceScheduleBackfillID;
         if (typeof backfillId !== 'string') {
           return null;
         }
 
+        const query = `CadenceScheduleID = "${escapeVisibilityQueryValue(scheduleId)}" AND CadenceScheduleBackfillID = "${escapeVisibilityQueryValue(backfillId)}"`;
+
         return createElement(
           Link,
           {
-            href: `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows?input=query&query=${encodeURIComponent(`CadenceScheduleBackfillID="${backfillId}"`)}`,
+            href: `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows?input=query&query=${encodeURIComponent(query)}`,
           },
           backfillId
         );

--- a/src/views/workflow-summary/config/workflow-summary-schedule-details.config.ts
+++ b/src/views/workflow-summary/config/workflow-summary-schedule-details.config.ts
@@ -1,0 +1,58 @@
+import { createElement } from 'react';
+
+import Link from '@/components/link/link';
+
+import { type WorkflowSummaryScheduleDetailsConfig } from '../workflow-summary-schedule-details/workflow-summary-schedule-details.types';
+
+const workflowSummaryScheduleDetailsConfig: WorkflowSummaryScheduleDetailsConfig[] =
+  [
+    {
+      key: 'scheduleId',
+      getLabel: () => 'Schedule ID',
+      getValue: ({ cluster, domain, scheduleId }) =>
+        createElement(
+          Link,
+          {
+            href: `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/schedules/${encodeURIComponent(scheduleId)}/details`,
+          },
+          scheduleId
+        ),
+    },
+    {
+      key: 'scheduleTime',
+      getLabel: () => 'Schedule time',
+      getValue: ({ searchAttributes }) => {
+        const scheduleTime = searchAttributes?.CadenceScheduleTime;
+        return typeof scheduleTime === 'string' ? scheduleTime : '-';
+      },
+    },
+    {
+      key: 'backfill',
+      getLabel: () => 'Backfill',
+      getValue: ({ searchAttributes }) =>
+        searchAttributes?.CadenceScheduleIsBackfill === true ? 'Yes' : 'No',
+    },
+    {
+      key: 'backfillId',
+      getLabel: () => 'Backfill ID',
+      getValue: ({ cluster, domain, searchAttributes }) => {
+        const backfillId = searchAttributes?.CadenceScheduleBackfillID;
+        if (typeof backfillId !== 'string') {
+          return null;
+        }
+
+        return createElement(
+          Link,
+          {
+            href: `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows?input=query&query=${encodeURIComponent(`CadenceScheduleBackfillID="${backfillId}"`)}`,
+          },
+          backfillId
+        );
+      },
+      hide: ({ searchAttributes }) =>
+        searchAttributes?.CadenceScheduleIsBackfill !== true ||
+        typeof searchAttributes?.CadenceScheduleBackfillID !== 'string',
+    },
+  ];
+
+export default workflowSummaryScheduleDetailsConfig;

--- a/src/views/workflow-summary/workflow-summary-schedule-details/__tests__/workflow-summary-schedule-details.test.tsx
+++ b/src/views/workflow-summary/workflow-summary-schedule-details/__tests__/workflow-summary-schedule-details.test.tsx
@@ -1,0 +1,128 @@
+import React from 'react';
+
+import { HttpResponse } from 'msw';
+
+import { render, screen, waitFor } from '@/test-utils/rtl';
+
+import WorkflowSummaryScheduleDetails from '../workflow-summary-schedule-details';
+import { type Props } from '../workflow-summary-schedule-details.types';
+
+jest.mock(
+  '@/components/link/link',
+  () =>
+    function MockLink({
+      children,
+      href,
+    }: React.PropsWithChildren<{ href: string }>) {
+      return <a href={href}>{children}</a>;
+    }
+);
+
+describe(WorkflowSummaryScheduleDetails.name, () => {
+  it('does not render when schedules are disabled', async () => {
+    setup({
+      isSchedulesEnabled: false,
+      searchAttributes: { CadenceScheduleID: 'schedule-id' },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('table', { name: 'Schedule details' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('does not render without a schedule ID', async () => {
+    setup({
+      isSchedulesEnabled: true,
+      searchAttributes: { CadenceScheduleTime: '2026-07-21T12:00:00Z' },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('table', { name: 'Schedule details' })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders schedule metadata and an encoded details link', async () => {
+    setup({
+      isSchedulesEnabled: true,
+      domain: 'test/domain',
+      cluster: 'test cluster',
+      searchAttributes: {
+        CadenceScheduleID: 'schedule/id',
+        CadenceScheduleTime: '2026-07-21T12:00:00Z',
+      },
+    });
+
+    expect(
+      await screen.findByRole('table', { name: 'Schedule details' })
+    ).toBeInTheDocument();
+    expect(screen.getByText('2026-07-21T12:00:00Z')).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'No' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'schedule/id' })).toHaveAttribute(
+      'href',
+      '/domains/test%2Fdomain/test%20cluster/schedules/schedule%2Fid/details'
+    );
+    expect(
+      screen.queryByRole('rowheader', { name: 'Backfill ID' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('uses fallbacks for missing optional metadata', async () => {
+    setup({
+      isSchedulesEnabled: true,
+      searchAttributes: { CadenceScheduleID: 'schedule-id' },
+    });
+
+    expect(await screen.findByRole('cell', { name: '-' })).toBeInTheDocument();
+    expect(screen.getByRole('cell', { name: 'No' })).toBeInTheDocument();
+  });
+
+  it('links backfill IDs to the filtered workflows list', async () => {
+    setup({
+      isSchedulesEnabled: true,
+      domain: 'test/domain',
+      cluster: 'test cluster',
+      searchAttributes: {
+        CadenceScheduleID: 'schedule-id',
+        CadenceScheduleIsBackfill: true,
+        CadenceScheduleBackfillID: 'backfill-id',
+      },
+    });
+
+    expect(
+      await screen.findByRole('cell', { name: 'Yes' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'backfill-id' })).toHaveAttribute(
+      'href',
+      `/domains/test%2Fdomain/test%20cluster/workflows?input=query&query=${encodeURIComponent(
+        'CadenceScheduleBackfillID="backfill-id"'
+      )}`
+    );
+  });
+});
+
+function setup({
+  isSchedulesEnabled,
+  ...props
+}: Partial<Props> & { isSchedulesEnabled: boolean }) {
+  render(
+    <WorkflowSummaryScheduleDetails
+      cluster="test-cluster"
+      domain="test-domain"
+      {...props}
+    />,
+    {
+      endpointsMocks: [
+        {
+          path: '/api/config',
+          httpMethod: 'GET',
+          mockOnce: false,
+          httpResolver: async () => HttpResponse.json(isSchedulesEnabled),
+        },
+      ],
+    }
+  );
+}

--- a/src/views/workflow-summary/workflow-summary-schedule-details/__tests__/workflow-summary-schedule-details.test.tsx
+++ b/src/views/workflow-summary/workflow-summary-schedule-details/__tests__/workflow-summary-schedule-details.test.tsx
@@ -98,7 +98,7 @@ describe(WorkflowSummaryScheduleDetails.name, () => {
     expect(screen.getByRole('link', { name: 'backfill-id' })).toHaveAttribute(
       'href',
       `/domains/test%2Fdomain/test%20cluster/workflows?input=query&query=${encodeURIComponent(
-        'CadenceScheduleBackfillID="backfill-id"'
+        'CadenceScheduleID = "schedule-id" AND CadenceScheduleBackfillID = "backfill-id"'
       )}`
     );
   });

--- a/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.tsx
+++ b/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.tsx
@@ -1,0 +1,89 @@
+'use client';
+import React from 'react';
+
+import Link from '@/components/link/link';
+import useConfigValue from '@/hooks/use-config-value/use-config-value';
+import useStyletronClasses from '@/hooks/use-styletron-classes';
+
+import { cssStyles } from '../workflow-summary-details/workflow-summary-details.styles';
+
+import { type Props } from './workflow-summary-schedule-details.types';
+
+export default function WorkflowSummaryScheduleDetails({
+  cluster,
+  domain,
+  searchAttributes,
+}: Props) {
+  const { cls } = useStyletronClasses(cssStyles);
+  const { data: isSchedulesEnabled } = useConfigValue('SCHEDULES_ENABLED', {
+    cluster,
+    domain,
+  });
+  const scheduleIdValue = searchAttributes?.CadenceScheduleID;
+  const scheduleId =
+    typeof scheduleIdValue === 'string' ? scheduleIdValue : null;
+
+  if (!isSchedulesEnabled || !scheduleId) {
+    return null;
+  }
+
+  const scheduleTimeValue = searchAttributes?.CadenceScheduleTime;
+  const scheduleTime =
+    typeof scheduleTimeValue === 'string' ? scheduleTimeValue : '-';
+  const isBackfill = searchAttributes?.CadenceScheduleIsBackfill === true;
+  const backfillIdValue = searchAttributes?.CadenceScheduleBackfillID;
+  const backfillId =
+    isBackfill && typeof backfillIdValue === 'string' ? backfillIdValue : null;
+
+  return (
+    <div className={cls.pageContainer}>
+      <div className={cls.workflowTitle}>
+        <strong>Schedule details</strong>
+      </div>
+      <div aria-label="Schedule details" role="table">
+        <div className={cls.detailsRow} role="row">
+          <div className={cls.detailsLabel} role="rowheader">
+            Schedule ID
+          </div>
+          <div className={cls.detailsValue} role="cell">
+            <Link
+              href={`/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/schedules/${encodeURIComponent(scheduleId)}/details`}
+            >
+              {scheduleId}
+            </Link>
+          </div>
+        </div>
+        <div className={cls.detailsRow} role="row">
+          <div className={cls.detailsLabel} role="rowheader">
+            Schedule time
+          </div>
+          <div className={cls.detailsValue} role="cell">
+            {scheduleTime}
+          </div>
+        </div>
+        <div className={cls.detailsRow} role="row">
+          <div className={cls.detailsLabel} role="rowheader">
+            Backfill
+          </div>
+          <div className={cls.detailsValue} role="cell">
+            {isBackfill ? 'Yes' : 'No'}
+          </div>
+        </div>
+        {backfillId && (
+          <div className={cls.detailsRow} role="row">
+            <div className={cls.detailsLabel} role="rowheader">
+              Backfill ID
+            </div>
+            <div className={cls.detailsValue} role="cell">
+              <Link
+                href={`/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows?input=query&query=${encodeURIComponent(`CadenceScheduleBackfillID="${backfillId}"`)}`}
+              >
+                {backfillId}
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.tsx
+++ b/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.tsx
@@ -1,10 +1,10 @@
 'use client';
 import React from 'react';
 
-import Link from '@/components/link/link';
 import useConfigValue from '@/hooks/use-config-value/use-config-value';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 
+import workflowSummaryScheduleDetailsConfig from '../config/workflow-summary-schedule-details.config';
 import { cssStyles } from '../workflow-summary-details/workflow-summary-details.styles';
 
 import { type Props } from './workflow-summary-schedule-details.types';
@@ -27,13 +27,7 @@ export default function WorkflowSummaryScheduleDetails({
     return null;
   }
 
-  const scheduleTimeValue = searchAttributes?.CadenceScheduleTime;
-  const scheduleTime =
-    typeof scheduleTimeValue === 'string' ? scheduleTimeValue : '-';
-  const isBackfill = searchAttributes?.CadenceScheduleIsBackfill === true;
-  const backfillIdValue = searchAttributes?.CadenceScheduleBackfillID;
-  const backfillId =
-    isBackfill && typeof backfillIdValue === 'string' ? backfillIdValue : null;
+  const rowArgs = { cluster, domain, scheduleId, searchAttributes };
 
   return (
     <div className={cls.pageContainer}>
@@ -41,48 +35,18 @@ export default function WorkflowSummaryScheduleDetails({
         <strong>Schedule details</strong>
       </div>
       <div aria-label="Schedule details" role="table">
-        <div className={cls.detailsRow} role="row">
-          <div className={cls.detailsLabel} role="rowheader">
-            Schedule ID
-          </div>
-          <div className={cls.detailsValue} role="cell">
-            <Link
-              href={`/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/schedules/${encodeURIComponent(scheduleId)}/details`}
-            >
-              {scheduleId}
-            </Link>
-          </div>
-        </div>
-        <div className={cls.detailsRow} role="row">
-          <div className={cls.detailsLabel} role="rowheader">
-            Schedule time
-          </div>
-          <div className={cls.detailsValue} role="cell">
-            {scheduleTime}
-          </div>
-        </div>
-        <div className={cls.detailsRow} role="row">
-          <div className={cls.detailsLabel} role="rowheader">
-            Backfill
-          </div>
-          <div className={cls.detailsValue} role="cell">
-            {isBackfill ? 'Yes' : 'No'}
-          </div>
-        </div>
-        {backfillId && (
-          <div className={cls.detailsRow} role="row">
-            <div className={cls.detailsLabel} role="rowheader">
-              Backfill ID
+        {workflowSummaryScheduleDetailsConfig
+          .filter((row) => !row.hide || !row.hide(rowArgs))
+          .map((row) => (
+            <div className={cls.detailsRow} key={row.key} role="row">
+              <div className={cls.detailsLabel} role="rowheader">
+                {row.getLabel()}
+              </div>
+              <div className={cls.detailsValue} role="cell">
+                {row.getValue(rowArgs)}
+              </div>
             </div>
-            <div className={cls.detailsValue} role="cell">
-              <Link
-                href={`/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows?input=query&query=${encodeURIComponent(`CadenceScheduleBackfillID="${backfillId}"`)}`}
-              >
-                {backfillId}
-              </Link>
-            </div>
-          </div>
-        )}
+          ))}
       </div>
     </div>
   );

--- a/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.types.ts
+++ b/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.types.ts
@@ -1,5 +1,18 @@
+import { type ReactNode } from 'react';
+
 export type Props = {
   cluster: string;
   domain: string;
   searchAttributes?: Record<string, unknown> | null;
+};
+
+export type WorkflowSummaryScheduleDetailsRowArgs = Props & {
+  scheduleId: string;
+};
+
+export type WorkflowSummaryScheduleDetailsConfig = {
+  key: string;
+  getLabel: () => string;
+  getValue: (args: WorkflowSummaryScheduleDetailsRowArgs) => ReactNode;
+  hide?: (args: WorkflowSummaryScheduleDetailsRowArgs) => boolean;
 };

--- a/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.types.ts
+++ b/src/views/workflow-summary/workflow-summary-schedule-details/workflow-summary-schedule-details.types.ts
@@ -1,0 +1,5 @@
+export type Props = {
+  cluster: string;
+  domain: string;
+  searchAttributes?: Record<string, unknown> | null;
+};

--- a/src/views/workflow-summary/workflow-summary.tsx
+++ b/src/views/workflow-summary/workflow-summary.tsx
@@ -26,6 +26,7 @@ import WorkflowSummaryDetails from './workflow-summary-details/workflow-summary-
 import WorkflowSummaryDiagnosticsBanner from './workflow-summary-diagnostics-banner/workflow-summary-diagnostics-banner';
 import WorkflowSummaryJsonView from './workflow-summary-json-view/workflow-summary-json-view';
 import { type Props as JsonViewProps } from './workflow-summary-json-view/workflow-summary-json-view.types';
+import WorkflowSummaryScheduleDetails from './workflow-summary-schedule-details/workflow-summary-schedule-details';
 import { cssStyles } from './workflow-summary.styles';
 
 export default function WorkflowSummary({
@@ -113,6 +114,13 @@ export default function WorkflowSummary({
             formattedCloseHistoryEvent={formattedCloseEvent}
             workflowDetails={workflowDetails}
             decodedPageUrlParams={decodedParams}
+          />
+          <WorkflowSummaryScheduleDetails
+            cluster={decodedParams.cluster}
+            domain={decodedParams.domain}
+            searchAttributes={
+              formattedStartEvent?.searchAttributes?.indexedFields
+            }
           />
         </div>
         {/* On narrow screens */}


### PR DESCRIPTION
## Summary

Add schedule context to workflow summaries for runs created by Cadence Schedules.

## Changes

- Show schedule details only when the Schedules feature is enabled and `CadenceScheduleID` is present.
- Link to the parent schedule and display schedule time and backfill metadata.
- Link backfill IDs to the corresponding filtered workflows list.
- Preserve the existing legacy CRON schedule row.

## Testing

- Schedule without backfil
<img width="1688" height="876" alt="Screenshot 2026-07-21 at 13 48 43" src="https://github.com/user-attachments/assets/d11e051e-d1d0-4809-b946-a7c551636984" />
- No schedule
<img width="1714" height="642" alt="Screenshot 2026-07-21 at 13 49 26" src="https://github.com/user-attachments/assets/61373a97-f714-4b92-93bc-3a4a1cc6c9ca" />
- Schedule with backfill and  navigation 

https://github.com/user-attachments/assets/39367fb5-cd5f-4db2-b729-2e5a551ce5d2
