### PR TITLE
feat(schedule-actions): add edit schedule form schema and submission

### DIFF
--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -177,9 +177,35 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
     expect(screen.getByLabelText('Expiration Interval')).toBeInTheDocument();
     expect(screen.queryByLabelText('Maximum Attempts')).not.toBeInTheDocument();
   });
+
+  it('keeps the Schedule Id field editable by default', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeEnabled();
+    expect(
+      screen.queryByText(/schedule id cannot be changed/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the Schedule Id field and explains why when read-only', async () => {
+    const { user } = setup({ scheduleIdReadOnly: true });
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeDisabled();
+    expect(
+      screen.getByText(/schedule id cannot be changed/i)
+    ).toBeInTheDocument();
+  });
 });
 
-function setup() {
+function setup({ scheduleIdReadOnly }: { scheduleIdReadOnly?: boolean } = {}) {
   const user = userEvent.setup();
   let getValues: () => DomainSchedulesCreateFormData;
 
@@ -200,6 +226,7 @@ function setup() {
         fieldErrors={fieldErrors}
         clearErrors={clearErrors}
         cluster="test-cluster"
+        scheduleIdReadOnly={scheduleIdReadOnly}
       />
     );
   }

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -11,6 +11,9 @@ import {
 
 export const MAX_CATCH_UP_WINDOW_DAYS = 90;
 
+export const SCHEDULE_ID_READ_ONLY_CAPTION =
+  'Schedule Id cannot be changed after the schedule is created.';
+
 /** Stable ids for advanced create-schedule horizontal fields. */
 export const CREATE_SCHEDULE_ADVANCED_FIELD_IDS = {
   scheduleId: 'domain-schedules-create-form-schedule-id',

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_OVERLAP_POLICY,
   MAX_CATCH_UP_WINDOW_DAYS,
   OVERLAP_POLICY_OPTIONS,
+  SCHEDULE_ID_READ_ONLY_CAPTION,
 } from './domain-schedules-create-advanced-form.constants';
 import {
   overrides,
@@ -48,6 +49,7 @@ export default function DomainSchedulesCreateAdvancedForm({
   isSubmitted = false,
   clearErrors,
   cluster,
+  scheduleIdReadOnly = false,
 }: Props) {
   const { data: searchAttributesData, isLoading: isLoadingSearchAttributes } =
     useSearchAttributes({ cluster, category: 'custom' });
@@ -117,6 +119,9 @@ export default function DomainSchedulesCreateAdvancedForm({
           label="Schedule Id"
           description={CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.scheduleId}
           htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.scheduleId}
+          caption={
+            scheduleIdReadOnly ? SCHEDULE_ID_READ_ONLY_CAPTION : undefined
+          }
           error={getFieldErrorMessage(fieldErrors, 'scheduleId')}
         >
           <Controller
@@ -129,6 +134,7 @@ export default function DomainSchedulesCreateAdvancedForm({
                 // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
                 inputRef={ref}
                 aria-label="Schedule Id"
+                disabled={scheduleIdReadOnly}
                 onChange={(e) => field.onChange(e.target.value || undefined)}
                 onBlur={field.onBlur}
                 error={Boolean(getFieldErrorMessage(fieldErrors, 'scheduleId'))}

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
@@ -14,4 +14,6 @@ export type Props = {
   isSubmitted?: boolean;
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   cluster: string;
+  /** Renders the Schedule Id field disabled, for flows where the id is fixed. */
+  scheduleIdReadOnly?: boolean;
 };

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -174,6 +174,16 @@ describe('DomainSchedulesCreateForm', () => {
       screen.getByText('This task list has no workers')
     ).toBeInTheDocument();
   });
+
+  it('passes scheduleIdReadOnly down to the advanced fields', async () => {
+    const { user } = await setup({ scheduleIdReadOnly: true });
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeDisabled();
+  });
 });
 
 type SetupProps = {
@@ -181,14 +191,17 @@ type SetupProps = {
   /** Applies fixed `setError` calls (same role as passing `fieldErrors` into start form tests). */
   injectFieldErrors?: boolean;
   taskListValidation?: ReturnType<typeof mockUseTaskListFieldValidation>;
+  scheduleIdReadOnly?: boolean;
 };
 
 function TestWrapper({
   defaultValues,
   injectFieldErrors,
+  scheduleIdReadOnly,
 }: {
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
   injectFieldErrors?: boolean;
+  scheduleIdReadOnly?: boolean;
 }) {
   const { control, trigger, setError, clearErrors } =
     useForm<DomainSchedulesCreateFormData>({
@@ -210,6 +223,7 @@ function TestWrapper({
       clearErrors={clearErrors}
       domain={MOCK_DOMAIN}
       cluster={MOCK_CLUSTER}
+      scheduleIdReadOnly={scheduleIdReadOnly}
     />
   );
 }
@@ -217,6 +231,7 @@ function TestWrapper({
 async function setup({
   defaultValues,
   injectFieldErrors = false,
+  scheduleIdReadOnly,
   taskListValidation = {
     isTaskListLoading: false,
     taskListCaptionMessage: null,
@@ -230,6 +245,7 @@ async function setup({
     <TestWrapper
       defaultValues={defaultValues}
       injectFieldErrors={injectFieldErrors}
+      scheduleIdReadOnly={scheduleIdReadOnly}
     />
   );
 

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -39,6 +39,7 @@ export default function DomainSchedulesCreateForm({
   clearErrors,
   domain,
   cluster,
+  scheduleIdReadOnly,
 }: Props) {
   const { errors: fieldErrors, isSubmitted } = useFormState({ control });
 
@@ -343,6 +344,7 @@ export default function DomainSchedulesCreateForm({
         isSubmitted={isSubmitted}
         clearErrors={clearErrors}
         cluster={cluster}
+        scheduleIdReadOnly={scheduleIdReadOnly}
       />
     </div>
   );

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -12,4 +12,6 @@ export type Props = {
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   domain: string;
   cluster: string;
+  /** Renders the Schedule Id field disabled, for flows where the id is fixed. */
+  scheduleIdReadOnly?: boolean;
 };

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-edit-schedule-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-edit-schedule-form-data.ts
@@ -1,0 +1,19 @@
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+export const mockEditScheduleFormData: EditScheduleFormData = {
+  scheduleId: 'mock-schedule-id',
+  cronExpression: {
+    minutes: '0',
+    hours: '9',
+    daysOfMonth: '*',
+    months: '*',
+    daysOfWeek: '*',
+  },
+  workflowType: { name: 'DemoWorkflow' },
+  taskList: { name: 'demo-task-list' },
+  workerSDKLanguage: 'GO',
+  executionStartToCloseTimeoutSeconds: 3600,
+  taskStartToCloseTimeoutSeconds: 30,
+  input: [''],
+  pauseOnFailure: false,
+};

--- a/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.types.tst.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.types.tst.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'tstyche';
+
+import type { ExhaustiveDefaults } from '../schedule-action-edit-form.types.js';
+
+type Fields = {
+  required: string;
+  optional?: number;
+};
+
+describe('ExhaustiveDefaults', () => {
+  it('accepts a literal that assigns every field', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.toBeAssignableWith({
+      required: 'value',
+      optional: 1,
+    });
+  });
+
+  it('still allows an optional field to be assigned undefined', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.toBeAssignableWith({
+      required: 'value',
+      optional: undefined,
+    });
+  });
+
+  it('rejects a literal that leaves an optional field out', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.not.toBeAssignableWith({
+      required: 'value',
+    });
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
@@ -1,0 +1,30 @@
+import { mockEditScheduleFormData } from '../../__fixtures__/mock-edit-schedule-form-data';
+import transformEditScheduleFormToSubmission from '../transform-edit-schedule-form-to-submission';
+
+describe(transformEditScheduleFormToSubmission.name, () => {
+  it('maps the form onto the update schedule body', () => {
+    const result = transformEditScheduleFormToSubmission(
+      mockEditScheduleFormData
+    );
+
+    expect(result).toEqual({
+      cronExpression: '0 9 * * *',
+      pauseOnFailure: false,
+      startWorkflow: {
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: { name: 'demo-task-list' },
+        workerSDKLanguage: 'GO',
+        executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: 30,
+      },
+    });
+  });
+
+  it('omits the schedule id, which the update URL carries instead', () => {
+    const result = transformEditScheduleFormToSubmission(
+      mockEditScheduleFormData
+    );
+
+    expect(result).not.toHaveProperty('scheduleId');
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
@@ -1,18 +1,10 @@
-import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
 import transformDomainSchedulesCreateFormToBody from '@/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body';
 
-import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+import {
+  type EditScheduleFormData,
+  type EditScheduleSubmissionData,
+} from '../schedule-action-edit-form.types';
 
-export type EditScheduleSubmissionData = Omit<
-  CreateScheduleRequestBody,
-  'scheduleId'
->;
-
-/**
- * UpdateSchedule replaces the whole schedule definition, so the body matches
- * the create one. The schedule id is display-only in the edit form: the PUT URL
- * already carries it and the schedule id of an existing schedule cannot change.
- */
 export default function transformEditScheduleFormToSubmission(
   formData: EditScheduleFormData
 ): EditScheduleSubmissionData {

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
@@ -1,0 +1,23 @@
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+import transformDomainSchedulesCreateFormToBody from '@/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body';
+
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+export type EditScheduleSubmissionData = Omit<
+  CreateScheduleRequestBody,
+  'scheduleId'
+>;
+
+/**
+ * UpdateSchedule replaces the whole schedule definition, so the body matches
+ * the create one. The schedule id is display-only in the edit form: the PUT URL
+ * already carries it and the schedule id of an existing schedule cannot change.
+ */
+export default function transformEditScheduleFormToSubmission(
+  formData: EditScheduleFormData
+): EditScheduleSubmissionData {
+  const { scheduleId: _scheduleId, ...body } =
+    transformDomainSchedulesCreateFormToBody(formData);
+
+  return body;
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -1,0 +1,13 @@
+import { type z } from 'zod';
+
+import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
+
+export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
+
+/**
+ * Forces every key of T to be explicitly assigned, including optional fields,
+ * whose value may still be `undefined`. Adding a field to T without updating a
+ * literal typed as `ExhaustiveDefaults<T>` is a compile error, which is what
+ * stops a newly-added form field from silently prefilling as blank.
+ */
+export type ExhaustiveDefaults<T> = { [K in keyof T]-?: T[K] };

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -9,5 +9,9 @@ export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
  * whose value may still be `undefined`. Adding a field to T without updating a
  * literal typed as `ExhaustiveDefaults<T>` is a compile error, which is what
  * stops a newly-added form field from silently prefilling as blank.
+ *
+ * The keys come from `Required<T>` rather than from `[K in keyof T]-?` because
+ * the `-?` modifier would also strip `undefined` out of the value type, which
+ * would make genuinely optional fields impossible to leave unset.
  */
-export type ExhaustiveDefaults<T> = { [K in keyof T]-?: T[K] };
+export type ExhaustiveDefaults<T> = { [K in keyof Required<T>]: T[K] };

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -1,8 +1,20 @@
 import { type z } from 'zod';
 
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+
 import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
 
 export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
+
+/**
+ * UpdateSchedule replaces the whole schedule definition, so the body matches
+ * the create one. The schedule id is display-only in the edit form: the PUT URL
+ * already carries it and the schedule id of an existing schedule cannot change.
+ */
+export type EditScheduleSubmissionData = Omit<
+  CreateScheduleRequestBody,
+  'scheduleId'
+>;
 
 /**
  * Forces every key of T to be explicitly assigned, including optional fields,

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
@@ -1,0 +1,55 @@
+import { mockEditScheduleFormData } from '../../__fixtures__/mock-edit-schedule-form-data';
+import { editScheduleFormSchema } from '../edit-schedule-form-schema';
+
+describe('editScheduleFormSchema', () => {
+  it('accepts a fully prefilled edit form', () => {
+    const result = editScheduleFormSchema.safeParse(mockEditScheduleFormData);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('requires a schedule id, unlike the create form', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      scheduleId: '',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['scheduleId'],
+        message: 'Schedule id is required',
+      }),
+    ]);
+  });
+
+  it('applies the shared create-schedule refinements', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      memo: 'not json',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['memo'],
+        message: 'Memo must be valid JSON',
+      }),
+    ]);
+  });
+
+  it('applies the shared create-schedule field validation', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      workflowType: { name: '' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['workflowType', 'name'],
+        message: 'Workflow type is required',
+      }),
+    ]);
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
@@ -8,21 +8,6 @@ describe('editScheduleFormSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('requires a schedule id, unlike the create form', () => {
-    const result = editScheduleFormSchema.safeParse({
-      ...mockEditScheduleFormData,
-      scheduleId: '',
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.error?.errors).toEqual([
-      expect.objectContaining({
-        path: ['scheduleId'],
-        message: 'Schedule id is required',
-      }),
-    ]);
-  });
-
   it('applies the shared create-schedule refinements', () => {
     const result = editScheduleFormSchema.safeParse({
       ...mockEditScheduleFormData,

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import refineCreateScheduleForm from '@/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form';
+import { createScheduleFormFieldsSchema } from '@/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema';
+
+/**
+ * Editing validates exactly like creating, except the schedule id is always
+ * known: it is prefilled from the existing schedule and shown read-only.
+ */
+export const editScheduleFormSchema = createScheduleFormFieldsSchema
+  .extend({ scheduleId: z.string().min(1, 'Schedule id is required') })
+  .superRefine(refineCreateScheduleForm);

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
@@ -1,12 +1,11 @@
-import { z } from 'zod';
-
 import refineCreateScheduleForm from '@/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form';
 import { createScheduleFormFieldsSchema } from '@/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema';
 
 /**
- * Editing validates exactly like creating, except the schedule id is always
- * known: it is prefilled from the existing schedule and shown read-only.
+ * Editing validates exactly like creating. Keeping the field shapes identical
+ * is what lets the edit form reuse the create form components as they are, so
+ * this deliberately re-composes the create pieces rather than adding rules of
+ * its own. It exists as a separate schema so edit-only rules have a home.
  */
-export const editScheduleFormSchema = createScheduleFormFieldsSchema
-  .extend({ scheduleId: z.string().min(1, 'Schedule id is required') })
-  .superRefine(refineCreateScheduleForm);
+export const editScheduleFormSchema =
+  createScheduleFormFieldsSchema.superRefine(refineCreateScheduleForm);


### PR DESCRIPTION
## Summary

Adds the validation schema, form data type and submission transform for the upcoming **Edit Schedule** action. Everything reuses the create-schedule equivalents rather than redefining them, so the two forms cannot drift apart. Nothing imports these files yet, so there is no user-visible change.

Also adds the `ExhaustiveDefaults<T>` utility type. The prefill transform in the next slices builds the whole form from an existing schedule, and most fields in the schema are `.optional()`, which means a plain return type would let a newly-added field go unmapped and silently prefill as blank. Annotating that transform with `ExhaustiveDefaults<EditScheduleFormData>` strips the optional modifiers, so forgetting a field becomes a `npm run typecheck` failure instead of a silent bug.

Part of the Edit Schedule stack (PR08b). Based on `master`, independent of [#1463](https://github.com/cadence-workflow/cadence-web/pull/1463) and [#1464](https://github.com/cadence-workflow/cadence-web/pull/1464).

## Changes

- `schemas/edit-schedule-form-schema.ts`: `createScheduleFormFieldsSchema` plus the shared `refineCreateScheduleForm`, with `scheduleId` promoted from optional to required since an existing schedule always has one
- `schedule-action-edit-form.types.ts`: `EditScheduleFormData` and the `ExhaustiveDefaults<T>` utility
- `helpers/transform-edit-schedule-form-to-submission.ts`: delegates to `transformDomainSchedulesCreateFormToBody` and drops `scheduleId`, which the PUT URL carries instead
- Fixture plus unit tests for the schema and the transform

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run test:unit:browser -- schedule-action-edit-form` (6 tests passing, covering a valid prefilled form, the required schedule id, the inherited field validation and refinements, and the transform output)
