### PR TITLE
feat(schedule-actions): prefill retry policy, search attributes and memo

### DIFF
--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -177,9 +177,35 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
     expect(screen.getByLabelText('Expiration Interval')).toBeInTheDocument();
     expect(screen.queryByLabelText('Maximum Attempts')).not.toBeInTheDocument();
   });
+
+  it('keeps the Schedule Id field editable by default', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeEnabled();
+    expect(
+      screen.queryByText(/schedule id cannot be changed/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the Schedule Id field and explains why when read-only', async () => {
+    const { user } = setup({ scheduleIdReadOnly: true });
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeDisabled();
+    expect(
+      screen.getByText(/schedule id cannot be changed/i)
+    ).toBeInTheDocument();
+  });
 });
 
-function setup() {
+function setup({ scheduleIdReadOnly }: { scheduleIdReadOnly?: boolean } = {}) {
   const user = userEvent.setup();
   let getValues: () => DomainSchedulesCreateFormData;
 
@@ -200,6 +226,7 @@ function setup() {
         fieldErrors={fieldErrors}
         clearErrors={clearErrors}
         cluster="test-cluster"
+        scheduleIdReadOnly={scheduleIdReadOnly}
       />
     );
   }

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -11,6 +11,9 @@ import {
 
 export const MAX_CATCH_UP_WINDOW_DAYS = 90;
 
+export const SCHEDULE_ID_READ_ONLY_CAPTION =
+  'Schedule Id cannot be changed after the schedule is created.';
+
 /** Stable ids for advanced create-schedule horizontal fields. */
 export const CREATE_SCHEDULE_ADVANCED_FIELD_IDS = {
   scheduleId: 'domain-schedules-create-form-schedule-id',

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_OVERLAP_POLICY,
   MAX_CATCH_UP_WINDOW_DAYS,
   OVERLAP_POLICY_OPTIONS,
+  SCHEDULE_ID_READ_ONLY_CAPTION,
 } from './domain-schedules-create-advanced-form.constants';
 import {
   overrides,
@@ -48,6 +49,7 @@ export default function DomainSchedulesCreateAdvancedForm({
   isSubmitted = false,
   clearErrors,
   cluster,
+  scheduleIdReadOnly = false,
 }: Props) {
   const { data: searchAttributesData, isLoading: isLoadingSearchAttributes } =
     useSearchAttributes({ cluster, category: 'custom' });
@@ -117,6 +119,9 @@ export default function DomainSchedulesCreateAdvancedForm({
           label="Schedule Id"
           description={CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.scheduleId}
           htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.scheduleId}
+          caption={
+            scheduleIdReadOnly ? SCHEDULE_ID_READ_ONLY_CAPTION : undefined
+          }
           error={getFieldErrorMessage(fieldErrors, 'scheduleId')}
         >
           <Controller
@@ -129,6 +134,7 @@ export default function DomainSchedulesCreateAdvancedForm({
                 // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
                 inputRef={ref}
                 aria-label="Schedule Id"
+                disabled={scheduleIdReadOnly}
                 onChange={(e) => field.onChange(e.target.value || undefined)}
                 onBlur={field.onBlur}
                 error={Boolean(getFieldErrorMessage(fieldErrors, 'scheduleId'))}

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
@@ -14,4 +14,6 @@ export type Props = {
   isSubmitted?: boolean;
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   cluster: string;
+  /** Renders the Schedule Id field disabled, for flows where the id is fixed. */
+  scheduleIdReadOnly?: boolean;
 };

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -174,6 +174,16 @@ describe('DomainSchedulesCreateForm', () => {
       screen.getByText('This task list has no workers')
     ).toBeInTheDocument();
   });
+
+  it('passes scheduleIdReadOnly down to the advanced fields', async () => {
+    const { user } = await setup({ scheduleIdReadOnly: true });
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeDisabled();
+  });
 });
 
 type SetupProps = {
@@ -181,14 +191,17 @@ type SetupProps = {
   /** Applies fixed `setError` calls (same role as passing `fieldErrors` into start form tests). */
   injectFieldErrors?: boolean;
   taskListValidation?: ReturnType<typeof mockUseTaskListFieldValidation>;
+  scheduleIdReadOnly?: boolean;
 };
 
 function TestWrapper({
   defaultValues,
   injectFieldErrors,
+  scheduleIdReadOnly,
 }: {
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
   injectFieldErrors?: boolean;
+  scheduleIdReadOnly?: boolean;
 }) {
   const { control, trigger, setError, clearErrors } =
     useForm<DomainSchedulesCreateFormData>({
@@ -210,6 +223,7 @@ function TestWrapper({
       clearErrors={clearErrors}
       domain={MOCK_DOMAIN}
       cluster={MOCK_CLUSTER}
+      scheduleIdReadOnly={scheduleIdReadOnly}
     />
   );
 }
@@ -217,6 +231,7 @@ function TestWrapper({
 async function setup({
   defaultValues,
   injectFieldErrors = false,
+  scheduleIdReadOnly,
   taskListValidation = {
     isTaskListLoading: false,
     taskListCaptionMessage: null,
@@ -230,6 +245,7 @@ async function setup({
     <TestWrapper
       defaultValues={defaultValues}
       injectFieldErrors={injectFieldErrors}
+      scheduleIdReadOnly={scheduleIdReadOnly}
     />
   );
 

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -39,6 +39,7 @@ export default function DomainSchedulesCreateForm({
   clearErrors,
   domain,
   cluster,
+  scheduleIdReadOnly,
 }: Props) {
   const { errors: fieldErrors, isSubmitted } = useFormState({ control });
 
@@ -343,6 +344,7 @@ export default function DomainSchedulesCreateForm({
         isSubmitted={isSubmitted}
         clearErrors={clearErrors}
         cluster={cluster}
+        scheduleIdReadOnly={scheduleIdReadOnly}
       />
     </div>
   );

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -12,4 +12,6 @@ export type Props = {
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   domain: string;
   cluster: string;
+  /** Renders the Schedule Id field disabled, for flows where the id is fixed. */
+  scheduleIdReadOnly?: boolean;
 };

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-edit-schedule-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-edit-schedule-form-data.ts
@@ -1,0 +1,19 @@
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+export const mockEditScheduleFormData: EditScheduleFormData = {
+  scheduleId: 'mock-schedule-id',
+  cronExpression: {
+    minutes: '0',
+    hours: '9',
+    daysOfMonth: '*',
+    months: '*',
+    daysOfWeek: '*',
+  },
+  workflowType: { name: 'DemoWorkflow' },
+  taskList: { name: 'demo-task-list' },
+  workerSDKLanguage: 'GO',
+  executionStartToCloseTimeoutSeconds: 3600,
+  taskStartToCloseTimeoutSeconds: 30,
+  input: [''],
+  pauseOnFailure: false,
+};

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
@@ -3,6 +3,10 @@ import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api
 import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
 
+export function encodePayload(json: string) {
+  return { data: Buffer.from(json, 'utf-8').toString('base64') };
+}
+
 /** A fully-populated schedule, used to check that every form field prefills. */
 export function getMockEditableDescribeScheduleResponse(
   overrides: Partial<DescribeScheduleResponse> = {}
@@ -22,15 +26,25 @@ export function getMockEditableDescribeScheduleResponse(
           kind: 'TASK_LIST_KIND_NORMAL',
           baseName: 'demo-task-list',
         },
-        input: {
-          data: Buffer.from('{"a":1} {"b":2}', 'utf-8').toString('base64'),
-        },
+        input: encodePayload('{"a":1} {"b":2}'),
         workflowIdPrefix: 'scheduled-demo-',
         executionStartToCloseTimeout: { seconds: '3600', nanos: 0 },
         taskStartToCloseTimeout: { seconds: '30', nanos: 0 },
-        retryPolicy: null,
-        memo: null,
-        searchAttributes: null,
+        retryPolicy: {
+          initialInterval: { seconds: '10', nanos: 0 },
+          backoffCoefficient: 2,
+          maximumInterval: { seconds: '600', nanos: 0 },
+          maximumAttempts: 5,
+          expirationInterval: null,
+          nonRetryableErrorReasons: [],
+        },
+        memo: { fields: { owner: encodePayload('"team-a"') } },
+        searchAttributes: {
+          indexedFields: {
+            CustomKeywordField: encodePayload('"keyword"'),
+            CustomIntField: encodePayload('7'),
+          },
+        },
       },
     },
     policies: {

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
@@ -1,0 +1,46 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+
+/** A fully-populated schedule, used to check that every form field prefills. */
+export function getMockEditableDescribeScheduleResponse(
+  overrides: Partial<DescribeScheduleResponse> = {}
+): DescribeScheduleResponse {
+  return getMockDescribeScheduleResponse({
+    spec: {
+      cronExpression: '30 9 1 * *',
+      startTime: { seconds: '1767225600', nanos: 0 },
+      endTime: { seconds: '1767312000', nanos: 0 },
+      jitter: { seconds: '90', nanos: 0 },
+    },
+    action: {
+      startWorkflow: {
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: {
+          name: 'demo-task-list',
+          kind: 'TASK_LIST_KIND_NORMAL',
+          baseName: 'demo-task-list',
+        },
+        input: {
+          data: Buffer.from('{"a":1} {"b":2}', 'utf-8').toString('base64'),
+        },
+        workflowIdPrefix: 'scheduled-demo-',
+        executionStartToCloseTimeout: { seconds: '3600', nanos: 0 },
+        taskStartToCloseTimeout: { seconds: '30', nanos: 0 },
+        retryPolicy: null,
+        memo: null,
+        searchAttributes: null,
+      },
+    },
+    policies: {
+      overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+      catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL,
+      catchUpWindow: { seconds: '172800', nanos: 0 },
+      pauseOnFailure: true,
+      bufferLimit: 5,
+      concurrencyLimit: 0,
+    },
+    ...overrides,
+  });
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.types.tst.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.types.tst.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'tstyche';
+
+import type { ExhaustiveDefaults } from '../schedule-action-edit-form.types.js';
+
+type Fields = {
+  required: string;
+  optional?: number;
+};
+
+describe('ExhaustiveDefaults', () => {
+  it('accepts a literal that assigns every field', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.toBeAssignableWith({
+      required: 'value',
+      optional: 1,
+    });
+  });
+
+  it('still allows an optional field to be assigned undefined', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.toBeAssignableWith({
+      required: 'value',
+      optional: undefined,
+    });
+  });
+
+  it('rejects a literal that leaves an optional field out', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.not.toBeAssignableWith({
+      required: 'value',
+    });
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -3,7 +3,10 @@ import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api
 import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
 
-import { getMockEditableDescribeScheduleResponse } from '../../__fixtures__/mock-editable-describe-schedule-response';
+import {
+  encodePayload,
+  getMockEditableDescribeScheduleResponse,
+} from '../../__fixtures__/mock-editable-describe-schedule-response';
 import { EMPTY_CRON_EXPRESSION_FIELDS } from '../../schedule-action-edit-form.constants';
 import transformDescribeScheduleResponseToFormData from '../transform-describe-schedule-response-to-form-data';
 
@@ -99,6 +102,68 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
     ).toEqual('2');
   });
 
+  it('prefills the retry policy and limits retries by attempts', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        enableRetryPolicy: true,
+        limitRetries: 'ATTEMPTS',
+        retryPolicy: {
+          initialIntervalSeconds: '10',
+          backoffCoefficient: '2',
+          maximumIntervalSeconds: '600',
+          maximumAttempts: '5',
+          expirationIntervalSeconds: undefined,
+        },
+      })
+    );
+  });
+
+  it('limits retries by duration when the policy has an expiration interval', () => {
+    const formData = transform(
+      withStartWorkflow({
+        retryPolicy: {
+          initialInterval: { seconds: '10', nanos: 0 },
+          backoffCoefficient: 2,
+          maximumInterval: null,
+          maximumAttempts: 0,
+          expirationInterval: { seconds: '3600', nanos: 0 },
+          nonRetryableErrorReasons: [],
+        },
+      })
+    );
+
+    expect(formData.limitRetries).toEqual('DURATION');
+    expect(formData.retryPolicy?.expirationIntervalSeconds).toEqual('3600');
+    expect(formData.retryPolicy?.maximumAttempts).toBeUndefined();
+  });
+
+  it('decodes search attribute payloads into key/value pairs', () => {
+    expect(transform().searchAttributes).toEqual([
+      { key: 'CustomKeywordField', value: 'keyword' },
+      { key: 'CustomIntField', value: 7 },
+    ]);
+  });
+
+  it('keeps the JSON text for a search attribute that is not a primitive', () => {
+    expect(
+      transform(
+        withStartWorkflow({
+          searchAttributes: {
+            indexedFields: { CustomListField: encodePayload('["a","b"]') },
+          },
+        })
+      ).searchAttributes
+    ).toEqual([{ key: 'CustomListField', value: '["a","b"]' }]);
+  });
+
+  it('decodes the memo into formatted JSON for the textarea', () => {
+    expect(transform().memo).toEqual('{\n  "owner": "team-a"\n}');
+  });
+
+  it('leaves the memo unset when the schedule has none', () => {
+    expect(transform(withStartWorkflow({ memo: null })).memo).toBeUndefined();
+  });
+
   it('falls back to blank values for an empty schedule', () => {
     const formData = transform(getMockDescribeScheduleResponse());
 
@@ -137,4 +202,23 @@ function transform(
     schedule,
     MOCK_SCHEDULE_ID
   );
+}
+
+/** Overrides fields on the mock's start-workflow action, keeping the rest. */
+function withStartWorkflow(
+  overrides: Partial<
+    NonNullable<
+      NonNullable<DescribeScheduleResponse['action']>['startWorkflow']
+    >
+  >
+): DescribeScheduleResponse {
+  const mock = getMockEditableDescribeScheduleResponse();
+  const startWorkflow = mock.action?.startWorkflow;
+
+  if (!startWorkflow)
+    throw new Error('mock is missing a start workflow action');
+
+  return getMockEditableDescribeScheduleResponse({
+    action: { startWorkflow: { ...startWorkflow, ...overrides } },
+  });
 }

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -1,0 +1,140 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+
+import { getMockEditableDescribeScheduleResponse } from '../../__fixtures__/mock-editable-describe-schedule-response';
+import { EMPTY_CRON_EXPRESSION_FIELDS } from '../../schedule-action-edit-form.constants';
+import transformDescribeScheduleResponseToFormData from '../transform-describe-schedule-response-to-form-data';
+
+const MOCK_SCHEDULE_ID = 'mock-schedule-id';
+
+describe(transformDescribeScheduleResponseToFormData.name, () => {
+  it('prefills the schedule id from the route rather than the response', () => {
+    expect(transform().scheduleId).toEqual(MOCK_SCHEDULE_ID);
+  });
+
+  it('splits the cron expression into its five fields', () => {
+    expect(transform().cronExpression).toEqual({
+      minutes: '30',
+      hours: '9',
+      daysOfMonth: '1',
+      months: '*',
+      daysOfWeek: '*',
+    });
+  });
+
+  it('leaves the cron fields empty for an expression it cannot split', () => {
+    expect(
+      transform(
+        getMockEditableDescribeScheduleResponse({
+          spec: {
+            cronExpression: '@every 1h',
+            startTime: null,
+            endTime: null,
+            jitter: null,
+          },
+        })
+      ).cronExpression
+    ).toEqual(EMPTY_CRON_EXPRESSION_FIELDS);
+  });
+
+  it('prefills the start workflow action fields', () => {
+    const formData = transform();
+
+    expect(formData).toEqual(
+      expect.objectContaining({
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: { name: 'demo-task-list' },
+        executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: 30,
+        workflowIdPrefix: 'scheduled-demo-',
+        workerSDKLanguage: 'GO',
+      })
+    );
+  });
+
+  it('splits a multi-argument workflow input back into separate entries', () => {
+    expect(transform().input).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it('prefills the policy fields', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+        catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL,
+        catchUpWindowDays: '2',
+        bufferLimit: '5',
+        concurrencyLimit: '0',
+        pauseOnFailure: true,
+      })
+    );
+  });
+
+  it('prefills the schedule period and jitter', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        startTime: '2026-01-01T00:00:00.000Z',
+        endTime: '2026-01-02T00:00:00.000Z',
+        jitterSeconds: '90',
+      })
+    );
+  });
+
+  it('rounds a partial catch-up window day up, so the window is never narrowed', () => {
+    expect(
+      transform(
+        getMockEditableDescribeScheduleResponse({
+          policies: {
+            overlapPolicy:
+              ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+            catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE,
+            catchUpWindow: { seconds: '90000', nanos: 0 },
+            pauseOnFailure: false,
+            bufferLimit: 0,
+            concurrencyLimit: 0,
+          },
+        })
+      ).catchUpWindowDays
+    ).toEqual('2');
+  });
+
+  it('falls back to blank values for an empty schedule', () => {
+    const formData = transform(getMockDescribeScheduleResponse());
+
+    expect(formData).toEqual({
+      scheduleId: MOCK_SCHEDULE_ID,
+      cronExpression: EMPTY_CRON_EXPRESSION_FIELDS,
+      workflowType: { name: '' },
+      taskList: { name: '' },
+      executionStartToCloseTimeoutSeconds: 0,
+      taskStartToCloseTimeoutSeconds: 0,
+      workerSDKLanguage: 'GO',
+      input: [''],
+      workflowIdPrefix: undefined,
+      pauseOnFailure: false,
+      overlapPolicy: undefined,
+      bufferLimit: undefined,
+      concurrencyLimit: undefined,
+      catchUpPolicy: undefined,
+      catchUpWindowDays: undefined,
+      jitterSeconds: undefined,
+      startTime: undefined,
+      endTime: undefined,
+      enableRetryPolicy: false,
+      limitRetries: undefined,
+      retryPolicy: undefined,
+      searchAttributes: undefined,
+      memo: undefined,
+    });
+  });
+});
+
+function transform(
+  schedule: DescribeScheduleResponse = getMockEditableDescribeScheduleResponse()
+) {
+  return transformDescribeScheduleResponseToFormData(
+    schedule,
+    MOCK_SCHEDULE_ID
+  );
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
@@ -1,0 +1,30 @@
+import { mockEditScheduleFormData } from '../../__fixtures__/mock-edit-schedule-form-data';
+import transformEditScheduleFormToSubmission from '../transform-edit-schedule-form-to-submission';
+
+describe(transformEditScheduleFormToSubmission.name, () => {
+  it('maps the form onto the update schedule body', () => {
+    const result = transformEditScheduleFormToSubmission(
+      mockEditScheduleFormData
+    );
+
+    expect(result).toEqual({
+      cronExpression: '0 9 * * *',
+      pauseOnFailure: false,
+      startWorkflow: {
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: { name: 'demo-task-list' },
+        workerSDKLanguage: 'GO',
+        executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: 30,
+      },
+    });
+  });
+
+  it('omits the schedule id, which the update URL carries instead', () => {
+    const result = transformEditScheduleFormToSubmission(
+      mockEditScheduleFormData
+    );
+
+    expect(result).not.toHaveProperty('scheduleId');
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -1,3 +1,5 @@
+import { type RetryPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/RetryPolicy';
+import { type _uber_cadence_api_v1_ScheduleAction_StartWorkflowAction as StartWorkflowAction } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleAction';
 import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
 import {
   SCHEDULE_CATCH_UP_POLICIES,
@@ -7,8 +9,10 @@ import {
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
 import formatDurationToSeconds from '@/utils/data-formatters/format-duration-to-seconds';
 import formatInputPayload from '@/utils/data-formatters/format-input-payload';
+import formatPayloadMap from '@/utils/data-formatters/format-payload-map';
 import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 import losslessJsonStringify from '@/utils/lossless-json-stringify';
+import { type RetryPolicyFormFields } from '@/views/shared/retry-policy-fields/schemas/retry-policy-form-schema';
 
 import {
   EMPTY_CRON_EXPRESSION_FIELDS,
@@ -68,13 +72,95 @@ export default function transformDescribeScheduleResponseToFormData(
     startTime: formatTimestampToIso(schedule.spec?.startTime),
     endTime: formatTimestampToIso(schedule.spec?.endTime),
 
-    // TODO(PR08d): decode the schedule's retry policy, search attributes and memo.
-    enableRetryPolicy: false,
-    limitRetries: undefined,
-    retryPolicy: undefined,
-    searchAttributes: undefined,
-    memo: undefined,
+    ...mapRetryPolicyToFormDefaults(startWorkflow?.retryPolicy),
+    searchAttributes: mapSearchAttributesToFormDefaults(
+      startWorkflow?.searchAttributes
+    ),
+    memo: mapMemoToFormDefault(startWorkflow?.memo),
   };
+}
+
+/**
+ * Has its own exhaustive return type: the top-level one cannot reach into the
+ * nested retry policy object, whose sub-fields are all optional too.
+ */
+function mapRetryPolicyToFormDefaults(
+  retryPolicy: RetryPolicy | null | undefined
+): ExhaustiveDefaults<RetryPolicyFormFields> {
+  if (!retryPolicy) {
+    return {
+      enableRetryPolicy: false,
+      limitRetries: undefined,
+      retryPolicy: undefined,
+    };
+  }
+
+  const expirationIntervalSeconds = formatDurationToSeconds(
+    retryPolicy.expirationInterval
+  );
+
+  const retryPolicyValues: ExhaustiveDefaults<
+    NonNullable<RetryPolicyFormFields['retryPolicy']>
+  > = {
+    initialIntervalSeconds: stringifyPositiveNumber(
+      formatDurationToSeconds(retryPolicy.initialInterval)
+    ),
+    backoffCoefficient: stringifyPositiveNumber(retryPolicy.backoffCoefficient),
+    maximumIntervalSeconds: stringifyPositiveNumber(
+      formatDurationToSeconds(retryPolicy.maximumInterval)
+    ),
+    maximumAttempts: stringifyPositiveNumber(retryPolicy.maximumAttempts),
+    expirationIntervalSeconds: stringifyPositiveNumber(
+      expirationIntervalSeconds
+    ),
+  };
+
+  return {
+    enableRetryPolicy: true,
+    // The form offers the two limits as an either/or, and the schedule only
+    // carries an expiration interval when it was configured by duration.
+    limitRetries: expirationIntervalSeconds ? 'DURATION' : 'ATTEMPTS',
+    retryPolicy: retryPolicyValues,
+  };
+}
+
+function mapSearchAttributesToFormDefaults(
+  searchAttributes: StartWorkflowAction['searchAttributes'] | undefined
+): EditScheduleFormData['searchAttributes'] {
+  const decoded = formatPayloadMap(searchAttributes ?? null, 'indexedFields')
+    ?.indexedFields as Record<string, unknown> | undefined;
+
+  if (!decoded || Object.keys(decoded).length === 0) {
+    return undefined;
+  }
+
+  return Object.entries(decoded).map(([key, value]) => ({
+    key,
+    // The form only edits primitives; anything richer keeps its JSON text.
+    value:
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+        ? value
+        : losslessJsonStringify(value),
+  }));
+}
+
+function mapMemoToFormDefault(
+  memo: StartWorkflowAction['memo'] | undefined
+): string | undefined {
+  const decoded = formatPayloadMap(memo ?? null, 'fields')?.fields as
+    | Record<string, unknown>
+    | undefined;
+
+  return decoded && Object.keys(decoded).length > 0
+    ? losslessJsonStringify(decoded, null, 2)
+    : undefined;
+}
+
+/** Zero and missing values both mean "unset" for these form fields. */
+function stringifyPositiveNumber(value: number | null | undefined) {
+  return value ? String(value) : undefined;
 }
 
 /**

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -1,0 +1,122 @@
+import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
+import {
+  SCHEDULE_CATCH_UP_POLICIES,
+  SCHEDULE_OVERLAP_POLICIES,
+  WORKER_SDK_LANGUAGES,
+} from '@/route-handlers/create-schedule/create-schedule.constants';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+import formatDurationToSeconds from '@/utils/data-formatters/format-duration-to-seconds';
+import formatInputPayload from '@/utils/data-formatters/format-input-payload';
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+import losslessJsonStringify from '@/utils/lossless-json-stringify';
+
+import {
+  EMPTY_CRON_EXPRESSION_FIELDS,
+  SECONDS_PER_DAY,
+} from '../schedule-action-edit-form.constants';
+import {
+  type EditScheduleFormData,
+  type ExhaustiveDefaults,
+} from '../schedule-action-edit-form.types';
+
+/**
+ * Builds the edit form's default values from an existing schedule.
+ *
+ * The return type deliberately makes every key required: forgetting to map a
+ * newly-added form field then fails `npm run typecheck` instead of silently
+ * prefilling that field as blank.
+ */
+export default function transformDescribeScheduleResponseToFormData(
+  schedule: DescribeScheduleResponse,
+  scheduleId: string
+): ExhaustiveDefaults<EditScheduleFormData> {
+  const startWorkflow = schedule.action?.startWorkflow;
+  const policies = schedule.policies;
+  const parsedInput = formatInputPayload(startWorkflow?.input);
+
+  return {
+    scheduleId,
+    cronExpression: splitCronExpression(schedule.spec?.cronExpression),
+    workflowType: { name: startWorkflow?.workflowType?.name ?? '' },
+    taskList: { name: startWorkflow?.taskList?.name ?? '' },
+    executionStartToCloseTimeoutSeconds:
+      formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ?? 0,
+    taskStartToCloseTimeoutSeconds:
+      formatDurationToSeconds(startWorkflow?.taskStartToCloseTimeout) ?? 0,
+    // The worker SDK is not stored on the schedule, only the input encoding it
+    // produced, which is ambiguous between languages. Fall back to the same
+    // default the create form uses.
+    workerSDKLanguage: WORKER_SDK_LANGUAGES[0],
+    input: parsedInput?.length
+      ? parsedInput.map((value) => losslessJsonStringify(value))
+      : [''],
+    workflowIdPrefix: startWorkflow?.workflowIdPrefix || undefined,
+    pauseOnFailure: policies?.pauseOnFailure ?? false,
+
+    overlapPolicy: SCHEDULE_OVERLAP_POLICIES.find(
+      (policy) => policy === policies?.overlapPolicy
+    ),
+    bufferLimit: stringifyLimit(policies?.bufferLimit),
+    concurrencyLimit: stringifyLimit(policies?.concurrencyLimit),
+    catchUpPolicy: SCHEDULE_CATCH_UP_POLICIES.find(
+      (policy) => policy === policies?.catchUpPolicy
+    ),
+    catchUpWindowDays: formatCatchUpWindowDays(policies?.catchUpWindow),
+
+    jitterSeconds:
+      formatDurationToSeconds(schedule.spec?.jitter)?.toString() ?? undefined,
+    startTime: formatTimestampToIso(schedule.spec?.startTime),
+    endTime: formatTimestampToIso(schedule.spec?.endTime),
+
+    // TODO(PR08d): decode the schedule's retry policy, search attributes and memo.
+    enableRetryPolicy: false,
+    limitRetries: undefined,
+    retryPolicy: undefined,
+    searchAttributes: undefined,
+    memo: undefined,
+  };
+}
+
+/**
+ * ponytail: only plain 5-field cron expressions map onto the cron inputs. A
+ * schedule using another syntax (for example `@every 1h`) prefills empty, so the
+ * form asks for a cron rather than silently mangling it. Upgrade path: teach
+ * `CronScheduleInput` about the other syntaxes and widen this.
+ */
+function splitCronExpression(
+  cronExpression: string | undefined
+): EditScheduleFormData['cronExpression'] {
+  const fields = cronExpression?.trim().split(/\s+/) ?? [];
+
+  if (fields.length !== CRON_FIELD_ORDER.length) {
+    return EMPTY_CRON_EXPRESSION_FIELDS;
+  }
+
+  return Object.fromEntries(
+    CRON_FIELD_ORDER.map((field, index) => [field, fields[index]])
+  ) as EditScheduleFormData['cronExpression'];
+}
+
+function stringifyLimit(limit: number | undefined): string | undefined {
+  return limit === undefined ? undefined : String(limit);
+}
+
+/**
+ * The form only accepts whole days, so a partial day rounds up rather than down
+ * to avoid narrowing the window the schedule already runs with.
+ */
+function formatCatchUpWindowDays(
+  catchUpWindow: Parameters<typeof formatDurationToSeconds>[0]
+): string | undefined {
+  const seconds = formatDurationToSeconds(catchUpWindow);
+
+  return seconds ? String(Math.ceil(seconds / SECONDS_PER_DAY)) : undefined;
+}
+
+function formatTimestampToIso(
+  timestamp: Parameters<typeof parseGrpcTimestamp>[0] | null | undefined
+): string | undefined {
+  return timestamp
+    ? new Date(parseGrpcTimestamp(timestamp)).toISOString()
+    : undefined;
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
@@ -1,18 +1,10 @@
-import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
 import transformDomainSchedulesCreateFormToBody from '@/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body';
 
-import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+import {
+  type EditScheduleFormData,
+  type EditScheduleSubmissionData,
+} from '../schedule-action-edit-form.types';
 
-export type EditScheduleSubmissionData = Omit<
-  CreateScheduleRequestBody,
-  'scheduleId'
->;
-
-/**
- * UpdateSchedule replaces the whole schedule definition, so the body matches
- * the create one. The schedule id is display-only in the edit form: the PUT URL
- * already carries it and the schedule id of an existing schedule cannot change.
- */
 export default function transformEditScheduleFormToSubmission(
   formData: EditScheduleFormData
 ): EditScheduleSubmissionData {

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
@@ -1,0 +1,23 @@
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+import transformDomainSchedulesCreateFormToBody from '@/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body';
+
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+export type EditScheduleSubmissionData = Omit<
+  CreateScheduleRequestBody,
+  'scheduleId'
+>;
+
+/**
+ * UpdateSchedule replaces the whole schedule definition, so the body matches
+ * the create one. The schedule id is display-only in the edit form: the PUT URL
+ * already carries it and the schedule id of an existing schedule cannot change.
+ */
+export default function transformEditScheduleFormToSubmission(
+  formData: EditScheduleFormData
+): EditScheduleSubmissionData {
+  const { scheduleId: _scheduleId, ...body } =
+    transformDomainSchedulesCreateFormToBody(formData);
+
+  return body;
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
@@ -1,0 +1,9 @@
+export const SECONDS_PER_DAY = 24 * 60 * 60;
+
+export const EMPTY_CRON_EXPRESSION_FIELDS = {
+  minutes: '',
+  hours: '',
+  daysOfMonth: '',
+  months: '',
+  daysOfWeek: '',
+} as const;

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -1,0 +1,13 @@
+import { type z } from 'zod';
+
+import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
+
+export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
+
+/**
+ * Forces every key of T to be explicitly assigned, including optional fields,
+ * whose value may still be `undefined`. Adding a field to T without updating a
+ * literal typed as `ExhaustiveDefaults<T>` is a compile error, which is what
+ * stops a newly-added form field from silently prefilling as blank.
+ */
+export type ExhaustiveDefaults<T> = { [K in keyof T]-?: T[K] };

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -9,5 +9,9 @@ export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
  * whose value may still be `undefined`. Adding a field to T without updating a
  * literal typed as `ExhaustiveDefaults<T>` is a compile error, which is what
  * stops a newly-added form field from silently prefilling as blank.
+ *
+ * The keys come from `Required<T>` rather than from `[K in keyof T]-?` because
+ * the `-?` modifier would also strip `undefined` out of the value type, which
+ * would make genuinely optional fields impossible to leave unset.
  */
-export type ExhaustiveDefaults<T> = { [K in keyof T]-?: T[K] };
+export type ExhaustiveDefaults<T> = { [K in keyof Required<T>]: T[K] };

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -1,8 +1,20 @@
 import { type z } from 'zod';
 
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+
 import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
 
 export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
+
+/**
+ * UpdateSchedule replaces the whole schedule definition, so the body matches
+ * the create one. The schedule id is display-only in the edit form: the PUT URL
+ * already carries it and the schedule id of an existing schedule cannot change.
+ */
+export type EditScheduleSubmissionData = Omit<
+  CreateScheduleRequestBody,
+  'scheduleId'
+>;
 
 /**
  * Forces every key of T to be explicitly assigned, including optional fields,

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
@@ -1,0 +1,55 @@
+import { mockEditScheduleFormData } from '../../__fixtures__/mock-edit-schedule-form-data';
+import { editScheduleFormSchema } from '../edit-schedule-form-schema';
+
+describe('editScheduleFormSchema', () => {
+  it('accepts a fully prefilled edit form', () => {
+    const result = editScheduleFormSchema.safeParse(mockEditScheduleFormData);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('requires a schedule id, unlike the create form', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      scheduleId: '',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['scheduleId'],
+        message: 'Schedule id is required',
+      }),
+    ]);
+  });
+
+  it('applies the shared create-schedule refinements', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      memo: 'not json',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['memo'],
+        message: 'Memo must be valid JSON',
+      }),
+    ]);
+  });
+
+  it('applies the shared create-schedule field validation', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      workflowType: { name: '' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['workflowType', 'name'],
+        message: 'Workflow type is required',
+      }),
+    ]);
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
@@ -8,21 +8,6 @@ describe('editScheduleFormSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('requires a schedule id, unlike the create form', () => {
-    const result = editScheduleFormSchema.safeParse({
-      ...mockEditScheduleFormData,
-      scheduleId: '',
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.error?.errors).toEqual([
-      expect.objectContaining({
-        path: ['scheduleId'],
-        message: 'Schedule id is required',
-      }),
-    ]);
-  });
-
   it('applies the shared create-schedule refinements', () => {
     const result = editScheduleFormSchema.safeParse({
       ...mockEditScheduleFormData,

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import refineCreateScheduleForm from '@/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form';
+import { createScheduleFormFieldsSchema } from '@/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema';
+
+/**
+ * Editing validates exactly like creating, except the schedule id is always
+ * known: it is prefilled from the existing schedule and shown read-only.
+ */
+export const editScheduleFormSchema = createScheduleFormFieldsSchema
+  .extend({ scheduleId: z.string().min(1, 'Schedule id is required') })
+  .superRefine(refineCreateScheduleForm);

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
@@ -1,12 +1,11 @@
-import { z } from 'zod';
-
 import refineCreateScheduleForm from '@/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form';
 import { createScheduleFormFieldsSchema } from '@/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema';
 
 /**
- * Editing validates exactly like creating, except the schedule id is always
- * known: it is prefilled from the existing schedule and shown read-only.
+ * Editing validates exactly like creating. Keeping the field shapes identical
+ * is what lets the edit form reuse the create form components as they are, so
+ * this deliberately re-composes the create pieces rather than adding rules of
+ * its own. It exists as a separate schema so edit-only rules have a home.
  */
-export const editScheduleFormSchema = createScheduleFormFieldsSchema
-  .extend({ scheduleId: z.string().min(1, 'Schedule id is required') })
-  .superRefine(refineCreateScheduleForm);
+export const editScheduleFormSchema =
+  createScheduleFormFieldsSchema.superRefine(refineCreateScheduleForm);


### PR DESCRIPTION
## Summary

Completes the **Edit Schedule** prefill transform by decoding the three payload-backed fields left blank in the previous slice: the retry policy, search attributes and memo. Removes the `TODO(PR08d)` marker. Still nothing imports this file, so there is no user-visible change.

Part of the Edit Schedule stack (PR08d). **Stacked on [#1466](https://github.com/cadence-workflow/cadence-web/pull/1466)** — review the last commit only; merge the parents first.

## Changes

- `mapRetryPolicyToFormDefaults`: turns the schedule's retry policy into the form's `enableRetryPolicy` / `limitRetries` / `retryPolicy` trio. It carries its own `ExhaustiveDefaults<...>` return type, because the top-level one cannot reach into a nested object whose sub-fields are all optional. `limitRetries` is derived from whether the policy has an expiration interval, since the form presents attempts and duration as an either/or.
- `mapSearchAttributesToFormDefaults` and `mapMemoToFormDefault`: decode via the existing `formatPayloadMap`. A search attribute value that is not a string, number or boolean keeps its JSON text, since the form only edits primitives. The memo is pretty-printed for the textarea.
- Extends the fixture and test file from the previous slice with these fields populated

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm run test:unit:browser -- schedule-action-edit-form` (21 tests passing). New cases cover a retry policy limited by attempts and one limited by duration, decoding search attributes into key/value pairs, the non-primitive search attribute fallback, and the memo both present and absent.
