### PR TITLE
feat(schedule-actions): add the edit schedule action

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/schedules/[scheduleId]/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest } from 'next/server';
 import { deleteSchedule } from '@/route-handlers/delete-schedule/delete-schedule';
 import { describeSchedule } from '@/route-handlers/describe-schedule/describe-schedule';
 import { type RouteParams } from '@/route-handlers/describe-schedule/describe-schedule.types';
+import { updateSchedule } from '@/route-handlers/update-schedule/update-schedule';
 import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
 import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
 
@@ -12,6 +13,18 @@ export async function GET(
 ) {
   return routeHandlerWithMiddlewares(
     describeSchedule,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}
+
+export async function PUT(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    updateSchedule,
     request,
     options,
     routeHandlersDefaultMiddlewares

--- a/src/config/dynamic/resolvers/__tests__/schedule-actions-enabled.node.ts
+++ b/src/config/dynamic/resolvers/__tests__/schedule-actions-enabled.node.ts
@@ -28,6 +28,7 @@ describe(scheduleActionsEnabled.name, () => {
       resume: 'ENABLED',
       delete: 'ENABLED',
       backfill: 'ENABLED',
+      edit: 'ENABLED',
     });
   });
 
@@ -44,6 +45,7 @@ describe(scheduleActionsEnabled.name, () => {
       resume: 'DISABLED_UNAUTHORIZED',
       delete: 'DISABLED_UNAUTHORIZED',
       backfill: 'DISABLED_UNAUTHORIZED',
+      edit: 'DISABLED_UNAUTHORIZED',
     });
   });
 
@@ -60,6 +62,7 @@ describe(scheduleActionsEnabled.name, () => {
       resume: 'DISABLED_DEFAULT',
       delete: 'DISABLED_DEFAULT',
       backfill: 'DISABLED_DEFAULT',
+      edit: 'DISABLED_DEFAULT',
     });
   });
 });

--- a/src/config/dynamic/resolvers/schedule-actions-enabled.constants.ts
+++ b/src/config/dynamic/resolvers/schedule-actions-enabled.constants.ts
@@ -6,6 +6,7 @@ export const AUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
     resume: 'ENABLED',
     delete: 'ENABLED',
     backfill: 'ENABLED',
+    edit: 'ENABLED',
   };
 
 export const UNAUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
@@ -14,6 +15,7 @@ export const UNAUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig 
     resume: 'DISABLED_UNAUTHORIZED',
     delete: 'DISABLED_UNAUTHORIZED',
     backfill: 'DISABLED_UNAUTHORIZED',
+    edit: 'DISABLED_UNAUTHORIZED',
   };
 
 export const DEFAULT_DISABLED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
@@ -22,4 +24,5 @@ export const DEFAULT_DISABLED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledCon
     resume: 'DISABLED_DEFAULT',
     delete: 'DISABLED_DEFAULT',
     backfill: 'DISABLED_DEFAULT',
+    edit: 'DISABLED_DEFAULT',
   };

--- a/src/config/dynamic/resolvers/schedule-actions-enabled.types.ts
+++ b/src/config/dynamic/resolvers/schedule-actions-enabled.types.ts
@@ -1,6 +1,11 @@
 import type SCHEDULE_ACTIONS_DISABLED_VALUES_CONFIG from './schedule-actions-disabled-values.config';
 
-export type ScheduleActionID = 'pause' | 'resume' | 'delete' | 'backfill';
+export type ScheduleActionID =
+  | 'pause'
+  | 'resume'
+  | 'delete'
+  | 'backfill'
+  | 'edit';
 
 export type ScheduleActionDisabledValue =
   (typeof SCHEDULE_ACTIONS_DISABLED_VALUES_CONFIG)[number];

--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -76,6 +76,7 @@ const resolverSchemas: ResolverSchemas = {
       resume: scheduleActionsEnabledValueSchema,
       delete: scheduleActionsEnabledValueSchema,
       backfill: scheduleActionsEnabledValueSchema,
+      edit: scheduleActionsEnabledValueSchema,
     }),
   },
   CRON_LIST_ENABLED: {

--- a/src/route-handlers/create-schedule/schemas/create-schedule-request-body-schema.ts
+++ b/src/route-handlers/create-schedule/schemas/create-schedule-request-body-schema.ts
@@ -37,41 +37,50 @@ const scheduleStartWorkflowBodySchema = z.object({
     .optional(),
 });
 
-const createScheduleRequestBodySchema = z
-  .object({
-    // Schedule identity (server generates one when omitted)
-    scheduleId: z.string().min(1).optional(),
+/**
+ * Spec, policies and action fields shared by create and update. UpdateSchedule
+ * accepts the same payload minus the schedule id, which it takes from the URL.
+ */
+export const scheduleBodyFieldsSchema = z.object({
+  // Schedule spec
+  cronExpression: z.string().min(1),
+  startTime: z.string().datetime().optional(),
+  endTime: z.string().datetime().optional(),
+  jitterSeconds: z.number().nonnegative().optional(),
 
-    // Schedule spec
-    cronExpression: z.string().min(1),
-    startTime: z.string().datetime().optional(),
-    endTime: z.string().datetime().optional(),
-    jitterSeconds: z.number().nonnegative().optional(),
+  // Schedule policies
+  overlapPolicy: z.enum(SCHEDULE_OVERLAP_POLICIES).optional(),
+  catchUpPolicy: z.enum(SCHEDULE_CATCH_UP_POLICIES).optional(),
+  catchUpWindowSeconds: z.number().nonnegative().optional(),
+  pauseOnFailure: z.boolean().optional(),
+  bufferLimit: z.number().int().nonnegative().optional(),
+  concurrencyLimit: z.number().int().nonnegative().optional(),
 
-    // Schedule policies
-    overlapPolicy: z.enum(SCHEDULE_OVERLAP_POLICIES).optional(),
-    catchUpPolicy: z.enum(SCHEDULE_CATCH_UP_POLICIES).optional(),
-    catchUpWindowSeconds: z.number().nonnegative().optional(),
-    pauseOnFailure: z.boolean().optional(),
-    bufferLimit: z.number().int().nonnegative().optional(),
-    concurrencyLimit: z.number().int().nonnegative().optional(),
+  // Start-workflow action
+  startWorkflow: scheduleStartWorkflowBodySchema,
+});
 
-    // Start-workflow action
-    startWorkflow: scheduleStartWorkflowBodySchema,
-  })
-  .superRefine((data, ctx) => {
-    const schedulePeriodError = getSchedulePeriodError(
-      data.startTime,
-      data.endTime
-    );
+export function refineScheduleBodyPeriod(
+  data: { startTime?: string; endTime?: string },
+  ctx: z.RefinementCtx
+) {
+  const schedulePeriodError = getSchedulePeriodError(
+    data.startTime,
+    data.endTime
+  );
 
-    if (schedulePeriodError) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: schedulePeriodError.message,
-        path: ['endTime'],
-      });
-    }
-  });
+  if (schedulePeriodError) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: schedulePeriodError.message,
+      path: ['endTime'],
+    });
+  }
+}
+
+const createScheduleRequestBodySchema = scheduleBodyFieldsSchema
+  // Schedule identity (server generates one when omitted)
+  .extend({ scheduleId: z.string().min(1).optional() })
+  .superRefine(refineScheduleBodyPeriod);
 
 export default createScheduleRequestBodySchema;

--- a/src/route-handlers/update-schedule/__fixtures__/update-schedule-request-body.ts
+++ b/src/route-handlers/update-schedule/__fixtures__/update-schedule-request-body.ts
@@ -1,0 +1,8 @@
+import { mockCreateScheduleRequestBody } from '../../create-schedule/__fixtures__/create-schedule-request-body';
+import { type UpdateScheduleRequestBody } from '../update-schedule.types';
+
+const { scheduleId: _scheduleId, ...mockUpdateScheduleRequestBodyFields } =
+  mockCreateScheduleRequestBody;
+
+export const mockUpdateScheduleRequestBody: UpdateScheduleRequestBody =
+  mockUpdateScheduleRequestBodyFields;

--- a/src/route-handlers/update-schedule/__tests__/update-schedule.node.ts
+++ b/src/route-handlers/update-schedule/__tests__/update-schedule.node.ts
@@ -1,0 +1,139 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import { mockUpdateScheduleRequestBody } from '../__fixtures__/update-schedule-request-body';
+import { updateSchedule } from '../update-schedule';
+import { type Context, type RequestParams } from '../update-schedule.types';
+
+jest.mock('@/utils/logger');
+
+describe(updateSchedule.name, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('calls updateSchedule with the schedule id from the route params', async () => {
+    const { res, mockUpdateSchedule } = await setup({});
+
+    expect(mockUpdateSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'mock-domain',
+        scheduleId: 'mock-schedule-id',
+        spec: expect.objectContaining({ cronExpression: '0 9 * * *' }),
+        action: expect.objectContaining({
+          startWorkflow: expect.objectContaining({
+            workflowType: { name: 'DemoWorkflow' },
+          }),
+        }),
+        policies: expect.any(Object),
+      })
+    );
+
+    expect(res.status).toEqual(200);
+    expect(await res.json()).toEqual({});
+  });
+
+  it('ignores a schedule id sent in the request body', async () => {
+    const { res, mockUpdateSchedule } = await setup({
+      body: { ...mockUpdateScheduleRequestBody, scheduleId: 'from-body' },
+    });
+
+    expect(res.status).toEqual(200);
+    expect(mockUpdateSchedule).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduleId: 'mock-schedule-id' })
+    );
+  });
+
+  it('returns a validation error when the body is invalid', async () => {
+    const { res, mockUpdateSchedule } = await setup({
+      body: { cronExpression: '' },
+    });
+
+    expect(mockUpdateSchedule).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+    const json = await res.json();
+    expect(json.message).toEqual('Invalid values provided for schedule update');
+    expect(Array.isArray(json.validationErrors)).toBe(true);
+  });
+
+  it('returns a validation error when the end time is before the start time', async () => {
+    const { res, mockUpdateSchedule } = await setup({
+      body: {
+        ...mockUpdateScheduleRequestBody,
+        startTime: '2026-01-02T00:00:00.000Z',
+        endTime: '2026-01-01T00:00:00.000Z',
+      },
+    });
+
+    expect(mockUpdateSchedule).not.toHaveBeenCalled();
+    expect(res.status).toEqual(400);
+  });
+
+  it('returns an error when updateSchedule throws a GRPCError', async () => {
+    const { res, mockUpdateSchedule } = await setup({
+      error: new GRPCError('Schedule not found', {
+        grpcStatusCode: status.NOT_FOUND,
+      }),
+    });
+
+    expect(mockUpdateSchedule).toHaveBeenCalled();
+    expect(res.status).toEqual(404);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({ message: 'Schedule not found' })
+    );
+  });
+
+  it('returns an error when updateSchedule throws a generic error', async () => {
+    const { res } = await setup({ error: new Error('Network error') });
+
+    expect(res.status).toEqual(500);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({ message: 'Error updating schedule' })
+    );
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: {
+          domain: 'mock-domain',
+          cluster: 'mock-cluster',
+          scheduleId: 'mock-schedule-id',
+        },
+        error: expect.any(Error),
+      }),
+      'Error updating schedule'
+    );
+  });
+});
+
+async function setup({ body, error }: { body?: unknown; error?: Error }) {
+  const mockUpdateSchedule = jest
+    .spyOn(mockGrpcClusterMethods, 'updateSchedule')
+    .mockImplementationOnce(async () => {
+      if (error) {
+        throw error;
+      }
+      return {};
+    });
+
+  const res = await updateSchedule(
+    new NextRequest('http://localhost', {
+      method: 'PUT',
+      body: JSON.stringify(body ?? mockUpdateScheduleRequestBody),
+    }),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        scheduleId: 'mock-schedule-id',
+      },
+    } as RequestParams,
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockUpdateSchedule };
+}

--- a/src/route-handlers/update-schedule/helpers/__tests__/transform-update-schedule-body-to-grpc-input.node.ts
+++ b/src/route-handlers/update-schedule/helpers/__tests__/transform-update-schedule-body-to-grpc-input.node.ts
@@ -1,0 +1,50 @@
+import { mockUpdateScheduleRequestBody } from '../../__fixtures__/update-schedule-request-body';
+import transformUpdateScheduleBodyToGrpcInput from '../transform-update-schedule-body-to-grpc-input';
+
+describe(transformUpdateScheduleBodyToGrpcInput.name, () => {
+  it('maps the body onto spec, action and policies', () => {
+    const result = transformUpdateScheduleBodyToGrpcInput({
+      domain: 'mock-domain',
+      scheduleId: 'mock-schedule-id',
+      body: {
+        ...mockUpdateScheduleRequestBody,
+        startTime: '2026-01-01T00:00:00.000Z',
+        jitterSeconds: 60,
+        catchUpWindowSeconds: 120,
+        pauseOnFailure: true,
+      },
+    });
+
+    expect(result).toEqual({
+      domain: 'mock-domain',
+      scheduleId: 'mock-schedule-id',
+      spec: expect.objectContaining({
+        cronExpression: '0 9 * * *',
+        startTime: { seconds: 1_767_225_600, nanos: 0 },
+        jitter: { seconds: 60, nanos: 0 },
+      }),
+      action: {
+        startWorkflow: expect.objectContaining({
+          workflowType: { name: 'DemoWorkflow' },
+          taskList: { name: 'demo-task-list' },
+          executionStartToCloseTimeout: { seconds: 3600, nanos: 0 },
+          taskStartToCloseTimeout: { seconds: 30, nanos: 0 },
+        }),
+      },
+      policies: expect.objectContaining({
+        catchUpWindow: { seconds: 120, nanos: 0 },
+        pauseOnFailure: true,
+      }),
+    });
+  });
+
+  it('does not forward a schedule id from the body', () => {
+    const result = transformUpdateScheduleBodyToGrpcInput({
+      domain: 'mock-domain',
+      scheduleId: 'from-params',
+      body: mockUpdateScheduleRequestBody,
+    });
+
+    expect(result.scheduleId).toEqual('from-params');
+  });
+});

--- a/src/route-handlers/update-schedule/helpers/transform-update-schedule-body-to-grpc-input.ts
+++ b/src/route-handlers/update-schedule/helpers/transform-update-schedule-body-to-grpc-input.ts
@@ -1,0 +1,23 @@
+import { type UpdateScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateScheduleRequest';
+
+import transformCreateScheduleBodyToGrpcInput from '../../create-schedule/helpers/transform-create-schedule-body-to-grpc-input';
+import { type UpdateScheduleRequestBody } from '../update-schedule.types';
+
+export default function transformUpdateScheduleBodyToGrpcInput({
+  domain,
+  scheduleId,
+  body,
+}: {
+  domain: string;
+  scheduleId: string;
+  body: UpdateScheduleRequestBody;
+}): UpdateScheduleRequest__Input {
+  // UpdateSchedule replaces the whole schedule definition, so spec/action/policies
+  // are built exactly as they are for CreateSchedule.
+  const { spec, action, policies } = transformCreateScheduleBodyToGrpcInput({
+    domain,
+    body: { ...body, scheduleId },
+  });
+
+  return { domain, scheduleId, spec, action, policies };
+}

--- a/src/route-handlers/update-schedule/schemas/update-schedule-request-body-schema.ts
+++ b/src/route-handlers/update-schedule/schemas/update-schedule-request-body-schema.ts
@@ -1,0 +1,10 @@
+import {
+  refineScheduleBodyPeriod,
+  scheduleBodyFieldsSchema,
+} from '../../create-schedule/schemas/create-schedule-request-body-schema';
+
+const updateScheduleRequestBodySchema = scheduleBodyFieldsSchema.superRefine(
+  refineScheduleBodyPeriod
+);
+
+export default updateScheduleRequestBodySchema;

--- a/src/route-handlers/update-schedule/update-schedule.ts
+++ b/src/route-handlers/update-schedule/update-schedule.ts
@@ -1,0 +1,59 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import transformUpdateScheduleBodyToGrpcInput from './helpers/transform-update-schedule-body-to-grpc-input';
+import updateScheduleRequestBodySchema from './schemas/update-schedule-request-body-schema';
+import {
+  type Context,
+  type RequestParams,
+  type UpdateScheduleResponse,
+} from './update-schedule.types';
+
+export async function updateSchedule(
+  request: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const requestBody = await request.json().catch(() => ({}));
+  const { data, error } =
+    updateScheduleRequestBodySchema.safeParse(requestBody);
+
+  if (error) {
+    return NextResponse.json(
+      {
+        message: 'Invalid values provided for schedule update',
+        validationErrors: error.errors,
+      },
+      { status: 400 }
+    );
+  }
+
+  const params = requestParams.params;
+
+  try {
+    const response = await ctx.grpcClusterMethods.updateSchedule(
+      transformUpdateScheduleBodyToGrpcInput({
+        domain: params.domain,
+        scheduleId: params.scheduleId,
+        body: data,
+      })
+    );
+
+    return NextResponse.json(response satisfies UpdateScheduleResponse);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: params, error: e },
+      'Error updating schedule'
+    );
+
+    return NextResponse.json(
+      {
+        message: e instanceof GRPCError ? e.message : 'Error updating schedule',
+        cause: e,
+      },
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/update-schedule/update-schedule.types.ts
+++ b/src/route-handlers/update-schedule/update-schedule.types.ts
@@ -1,0 +1,26 @@
+import { type z } from 'zod';
+
+import { type UpdateScheduleResponse as UpdateScheduleResponseProto } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateScheduleResponse';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+import type updateScheduleRequestBodySchema from './schemas/update-schedule-request-body-schema';
+
+export type RouteParams = {
+  domain: string;
+  cluster: string;
+  scheduleId: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type UpdateScheduleResponse = UpdateScheduleResponseProto;
+
+export type UpdateScheduleRequestBody = z.infer<
+  typeof updateScheduleRequestBodySchema
+>;
+
+export type UpdateScheduleSubmissionData = UpdateScheduleRequestBody;
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -55,6 +55,7 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
     resume: 'ENABLED',
     delete: 'ENABLED',
     backfill: 'ENABLED',
+    edit: 'ENABLED',
   },
   SCHEDULES_ENABLED: false,
   WORKFLOWS_LIST_ENABLED: false,

--- a/src/utils/grpc/grpc-client.ts
+++ b/src/utils/grpc/grpc-client.ts
@@ -58,6 +58,8 @@ import { type UnpauseScheduleRequest__Input } from '@/__generated__/proto-ts/ube
 import { type UnpauseScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/UnpauseScheduleResponse';
 import { type UpdateDomainRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateDomainRequest';
 import { type UpdateDomainResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateDomainResponse';
+import { type UpdateScheduleRequest__Input } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateScheduleRequest';
+import { type UpdateScheduleResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/UpdateScheduleResponse';
 import { type ClusterConfig } from '@/config/dynamic/resolvers/clusters.types';
 
 import grpcServiceConfigurations from '../../config/grpc/grpc-services-config';
@@ -99,6 +101,9 @@ export type GRPCClusterMethods = {
   describeSchedule: (
     payload: DescribeScheduleRequest__Input
   ) => Promise<DescribeScheduleResponse>;
+  updateSchedule: (
+    payload: UpdateScheduleRequest__Input
+  ) => Promise<UpdateScheduleResponse>;
   describeCluster: (
     payload: DescribeClusterRequest__Input
   ) => Promise<DescribeClusterResponse>;
@@ -299,6 +304,13 @@ const getClusterServicesMethods = async (
       DescribeScheduleResponse
     >({
       method: 'DescribeSchedule',
+      metadata: metadata,
+    }),
+    updateSchedule: scheduleService.request<
+      UpdateScheduleRequest__Input,
+      UpdateScheduleResponse
+    >({
+      method: 'UpdateSchedule',
       metadata: metadata,
     }),
     describeCluster: adminService.request<

--- a/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
+++ b/src/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods.ts
@@ -8,6 +8,7 @@ export const mockGrpcClusterMethods: GRPCClusterMethods = {
   backfillSchedule: jest.fn(),
   deleteSchedule: jest.fn(),
   describeSchedule: jest.fn(),
+  updateSchedule: jest.fn(),
   describeCluster: jest.fn(),
   describeDomain: jest.fn(),
   updateDomain: jest.fn(),

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -177,9 +177,35 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
     expect(screen.getByLabelText('Expiration Interval')).toBeInTheDocument();
     expect(screen.queryByLabelText('Maximum Attempts')).not.toBeInTheDocument();
   });
+
+  it('keeps the Schedule Id field editable by default', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeEnabled();
+    expect(
+      screen.queryByText(/schedule id cannot be changed/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables the Schedule Id field and explains why when read-only', async () => {
+    const { user } = setup({ scheduleIdReadOnly: true });
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeDisabled();
+    expect(
+      screen.getByText(/schedule id cannot be changed/i)
+    ).toBeInTheDocument();
+  });
 });
 
-function setup() {
+function setup({ scheduleIdReadOnly }: { scheduleIdReadOnly?: boolean } = {}) {
   const user = userEvent.setup();
   let getValues: () => DomainSchedulesCreateFormData;
 
@@ -200,6 +226,7 @@ function setup() {
         fieldErrors={fieldErrors}
         clearErrors={clearErrors}
         cluster="test-cluster"
+        scheduleIdReadOnly={scheduleIdReadOnly}
       />
     );
   }

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -11,6 +11,9 @@ import {
 
 export const MAX_CATCH_UP_WINDOW_DAYS = 90;
 
+export const SCHEDULE_ID_READ_ONLY_CAPTION =
+  'Schedule Id cannot be changed after the schedule is created.';
+
 /** Stable ids for advanced create-schedule horizontal fields. */
 export const CREATE_SCHEDULE_ADVANCED_FIELD_IDS = {
   scheduleId: 'domain-schedules-create-form-schedule-id',

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -34,6 +34,7 @@ import {
   DEFAULT_OVERLAP_POLICY,
   MAX_CATCH_UP_WINDOW_DAYS,
   OVERLAP_POLICY_OPTIONS,
+  SCHEDULE_ID_READ_ONLY_CAPTION,
 } from './domain-schedules-create-advanced-form.constants';
 import {
   overrides,
@@ -48,6 +49,7 @@ export default function DomainSchedulesCreateAdvancedForm({
   isSubmitted = false,
   clearErrors,
   cluster,
+  scheduleIdReadOnly = false,
 }: Props) {
   const { data: searchAttributesData, isLoading: isLoadingSearchAttributes } =
     useSearchAttributes({ cluster, category: 'custom' });
@@ -117,6 +119,9 @@ export default function DomainSchedulesCreateAdvancedForm({
           label="Schedule Id"
           description={CREATE_SCHEDULE_ADVANCED_FIELD_DESCRIPTIONS.scheduleId}
           htmlFor={CREATE_SCHEDULE_ADVANCED_FIELD_IDS.scheduleId}
+          caption={
+            scheduleIdReadOnly ? SCHEDULE_ID_READ_ONLY_CAPTION : undefined
+          }
           error={getFieldErrorMessage(fieldErrors, 'scheduleId')}
         >
           <Controller
@@ -129,6 +134,7 @@ export default function DomainSchedulesCreateAdvancedForm({
                 // @ts-expect-error - inputRef expects ref object while ref is a callback. It should support both.
                 inputRef={ref}
                 aria-label="Schedule Id"
+                disabled={scheduleIdReadOnly}
                 onChange={(e) => field.onChange(e.target.value || undefined)}
                 onBlur={field.onBlur}
                 error={Boolean(getFieldErrorMessage(fieldErrors, 'scheduleId'))}

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.types.ts
@@ -14,4 +14,6 @@ export type Props = {
   isSubmitted?: boolean;
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   cluster: string;
+  /** Renders the Schedule Id field disabled, for flows where the id is fixed. */
+  scheduleIdReadOnly?: boolean;
 };

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -174,6 +174,16 @@ describe('DomainSchedulesCreateForm', () => {
       screen.getByText('This task list has no workers')
     ).toBeInTheDocument();
   });
+
+  it('passes scheduleIdReadOnly down to the advanced fields', async () => {
+    const { user } = await setup({ scheduleIdReadOnly: true });
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    expect(screen.getByLabelText('Schedule Id')).toBeDisabled();
+  });
 });
 
 type SetupProps = {
@@ -181,14 +191,17 @@ type SetupProps = {
   /** Applies fixed `setError` calls (same role as passing `fieldErrors` into start form tests). */
   injectFieldErrors?: boolean;
   taskListValidation?: ReturnType<typeof mockUseTaskListFieldValidation>;
+  scheduleIdReadOnly?: boolean;
 };
 
 function TestWrapper({
   defaultValues,
   injectFieldErrors,
+  scheduleIdReadOnly,
 }: {
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
   injectFieldErrors?: boolean;
+  scheduleIdReadOnly?: boolean;
 }) {
   const { control, trigger, setError, clearErrors } =
     useForm<DomainSchedulesCreateFormData>({
@@ -210,6 +223,7 @@ function TestWrapper({
       clearErrors={clearErrors}
       domain={MOCK_DOMAIN}
       cluster={MOCK_CLUSTER}
+      scheduleIdReadOnly={scheduleIdReadOnly}
     />
   );
 }
@@ -217,6 +231,7 @@ function TestWrapper({
 async function setup({
   defaultValues,
   injectFieldErrors = false,
+  scheduleIdReadOnly,
   taskListValidation = {
     isTaskListLoading: false,
     taskListCaptionMessage: null,
@@ -230,6 +245,7 @@ async function setup({
     <TestWrapper
       defaultValues={defaultValues}
       injectFieldErrors={injectFieldErrors}
+      scheduleIdReadOnly={scheduleIdReadOnly}
     />
   );
 

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -39,6 +39,7 @@ export default function DomainSchedulesCreateForm({
   clearErrors,
   domain,
   cluster,
+  scheduleIdReadOnly,
 }: Props) {
   const { errors: fieldErrors, isSubmitted } = useFormState({ control });
 
@@ -343,6 +344,7 @@ export default function DomainSchedulesCreateForm({
         isSubmitted={isSubmitted}
         clearErrors={clearErrors}
         cluster={cluster}
+        scheduleIdReadOnly={scheduleIdReadOnly}
       />
     </div>
   );

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -105,7 +105,7 @@ export default function DomainSchedulesCreateForm({
               onChange={(value) => {
                 field.onChange(value);
                 // If form is submitted, trigger the validation to show fix immediately
-                if (isSubmitted) trigger('cronExpression');
+                if (isSubmitted) trigger?.('cronExpression');
               }}
               onBlur={field.onBlur}
               error={cronExpressionError}
@@ -212,7 +212,7 @@ export default function DomainSchedulesCreateForm({
               value={field.value}
               onChange={(value) => {
                 field.onChange(value);
-                if (isSubmitted) trigger('input');
+                if (isSubmitted) trigger?.('input');
               }}
               error={inputError}
               addButtonText="Add argument"

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -8,7 +8,7 @@ import { type DomainSchedulesCreateFormData } from '../domain-schedules-create-m
 
 export type Props = {
   control: Control<DomainSchedulesCreateFormData>;
-  trigger: UseFormTrigger<DomainSchedulesCreateFormData>;
+  trigger?: UseFormTrigger<DomainSchedulesCreateFormData>;
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   domain: string;
   cluster: string;

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -12,4 +12,6 @@ export type Props = {
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   domain: string;
   cluster: string;
+  /** Renders the Schedule Id field disabled, for flows where the id is fixed. */
+  scheduleIdReadOnly?: boolean;
 };

--- a/src/views/schedule-actions/__tests__/schedule-actions.test.tsx
+++ b/src/views/schedule-actions/__tests__/schedule-actions.test.tsx
@@ -7,7 +7,16 @@ import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 import { mockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
 
 import { mockScheduleActionsConfig } from '../__fixtures__/schedule-actions-config';
+import scheduleActionsConfig from '../config/schedule-actions.config';
 import ScheduleActions from '../schedule-actions';
+
+const editScheduleAction = scheduleActionsConfig.find(
+  (action) => action.id === 'edit'
+);
+
+if (!editScheduleAction) {
+  throw new Error('the edit action is not registered in the actions config');
+}
 
 const mockScheduleParams = {
   domain: 'mock-domain',
@@ -20,8 +29,16 @@ jest.mock('next/navigation', () => ({
   useParams: () => mockScheduleParams,
 }));
 
+const mockModalProps = jest.fn();
+
+/** Action the mocked menu selects when clicked; defaults to the first one. */
+let actionToSelect:
+  | (typeof mockScheduleActionsConfig)[number]
+  | NonNullable<typeof editScheduleAction> = mockScheduleActionsConfig[0];
+
 jest.mock('../schedule-actions-modal/schedule-actions-modal', () =>
   jest.fn((props) => {
+    mockModalProps(props);
     return props.action ? (
       <div data-testid="actions-modal">Actions Modal</div>
     ) : null;
@@ -38,7 +55,7 @@ jest.mock('../schedule-actions-menu/schedule-actions-menu', () =>
 
     return (
       <div
-        onClick={() => props.onActionSelect(mockScheduleActionsConfig[0])}
+        onClick={() => props.onActionSelect(actionToSelect)}
         data-testid="actions-menu"
       >
         Actions Menu{areAllActionsDisabled ? ' (disabled)' : ''}
@@ -50,6 +67,7 @@ jest.mock('../schedule-actions-menu/schedule-actions-menu', () =>
 describe(ScheduleActions.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    actionToSelect = mockScheduleActionsConfig[0];
   });
 
   it('renders the button with the correct text', async () => {
@@ -99,6 +117,39 @@ describe(ScheduleActions.name, () => {
     await user.click(await screen.findByTestId('actions-menu'));
 
     expect(await screen.findByTestId('actions-modal')).toBeInTheDocument();
+  });
+
+  it('prefills the modal from the schedule when the edit action is selected', async () => {
+    actionToSelect = editScheduleAction;
+    const { user } = setup({});
+
+    const actionsButton = await screen.findByRole('button');
+    await user.click(actionsButton);
+    await user.click(await screen.findByTestId('actions-menu'));
+
+    await waitFor(() => {
+      expect(mockModalProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialFormValues: expect.objectContaining({
+            scheduleId: mockScheduleParams.scheduleId,
+          }),
+        })
+      );
+    });
+  });
+
+  it('does not prefill the modal for other actions', async () => {
+    const { user } = setup({});
+
+    const actionsButton = await screen.findByRole('button');
+    await user.click(actionsButton);
+    await user.click(await screen.findByTestId('actions-menu'));
+
+    expect(mockModalProps).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialFormValues: expect.anything(),
+      })
+    );
   });
 
   it('renders nothing if describeSchedule fails', async () => {
@@ -154,6 +205,7 @@ function setup({
               resume: 'ENABLED',
               delete: 'ENABLED',
               backfill: 'ENABLED',
+              edit: 'ENABLED',
             },
             { status: 200 }
           );

--- a/src/views/schedule-actions/config/schedule-actions.config.ts
+++ b/src/views/schedule-actions/config/schedule-actions.config.ts
@@ -1,6 +1,7 @@
 import {
   MdDeleteOutline,
   MdHistory,
+  MdOutlineEdit,
   MdOutlineWarningAmber,
   MdPauseCircleOutline,
   MdPlayCircleOutline,
@@ -10,11 +11,19 @@ import { type BackfillScheduleResponse } from '@/route-handlers/backfill-schedul
 import { type DeleteScheduleResponse } from '@/route-handlers/delete-schedule/delete-schedule.types';
 import { type PauseScheduleResponse } from '@/route-handlers/pause-schedule/pause-schedule.types';
 import { type UnpauseScheduleResponse } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
+import { type UpdateScheduleResponse } from '@/route-handlers/update-schedule/update-schedule.types';
 
 import transformBackfillScheduleFormToSubmission from '../schedule-action-backfill-form/helpers/transform-backfill-schedule-form-to-submission';
 import ScheduleActionBackfillForm from '../schedule-action-backfill-form/schedule-action-backfill-form';
 import { type BackfillScheduleFormData } from '../schedule-action-backfill-form/schedule-action-backfill-form.types';
 import { backfillScheduleFormSchema } from '../schedule-action-backfill-form/schemas/backfill-schedule-form-schema';
+import transformEditScheduleFormToSubmission from '../schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission';
+import ScheduleActionEditForm from '../schedule-action-edit-form/schedule-action-edit-form';
+import {
+  type EditScheduleFormData,
+  type EditScheduleSubmissionData,
+} from '../schedule-action-edit-form/schedule-action-edit-form.types';
+import { editScheduleFormSchema } from '../schedule-action-edit-form/schemas/edit-schedule-form-schema';
 import ScheduleActionPauseForm from '../schedule-action-pause-form/schedule-action-pause-form';
 import { type PauseScheduleFormData } from '../schedule-action-pause-form/schedule-action-pause-form.types';
 import { pauseScheduleFormSchema } from '../schedule-action-pause-form/schemas/pause-schedule-form-schema';
@@ -136,11 +145,42 @@ const backfillScheduleActionConfig: ScheduleAction<
   renderSuccessMessage: () => 'Schedule backfill has been started.',
 };
 
+const editScheduleActionConfig: ScheduleAction<
+  UpdateScheduleResponse,
+  EditScheduleFormData,
+  EditScheduleSubmissionData
+> = {
+  id: 'edit',
+  label: 'Edit',
+  subtitle: 'Edit this schedule’s configuration',
+  modal: {
+    banner: {
+      kind: 'warning',
+      icon: MdOutlineWarningAmber,
+      // Static rather than shown only on cron changes: UpdateSchedule has no
+      // partial-update mode, so any save has these consequences.
+      render: () =>
+        'Attention: Updating this schedule replaces the entire specification and clears all pending backfills. Ensure any critical backfills are completed or documented before saving changes.',
+    },
+    withForm: true,
+    form: ScheduleActionEditForm,
+    formSchema: editScheduleFormSchema,
+    transformFormDataToSubmission: transformEditScheduleFormToSubmission,
+  },
+  icon: MdOutlineEdit,
+  getRunnableStatus: () => 'RUNNABLE',
+  apiRoute: (params) =>
+    `/api/domains/${encodeURIComponent(params.domain)}/${encodeURIComponent(params.cluster)}/schedules/${encodeURIComponent(params.scheduleId)}`,
+  httpMethod: 'PUT',
+  renderSuccessMessage: () => 'Schedule has been updated.',
+};
+
 const scheduleActionsConfig = [
   pauseScheduleActionConfig,
   resumeScheduleActionConfig,
   deleteScheduleActionConfig,
   backfillScheduleActionConfig,
+  editScheduleActionConfig,
 ] as const;
 
 /** Discriminated union of configured actions; use at menu/selection boundaries. */

--- a/src/views/schedule-actions/config/schedule-actions.config.ts
+++ b/src/views/schedule-actions/config/schedule-actions.config.ts
@@ -1,6 +1,7 @@
 import {
   MdDeleteOutline,
   MdHistory,
+  MdOutlineEdit,
   MdOutlineWarningAmber,
   MdPauseCircleOutline,
   MdPlayCircleOutline,
@@ -10,11 +11,18 @@ import { type BackfillScheduleResponse } from '@/route-handlers/backfill-schedul
 import { type DeleteScheduleResponse } from '@/route-handlers/delete-schedule/delete-schedule.types';
 import { type PauseScheduleResponse } from '@/route-handlers/pause-schedule/pause-schedule.types';
 import { type UnpauseScheduleResponse } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
+import { type UpdateScheduleResponse } from '@/route-handlers/update-schedule/update-schedule.types';
 
 import transformBackfillScheduleFormToSubmission from '../schedule-action-backfill-form/helpers/transform-backfill-schedule-form-to-submission';
 import ScheduleActionBackfillForm from '../schedule-action-backfill-form/schedule-action-backfill-form';
 import { type BackfillScheduleFormData } from '../schedule-action-backfill-form/schedule-action-backfill-form.types';
 import { backfillScheduleFormSchema } from '../schedule-action-backfill-form/schemas/backfill-schedule-form-schema';
+import transformEditScheduleFormToSubmission, {
+  type EditScheduleSubmissionData,
+} from '../schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission';
+import ScheduleActionEditForm from '../schedule-action-edit-form/schedule-action-edit-form';
+import { type EditScheduleFormData } from '../schedule-action-edit-form/schedule-action-edit-form.types';
+import { editScheduleFormSchema } from '../schedule-action-edit-form/schemas/edit-schedule-form-schema';
 import ScheduleActionPauseForm from '../schedule-action-pause-form/schedule-action-pause-form';
 import { type PauseScheduleFormData } from '../schedule-action-pause-form/schedule-action-pause-form.types';
 import { pauseScheduleFormSchema } from '../schedule-action-pause-form/schemas/pause-schedule-form-schema';
@@ -136,11 +144,42 @@ const backfillScheduleActionConfig: ScheduleAction<
   renderSuccessMessage: () => 'Schedule backfill has been started.',
 };
 
+const editScheduleActionConfig: ScheduleAction<
+  UpdateScheduleResponse,
+  EditScheduleFormData,
+  EditScheduleSubmissionData
+> = {
+  id: 'edit',
+  label: 'Edit',
+  subtitle: 'Edit this schedule’s configuration',
+  modal: {
+    banner: {
+      kind: 'warning',
+      icon: MdOutlineWarningAmber,
+      // Static rather than shown only on cron changes: UpdateSchedule has no
+      // partial-update mode, so any save has these consequences.
+      render: () =>
+        'Attention: Updating this schedule replaces the entire specification and clears all pending backfills. Ensure any critical backfills are completed or documented before saving changes.',
+    },
+    withForm: true,
+    form: ScheduleActionEditForm,
+    formSchema: editScheduleFormSchema,
+    transformFormDataToSubmission: transformEditScheduleFormToSubmission,
+  },
+  icon: MdOutlineEdit,
+  getRunnableStatus: () => 'RUNNABLE',
+  apiRoute: (params) =>
+    `/api/domains/${encodeURIComponent(params.domain)}/${encodeURIComponent(params.cluster)}/schedules/${encodeURIComponent(params.scheduleId)}`,
+  httpMethod: 'PUT',
+  renderSuccessMessage: () => 'Schedule has been updated.',
+};
+
 const scheduleActionsConfig = [
   pauseScheduleActionConfig,
   resumeScheduleActionConfig,
   deleteScheduleActionConfig,
   backfillScheduleActionConfig,
+  editScheduleActionConfig,
 ] as const;
 
 /** Discriminated union of configured actions; use at menu/selection boundaries. */

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-edit-schedule-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-edit-schedule-form-data.ts
@@ -1,0 +1,19 @@
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+export const mockEditScheduleFormData: EditScheduleFormData = {
+  scheduleId: 'mock-schedule-id',
+  cronExpression: {
+    minutes: '0',
+    hours: '9',
+    daysOfMonth: '*',
+    months: '*',
+    daysOfWeek: '*',
+  },
+  workflowType: { name: 'DemoWorkflow' },
+  taskList: { name: 'demo-task-list' },
+  workerSDKLanguage: 'GO',
+  executionStartToCloseTimeoutSeconds: 3600,
+  taskStartToCloseTimeoutSeconds: 30,
+  input: [''],
+  pauseOnFailure: false,
+};

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
@@ -3,6 +3,10 @@ import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api
 import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
 
+export function encodePayload(json: string) {
+  return { data: Buffer.from(json, 'utf-8').toString('base64') };
+}
+
 /** A fully-populated schedule, used to check that every form field prefills. */
 export function getMockEditableDescribeScheduleResponse(
   overrides: Partial<DescribeScheduleResponse> = {}
@@ -22,15 +26,25 @@ export function getMockEditableDescribeScheduleResponse(
           kind: 'TASK_LIST_KIND_NORMAL',
           baseName: 'demo-task-list',
         },
-        input: {
-          data: Buffer.from('{"a":1} {"b":2}', 'utf-8').toString('base64'),
-        },
+        input: encodePayload('{"a":1} {"b":2}'),
         workflowIdPrefix: 'scheduled-demo-',
         executionStartToCloseTimeout: { seconds: '3600', nanos: 0 },
         taskStartToCloseTimeout: { seconds: '30', nanos: 0 },
-        retryPolicy: null,
-        memo: null,
-        searchAttributes: null,
+        retryPolicy: {
+          initialInterval: { seconds: '10', nanos: 0 },
+          backoffCoefficient: 2,
+          maximumInterval: { seconds: '600', nanos: 0 },
+          maximumAttempts: 5,
+          expirationInterval: null,
+          nonRetryableErrorReasons: [],
+        },
+        memo: { fields: { owner: encodePayload('"team-a"') } },
+        searchAttributes: {
+          indexedFields: {
+            CustomKeywordField: encodePayload('"keyword"'),
+            CustomIntField: encodePayload('7'),
+          },
+        },
       },
     },
     policies: {

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
@@ -1,0 +1,46 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+
+/** A fully-populated schedule, used to check that every form field prefills. */
+export function getMockEditableDescribeScheduleResponse(
+  overrides: Partial<DescribeScheduleResponse> = {}
+): DescribeScheduleResponse {
+  return getMockDescribeScheduleResponse({
+    spec: {
+      cronExpression: '30 9 1 * *',
+      startTime: { seconds: '1767225600', nanos: 0 },
+      endTime: { seconds: '1767312000', nanos: 0 },
+      jitter: { seconds: '90', nanos: 0 },
+    },
+    action: {
+      startWorkflow: {
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: {
+          name: 'demo-task-list',
+          kind: 'TASK_LIST_KIND_NORMAL',
+          baseName: 'demo-task-list',
+        },
+        input: {
+          data: Buffer.from('{"a":1} {"b":2}', 'utf-8').toString('base64'),
+        },
+        workflowIdPrefix: 'scheduled-demo-',
+        executionStartToCloseTimeout: { seconds: '3600', nanos: 0 },
+        taskStartToCloseTimeout: { seconds: '30', nanos: 0 },
+        retryPolicy: null,
+        memo: null,
+        searchAttributes: null,
+      },
+    },
+    policies: {
+      overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+      catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL,
+      catchUpWindow: { seconds: '172800', nanos: 0 },
+      pauseOnFailure: true,
+      bufferLimit: 5,
+      concurrencyLimit: 0,
+    },
+    ...overrides,
+  });
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.test.tsx
+++ b/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { useForm } from 'react-hook-form';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import ScheduleActionEditForm from '../schedule-action-edit-form';
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+const mockCreateForm = jest.fn();
+
+jest.mock(
+  '@/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form',
+  () =>
+    function MockDomainSchedulesCreateForm(props: any) {
+      mockCreateForm(props);
+      return <div>mock create form</div>;
+    }
+);
+
+describe(ScheduleActionEditForm.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the create schedule form', () => {
+    setup();
+
+    expect(screen.getByText('mock create form')).toBeInTheDocument();
+  });
+
+  it('makes the schedule id read-only, since it cannot be changed', () => {
+    setup();
+
+    expect(mockCreateForm).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduleIdReadOnly: true })
+    );
+  });
+
+  it('forwards the domain, cluster and form handles', () => {
+    setup();
+
+    expect(mockCreateForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        control: expect.any(Object),
+        trigger: expect.any(Function),
+        clearErrors: expect.any(Function),
+      })
+    );
+  });
+});
+
+function setup() {
+  function Wrapper() {
+    const { control, trigger, clearErrors } = useForm<EditScheduleFormData>();
+
+    return (
+      <ScheduleActionEditForm
+        control={control}
+        trigger={trigger}
+        clearErrors={clearErrors}
+        domain="mock-domain"
+        cluster="mock-cluster"
+      />
+    );
+  }
+
+  render(<Wrapper />);
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.types.tst.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.types.tst.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'tstyche';
+
+import type { ExhaustiveDefaults } from '../schedule-action-edit-form.types.js';
+
+type Fields = {
+  required: string;
+  optional?: number;
+};
+
+describe('ExhaustiveDefaults', () => {
+  it('accepts a literal that assigns every field', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.toBeAssignableWith({
+      required: 'value',
+      optional: 1,
+    });
+  });
+
+  it('still allows an optional field to be assigned undefined', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.toBeAssignableWith({
+      required: 'value',
+      optional: undefined,
+    });
+  });
+
+  it('rejects a literal that leaves an optional field out', () => {
+    expect<ExhaustiveDefaults<Fields>>().type.not.toBeAssignableWith({
+      required: 'value',
+    });
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -3,7 +3,10 @@ import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api
 import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
 
-import { getMockEditableDescribeScheduleResponse } from '../../__fixtures__/mock-editable-describe-schedule-response';
+import {
+  encodePayload,
+  getMockEditableDescribeScheduleResponse,
+} from '../../__fixtures__/mock-editable-describe-schedule-response';
 import { EMPTY_CRON_EXPRESSION_FIELDS } from '../../schedule-action-edit-form.constants';
 import transformDescribeScheduleResponseToFormData from '../transform-describe-schedule-response-to-form-data';
 
@@ -99,6 +102,68 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
     ).toEqual('2');
   });
 
+  it('prefills the retry policy and limits retries by attempts', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        enableRetryPolicy: true,
+        limitRetries: 'ATTEMPTS',
+        retryPolicy: {
+          initialIntervalSeconds: '10',
+          backoffCoefficient: '2',
+          maximumIntervalSeconds: '600',
+          maximumAttempts: '5',
+          expirationIntervalSeconds: undefined,
+        },
+      })
+    );
+  });
+
+  it('limits retries by duration when the policy has an expiration interval', () => {
+    const formData = transform(
+      withStartWorkflow({
+        retryPolicy: {
+          initialInterval: { seconds: '10', nanos: 0 },
+          backoffCoefficient: 2,
+          maximumInterval: null,
+          maximumAttempts: 0,
+          expirationInterval: { seconds: '3600', nanos: 0 },
+          nonRetryableErrorReasons: [],
+        },
+      })
+    );
+
+    expect(formData.limitRetries).toEqual('DURATION');
+    expect(formData.retryPolicy?.expirationIntervalSeconds).toEqual('3600');
+    expect(formData.retryPolicy?.maximumAttempts).toBeUndefined();
+  });
+
+  it('decodes search attribute payloads into key/value pairs', () => {
+    expect(transform().searchAttributes).toEqual([
+      { key: 'CustomKeywordField', value: 'keyword' },
+      { key: 'CustomIntField', value: 7 },
+    ]);
+  });
+
+  it('keeps the JSON text for a search attribute that is not a primitive', () => {
+    expect(
+      transform(
+        withStartWorkflow({
+          searchAttributes: {
+            indexedFields: { CustomListField: encodePayload('["a","b"]') },
+          },
+        })
+      ).searchAttributes
+    ).toEqual([{ key: 'CustomListField', value: '["a","b"]' }]);
+  });
+
+  it('decodes the memo into formatted JSON for the textarea', () => {
+    expect(transform().memo).toEqual('{\n  "owner": "team-a"\n}');
+  });
+
+  it('leaves the memo unset when the schedule has none', () => {
+    expect(transform(withStartWorkflow({ memo: null })).memo).toBeUndefined();
+  });
+
   it('falls back to blank values for an empty schedule', () => {
     const formData = transform(getMockDescribeScheduleResponse());
 
@@ -137,4 +202,23 @@ function transform(
     schedule,
     MOCK_SCHEDULE_ID
   );
+}
+
+/** Overrides fields on the mock's start-workflow action, keeping the rest. */
+function withStartWorkflow(
+  overrides: Partial<
+    NonNullable<
+      NonNullable<DescribeScheduleResponse['action']>['startWorkflow']
+    >
+  >
+): DescribeScheduleResponse {
+  const mock = getMockEditableDescribeScheduleResponse();
+  const startWorkflow = mock.action?.startWorkflow;
+
+  if (!startWorkflow)
+    throw new Error('mock is missing a start workflow action');
+
+  return getMockEditableDescribeScheduleResponse({
+    action: { startWorkflow: { ...startWorkflow, ...overrides } },
+  });
 }

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -1,0 +1,140 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+
+import { getMockEditableDescribeScheduleResponse } from '../../__fixtures__/mock-editable-describe-schedule-response';
+import { EMPTY_CRON_EXPRESSION_FIELDS } from '../../schedule-action-edit-form.constants';
+import transformDescribeScheduleResponseToFormData from '../transform-describe-schedule-response-to-form-data';
+
+const MOCK_SCHEDULE_ID = 'mock-schedule-id';
+
+describe(transformDescribeScheduleResponseToFormData.name, () => {
+  it('prefills the schedule id from the route rather than the response', () => {
+    expect(transform().scheduleId).toEqual(MOCK_SCHEDULE_ID);
+  });
+
+  it('splits the cron expression into its five fields', () => {
+    expect(transform().cronExpression).toEqual({
+      minutes: '30',
+      hours: '9',
+      daysOfMonth: '1',
+      months: '*',
+      daysOfWeek: '*',
+    });
+  });
+
+  it('leaves the cron fields empty for an expression it cannot split', () => {
+    expect(
+      transform(
+        getMockEditableDescribeScheduleResponse({
+          spec: {
+            cronExpression: '@every 1h',
+            startTime: null,
+            endTime: null,
+            jitter: null,
+          },
+        })
+      ).cronExpression
+    ).toEqual(EMPTY_CRON_EXPRESSION_FIELDS);
+  });
+
+  it('prefills the start workflow action fields', () => {
+    const formData = transform();
+
+    expect(formData).toEqual(
+      expect.objectContaining({
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: { name: 'demo-task-list' },
+        executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: 30,
+        workflowIdPrefix: 'scheduled-demo-',
+        workerSDKLanguage: 'GO',
+      })
+    );
+  });
+
+  it('splits a multi-argument workflow input back into separate entries', () => {
+    expect(transform().input).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it('prefills the policy fields', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+        catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL,
+        catchUpWindowDays: '2',
+        bufferLimit: '5',
+        concurrencyLimit: '0',
+        pauseOnFailure: true,
+      })
+    );
+  });
+
+  it('prefills the schedule period and jitter', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        startTime: '2026-01-01T00:00:00.000Z',
+        endTime: '2026-01-02T00:00:00.000Z',
+        jitterSeconds: '90',
+      })
+    );
+  });
+
+  it('rounds a partial catch-up window day up, so the window is never narrowed', () => {
+    expect(
+      transform(
+        getMockEditableDescribeScheduleResponse({
+          policies: {
+            overlapPolicy:
+              ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+            catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE,
+            catchUpWindow: { seconds: '90000', nanos: 0 },
+            pauseOnFailure: false,
+            bufferLimit: 0,
+            concurrencyLimit: 0,
+          },
+        })
+      ).catchUpWindowDays
+    ).toEqual('2');
+  });
+
+  it('falls back to blank values for an empty schedule', () => {
+    const formData = transform(getMockDescribeScheduleResponse());
+
+    expect(formData).toEqual({
+      scheduleId: MOCK_SCHEDULE_ID,
+      cronExpression: EMPTY_CRON_EXPRESSION_FIELDS,
+      workflowType: { name: '' },
+      taskList: { name: '' },
+      executionStartToCloseTimeoutSeconds: 0,
+      taskStartToCloseTimeoutSeconds: 0,
+      workerSDKLanguage: 'GO',
+      input: [''],
+      workflowIdPrefix: undefined,
+      pauseOnFailure: false,
+      overlapPolicy: undefined,
+      bufferLimit: undefined,
+      concurrencyLimit: undefined,
+      catchUpPolicy: undefined,
+      catchUpWindowDays: undefined,
+      jitterSeconds: undefined,
+      startTime: undefined,
+      endTime: undefined,
+      enableRetryPolicy: false,
+      limitRetries: undefined,
+      retryPolicy: undefined,
+      searchAttributes: undefined,
+      memo: undefined,
+    });
+  });
+});
+
+function transform(
+  schedule: DescribeScheduleResponse = getMockEditableDescribeScheduleResponse()
+) {
+  return transformDescribeScheduleResponseToFormData(
+    schedule,
+    MOCK_SCHEDULE_ID
+  );
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
@@ -1,0 +1,30 @@
+import { mockEditScheduleFormData } from '../../__fixtures__/mock-edit-schedule-form-data';
+import transformEditScheduleFormToSubmission from '../transform-edit-schedule-form-to-submission';
+
+describe(transformEditScheduleFormToSubmission.name, () => {
+  it('maps the form onto the update schedule body', () => {
+    const result = transformEditScheduleFormToSubmission(
+      mockEditScheduleFormData
+    );
+
+    expect(result).toEqual({
+      cronExpression: '0 9 * * *',
+      pauseOnFailure: false,
+      startWorkflow: {
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: { name: 'demo-task-list' },
+        workerSDKLanguage: 'GO',
+        executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: 30,
+      },
+    });
+  });
+
+  it('omits the schedule id, which the update URL carries instead', () => {
+    const result = transformEditScheduleFormToSubmission(
+      mockEditScheduleFormData
+    );
+
+    expect(result).not.toHaveProperty('scheduleId');
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -1,3 +1,5 @@
+import { type RetryPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/RetryPolicy';
+import { type _uber_cadence_api_v1_ScheduleAction_StartWorkflowAction as StartWorkflowAction } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleAction';
 import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
 import {
   SCHEDULE_CATCH_UP_POLICIES,
@@ -7,8 +9,10 @@ import {
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
 import formatDurationToSeconds from '@/utils/data-formatters/format-duration-to-seconds';
 import formatInputPayload from '@/utils/data-formatters/format-input-payload';
+import formatPayloadMap from '@/utils/data-formatters/format-payload-map';
 import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 import losslessJsonStringify from '@/utils/lossless-json-stringify';
+import { type RetryPolicyFormFields } from '@/views/shared/retry-policy-fields/schemas/retry-policy-form-schema';
 
 import {
   EMPTY_CRON_EXPRESSION_FIELDS,
@@ -68,13 +72,95 @@ export default function transformDescribeScheduleResponseToFormData(
     startTime: formatTimestampToIso(schedule.spec?.startTime),
     endTime: formatTimestampToIso(schedule.spec?.endTime),
 
-    // TODO(PR08d): decode the schedule's retry policy, search attributes and memo.
-    enableRetryPolicy: false,
-    limitRetries: undefined,
-    retryPolicy: undefined,
-    searchAttributes: undefined,
-    memo: undefined,
+    ...mapRetryPolicyToFormDefaults(startWorkflow?.retryPolicy),
+    searchAttributes: mapSearchAttributesToFormDefaults(
+      startWorkflow?.searchAttributes
+    ),
+    memo: mapMemoToFormDefault(startWorkflow?.memo),
   };
+}
+
+/**
+ * Has its own exhaustive return type: the top-level one cannot reach into the
+ * nested retry policy object, whose sub-fields are all optional too.
+ */
+function mapRetryPolicyToFormDefaults(
+  retryPolicy: RetryPolicy | null | undefined
+): ExhaustiveDefaults<RetryPolicyFormFields> {
+  if (!retryPolicy) {
+    return {
+      enableRetryPolicy: false,
+      limitRetries: undefined,
+      retryPolicy: undefined,
+    };
+  }
+
+  const expirationIntervalSeconds = formatDurationToSeconds(
+    retryPolicy.expirationInterval
+  );
+
+  const retryPolicyValues: ExhaustiveDefaults<
+    NonNullable<RetryPolicyFormFields['retryPolicy']>
+  > = {
+    initialIntervalSeconds: stringifyPositiveNumber(
+      formatDurationToSeconds(retryPolicy.initialInterval)
+    ),
+    backoffCoefficient: stringifyPositiveNumber(retryPolicy.backoffCoefficient),
+    maximumIntervalSeconds: stringifyPositiveNumber(
+      formatDurationToSeconds(retryPolicy.maximumInterval)
+    ),
+    maximumAttempts: stringifyPositiveNumber(retryPolicy.maximumAttempts),
+    expirationIntervalSeconds: stringifyPositiveNumber(
+      expirationIntervalSeconds
+    ),
+  };
+
+  return {
+    enableRetryPolicy: true,
+    // The form offers the two limits as an either/or, and the schedule only
+    // carries an expiration interval when it was configured by duration.
+    limitRetries: expirationIntervalSeconds ? 'DURATION' : 'ATTEMPTS',
+    retryPolicy: retryPolicyValues,
+  };
+}
+
+function mapSearchAttributesToFormDefaults(
+  searchAttributes: StartWorkflowAction['searchAttributes'] | undefined
+): EditScheduleFormData['searchAttributes'] {
+  const decoded = formatPayloadMap(searchAttributes ?? null, 'indexedFields')
+    ?.indexedFields as Record<string, unknown> | undefined;
+
+  if (!decoded || Object.keys(decoded).length === 0) {
+    return undefined;
+  }
+
+  return Object.entries(decoded).map(([key, value]) => ({
+    key,
+    // The form only edits primitives; anything richer keeps its JSON text.
+    value:
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      typeof value === 'boolean'
+        ? value
+        : losslessJsonStringify(value),
+  }));
+}
+
+function mapMemoToFormDefault(
+  memo: StartWorkflowAction['memo'] | undefined
+): string | undefined {
+  const decoded = formatPayloadMap(memo ?? null, 'fields')?.fields as
+    | Record<string, unknown>
+    | undefined;
+
+  return decoded && Object.keys(decoded).length > 0
+    ? losslessJsonStringify(decoded, null, 2)
+    : undefined;
+}
+
+/** Zero and missing values both mean "unset" for these form fields. */
+function stringifyPositiveNumber(value: number | null | undefined) {
+  return value ? String(value) : undefined;
 }
 
 /**

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -1,0 +1,122 @@
+import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
+import {
+  SCHEDULE_CATCH_UP_POLICIES,
+  SCHEDULE_OVERLAP_POLICIES,
+  WORKER_SDK_LANGUAGES,
+} from '@/route-handlers/create-schedule/create-schedule.constants';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+import formatDurationToSeconds from '@/utils/data-formatters/format-duration-to-seconds';
+import formatInputPayload from '@/utils/data-formatters/format-input-payload';
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+import losslessJsonStringify from '@/utils/lossless-json-stringify';
+
+import {
+  EMPTY_CRON_EXPRESSION_FIELDS,
+  SECONDS_PER_DAY,
+} from '../schedule-action-edit-form.constants';
+import {
+  type EditScheduleFormData,
+  type ExhaustiveDefaults,
+} from '../schedule-action-edit-form.types';
+
+/**
+ * Builds the edit form's default values from an existing schedule.
+ *
+ * The return type deliberately makes every key required: forgetting to map a
+ * newly-added form field then fails `npm run typecheck` instead of silently
+ * prefilling that field as blank.
+ */
+export default function transformDescribeScheduleResponseToFormData(
+  schedule: DescribeScheduleResponse,
+  scheduleId: string
+): ExhaustiveDefaults<EditScheduleFormData> {
+  const startWorkflow = schedule.action?.startWorkflow;
+  const policies = schedule.policies;
+  const parsedInput = formatInputPayload(startWorkflow?.input);
+
+  return {
+    scheduleId,
+    cronExpression: splitCronExpression(schedule.spec?.cronExpression),
+    workflowType: { name: startWorkflow?.workflowType?.name ?? '' },
+    taskList: { name: startWorkflow?.taskList?.name ?? '' },
+    executionStartToCloseTimeoutSeconds:
+      formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ?? 0,
+    taskStartToCloseTimeoutSeconds:
+      formatDurationToSeconds(startWorkflow?.taskStartToCloseTimeout) ?? 0,
+    // The worker SDK is not stored on the schedule, only the input encoding it
+    // produced, which is ambiguous between languages. Fall back to the same
+    // default the create form uses.
+    workerSDKLanguage: WORKER_SDK_LANGUAGES[0],
+    input: parsedInput?.length
+      ? parsedInput.map((value) => losslessJsonStringify(value))
+      : [''],
+    workflowIdPrefix: startWorkflow?.workflowIdPrefix || undefined,
+    pauseOnFailure: policies?.pauseOnFailure ?? false,
+
+    overlapPolicy: SCHEDULE_OVERLAP_POLICIES.find(
+      (policy) => policy === policies?.overlapPolicy
+    ),
+    bufferLimit: stringifyLimit(policies?.bufferLimit),
+    concurrencyLimit: stringifyLimit(policies?.concurrencyLimit),
+    catchUpPolicy: SCHEDULE_CATCH_UP_POLICIES.find(
+      (policy) => policy === policies?.catchUpPolicy
+    ),
+    catchUpWindowDays: formatCatchUpWindowDays(policies?.catchUpWindow),
+
+    jitterSeconds:
+      formatDurationToSeconds(schedule.spec?.jitter)?.toString() ?? undefined,
+    startTime: formatTimestampToIso(schedule.spec?.startTime),
+    endTime: formatTimestampToIso(schedule.spec?.endTime),
+
+    // TODO(PR08d): decode the schedule's retry policy, search attributes and memo.
+    enableRetryPolicy: false,
+    limitRetries: undefined,
+    retryPolicy: undefined,
+    searchAttributes: undefined,
+    memo: undefined,
+  };
+}
+
+/**
+ * ponytail: only plain 5-field cron expressions map onto the cron inputs. A
+ * schedule using another syntax (for example `@every 1h`) prefills empty, so the
+ * form asks for a cron rather than silently mangling it. Upgrade path: teach
+ * `CronScheduleInput` about the other syntaxes and widen this.
+ */
+function splitCronExpression(
+  cronExpression: string | undefined
+): EditScheduleFormData['cronExpression'] {
+  const fields = cronExpression?.trim().split(/\s+/) ?? [];
+
+  if (fields.length !== CRON_FIELD_ORDER.length) {
+    return EMPTY_CRON_EXPRESSION_FIELDS;
+  }
+
+  return Object.fromEntries(
+    CRON_FIELD_ORDER.map((field, index) => [field, fields[index]])
+  ) as EditScheduleFormData['cronExpression'];
+}
+
+function stringifyLimit(limit: number | undefined): string | undefined {
+  return limit === undefined ? undefined : String(limit);
+}
+
+/**
+ * The form only accepts whole days, so a partial day rounds up rather than down
+ * to avoid narrowing the window the schedule already runs with.
+ */
+function formatCatchUpWindowDays(
+  catchUpWindow: Parameters<typeof formatDurationToSeconds>[0]
+): string | undefined {
+  const seconds = formatDurationToSeconds(catchUpWindow);
+
+  return seconds ? String(Math.ceil(seconds / SECONDS_PER_DAY)) : undefined;
+}
+
+function formatTimestampToIso(
+  timestamp: Parameters<typeof parseGrpcTimestamp>[0] | null | undefined
+): string | undefined {
+  return timestamp
+    ? new Date(parseGrpcTimestamp(timestamp)).toISOString()
+    : undefined;
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
@@ -1,18 +1,10 @@
-import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
 import transformDomainSchedulesCreateFormToBody from '@/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body';
 
-import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+import {
+  type EditScheduleFormData,
+  type EditScheduleSubmissionData,
+} from '../schedule-action-edit-form.types';
 
-export type EditScheduleSubmissionData = Omit<
-  CreateScheduleRequestBody,
-  'scheduleId'
->;
-
-/**
- * UpdateSchedule replaces the whole schedule definition, so the body matches
- * the create one. The schedule id is display-only in the edit form: the PUT URL
- * already carries it and the schedule id of an existing schedule cannot change.
- */
 export default function transformEditScheduleFormToSubmission(
   formData: EditScheduleFormData
 ): EditScheduleSubmissionData {

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission.ts
@@ -1,0 +1,23 @@
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+import transformDomainSchedulesCreateFormToBody from '@/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body';
+
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+export type EditScheduleSubmissionData = Omit<
+  CreateScheduleRequestBody,
+  'scheduleId'
+>;
+
+/**
+ * UpdateSchedule replaces the whole schedule definition, so the body matches
+ * the create one. The schedule id is display-only in the edit form: the PUT URL
+ * already carries it and the schedule id of an existing schedule cannot change.
+ */
+export default function transformEditScheduleFormToSubmission(
+  formData: EditScheduleFormData
+): EditScheduleSubmissionData {
+  const { scheduleId: _scheduleId, ...body } =
+    transformDomainSchedulesCreateFormToBody(formData);
+
+  return body;
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
@@ -1,0 +1,9 @@
+export const SECONDS_PER_DAY = 24 * 60 * 60;
+
+export const EMPTY_CRON_EXPRESSION_FIELDS = {
+  minutes: '',
+  hours: '',
+  daysOfMonth: '',
+  months: '',
+  daysOfWeek: '',
+} as const;

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.tsx
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+
+import DomainSchedulesCreateForm from '@/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form';
+
+import { type Props } from './schedule-action-edit-form.types';
+
+export default function ScheduleActionEditForm({
+  control,
+  trigger,
+  clearErrors,
+  domain,
+  cluster,
+}: Props) {
+  return (
+    <DomainSchedulesCreateForm
+      control={control}
+      trigger={trigger}
+      clearErrors={clearErrors}
+      domain={domain}
+      cluster={cluster}
+      scheduleIdReadOnly
+    />
+  );
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -1,0 +1,13 @@
+import { type z } from 'zod';
+
+import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
+
+export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
+
+/**
+ * Forces every key of T to be explicitly assigned, including optional fields,
+ * whose value may still be `undefined`. Adding a field to T without updating a
+ * literal typed as `ExhaustiveDefaults<T>` is a compile error, which is what
+ * stops a newly-added form field from silently prefilling as blank.
+ */
+export type ExhaustiveDefaults<T> = { [K in keyof T]-?: T[K] };

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -9,5 +9,9 @@ export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
  * whose value may still be `undefined`. Adding a field to T without updating a
  * literal typed as `ExhaustiveDefaults<T>` is a compile error, which is what
  * stops a newly-added form field from silently prefilling as blank.
+ *
+ * The keys come from `Required<T>` rather than from `[K in keyof T]-?` because
+ * the `-?` modifier would also strip `undefined` out of the value type, which
+ * would make genuinely optional fields impossible to leave unset.
  */
-export type ExhaustiveDefaults<T> = { [K in keyof T]-?: T[K] };
+export type ExhaustiveDefaults<T> = { [K in keyof Required<T>]: T[K] };

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -1,8 +1,20 @@
 import { type z } from 'zod';
 
+import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
+
 import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
 
 export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
+
+/**
+ * UpdateSchedule replaces the whole schedule definition, so the body matches
+ * the create one. The schedule id is display-only in the edit form: the PUT URL
+ * already carries it and the schedule id of an existing schedule cannot change.
+ */
+export type EditScheduleSubmissionData = Omit<
+  CreateScheduleRequestBody,
+  'scheduleId'
+>;
 
 /**
  * Forces every key of T to be explicitly assigned, including optional fields,

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -2,6 +2,8 @@ import { type z } from 'zod';
 
 import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
 
+import { type ScheduleActionFormProps } from '../schedule-actions.types';
+
 import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
 
 export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
@@ -27,3 +29,8 @@ export type EditScheduleSubmissionData = Omit<
  * would make genuinely optional fields impossible to leave unset.
  */
 export type ExhaustiveDefaults<T> = { [K in keyof Required<T>]: T[K] };
+
+export type Props = Pick<
+  ScheduleActionFormProps<EditScheduleFormData>,
+  'control' | 'trigger' | 'clearErrors' | 'domain' | 'cluster'
+>;

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -1,5 +1,7 @@
 import { type z } from 'zod';
 
+import { type ScheduleActionFormProps } from '../schedule-actions.types';
+
 import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
 
 export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
@@ -15,3 +17,8 @@ export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
  * would make genuinely optional fields impossible to leave unset.
  */
 export type ExhaustiveDefaults<T> = { [K in keyof Required<T>]: T[K] };
+
+export type Props = Pick<
+  ScheduleActionFormProps<EditScheduleFormData>,
+  'control' | 'trigger' | 'clearErrors' | 'domain' | 'cluster'
+>;

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
@@ -1,0 +1,55 @@
+import { mockEditScheduleFormData } from '../../__fixtures__/mock-edit-schedule-form-data';
+import { editScheduleFormSchema } from '../edit-schedule-form-schema';
+
+describe('editScheduleFormSchema', () => {
+  it('accepts a fully prefilled edit form', () => {
+    const result = editScheduleFormSchema.safeParse(mockEditScheduleFormData);
+
+    expect(result.success).toBe(true);
+  });
+
+  it('requires a schedule id, unlike the create form', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      scheduleId: '',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['scheduleId'],
+        message: 'Schedule id is required',
+      }),
+    ]);
+  });
+
+  it('applies the shared create-schedule refinements', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      memo: 'not json',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['memo'],
+        message: 'Memo must be valid JSON',
+      }),
+    ]);
+  });
+
+  it('applies the shared create-schedule field validation', () => {
+    const result = editScheduleFormSchema.safeParse({
+      ...mockEditScheduleFormData,
+      workflowType: { name: '' },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.errors).toEqual([
+      expect.objectContaining({
+        path: ['workflowType', 'name'],
+        message: 'Workflow type is required',
+      }),
+    ]);
+  });
+});

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/__tests__/edit-schedule-form-schema.test.ts
@@ -8,21 +8,6 @@ describe('editScheduleFormSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('requires a schedule id, unlike the create form', () => {
-    const result = editScheduleFormSchema.safeParse({
-      ...mockEditScheduleFormData,
-      scheduleId: '',
-    });
-
-    expect(result.success).toBe(false);
-    expect(result.error?.errors).toEqual([
-      expect.objectContaining({
-        path: ['scheduleId'],
-        message: 'Schedule id is required',
-      }),
-    ]);
-  });
-
   it('applies the shared create-schedule refinements', () => {
     const result = editScheduleFormSchema.safeParse({
       ...mockEditScheduleFormData,

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+import refineCreateScheduleForm from '@/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form';
+import { createScheduleFormFieldsSchema } from '@/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema';
+
+/**
+ * Editing validates exactly like creating, except the schedule id is always
+ * known: it is prefilled from the existing schedule and shown read-only.
+ */
+export const editScheduleFormSchema = createScheduleFormFieldsSchema
+  .extend({ scheduleId: z.string().min(1, 'Schedule id is required') })
+  .superRefine(refineCreateScheduleForm);

--- a/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schemas/edit-schedule-form-schema.ts
@@ -1,12 +1,11 @@
-import { z } from 'zod';
-
 import refineCreateScheduleForm from '@/views/domain-schedules/domain-schedules-create-modal/helpers/refine-create-schedule-form';
 import { createScheduleFormFieldsSchema } from '@/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema';
 
 /**
- * Editing validates exactly like creating, except the schedule id is always
- * known: it is prefilled from the existing schedule and shown read-only.
+ * Editing validates exactly like creating. Keeping the field shapes identical
+ * is what lets the edit form reuse the create form components as they are, so
+ * this deliberately re-composes the create pieces rather than adding rules of
+ * its own. It exists as a separate schema so edit-only rules have a home.
  */
-export const editScheduleFormSchema = createScheduleFormFieldsSchema
-  .extend({ scheduleId: z.string().min(1, 'Schedule id is required') })
-  .superRefine(refineCreateScheduleForm);
+export const editScheduleFormSchema =
+  createScheduleFormFieldsSchema.superRefine(refineCreateScheduleForm);

--- a/src/views/schedule-actions/schedule-actions-menu/__tests__/schedule-actions-menu.test.tsx
+++ b/src/views/schedule-actions/schedule-actions-menu/__tests__/schedule-actions-menu.test.tsx
@@ -69,6 +69,7 @@ describe(ScheduleActionsMenu.name, () => {
         resume: 'DISABLED_DEFAULT',
         delete: 'DISABLED_DEFAULT',
         backfill: 'DISABLED_DEFAULT',
+        edit: 'DISABLED_DEFAULT',
       },
     });
 

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
@@ -41,6 +41,7 @@ export default function ScheduleActionsModalContent<
     formState: { errors: validationErrors, isSubmitting, isSubmitted },
     control,
     trigger,
+    clearErrors,
   } = useForm<OptionalFormData>({
     resolver: action.modal.formSchema
       ? zodResolver(action.modal.formSchema)
@@ -151,6 +152,7 @@ export default function ScheduleActionsModalContent<
                 fieldErrors={validationErrors}
                 control={control}
                 trigger={trigger}
+                clearErrors={clearErrors}
                 cluster={params.cluster}
                 domain={params.domain}
                 scheduleId={params.scheduleId}

--- a/src/views/schedule-actions/schedule-actions.tsx
+++ b/src/views/schedule-actions/schedule-actions.tsx
@@ -15,6 +15,7 @@ import { type SchedulePageParams } from '@/views/schedule-page/schedule-page.typ
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
 
 import { type SelectableScheduleAction } from './config/schedule-actions.config';
+import transformDescribeScheduleResponseToFormData from './schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data';
 import ScheduleActionsMenu from './schedule-actions-menu/schedule-actions-menu';
 import ScheduleActionsModal from './schedule-actions-modal/schedule-actions-modal';
 import { overrides } from './schedule-actions.styles';
@@ -78,6 +79,14 @@ export default function ScheduleActions() {
         {...scheduleDetailsParams}
         schedule={schedule}
         action={selectedAction as ErasedScheduleAction | undefined}
+        initialFormValues={
+          selectedAction?.id === 'edit' && schedule
+            ? transformDescribeScheduleResponseToFormData(
+                schedule,
+                params.scheduleId
+              )
+            : undefined
+        }
         onClose={() => setSelectedAction(undefined)}
       />
     </>

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -79,7 +79,9 @@ export type ScheduleActionModalForm<FormData, SubmissionData> =
           FormData extends FieldValues ? FormData : FieldValues
         >
       ) => ReactNode;
-      formSchema: z.ZodSchema<FormData>;
+      // Input is unknown rather than FormData: a form schema parses whatever
+      // the controls hold, which is not always the shape it validates into.
+      formSchema: z.ZodType<FormData, z.ZodTypeDef, unknown>;
       transformFormDataToSubmission: (formData: FormData) => SubmissionData;
     }
   | {

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -8,6 +8,7 @@ import {
   type Control,
   type FieldErrors,
   type FieldValues,
+  type UseFormClearErrors,
   type UseFormTrigger,
 } from 'react-hook-form';
 import { type z } from 'zod';
@@ -37,6 +38,7 @@ export type ScheduleActionFormProps<FormData extends FieldValues> = {
   fieldErrors: FieldErrors<FormData>;
   control: Control<FormData>;
   trigger?: UseFormTrigger<FormData>;
+  clearErrors: UseFormClearErrors<FormData>;
   isSubmitted?: boolean;
   cluster: string;
   domain: string;


### PR DESCRIPTION
## Summary

Turns on the **Edit Schedule** action. This is the first user-visible slice of the stack: `edit` gains a config entry, so it now shows up in the Schedule Actions menu, opens the reused create-schedule form pre-filled from the described schedule with a read-only Schedule Id, and saves through `PUT .../schedules/{scheduleId}`.

Part of the Edit Schedule stack (PR08f, final). **Stacked on [#1468](https://github.com/cadence-workflow/cadence-web/pull/1468) and [#1463](https://github.com/cadence-workflow/cadence-web/pull/1463)** — review the last commit only; merge the parents first. It cannot merge before the update API (#1463), the prefill transform (#1467) and the form component (#1468) are in.

## Changes

- `schedule-actions.config.ts` — `editScheduleActionConfig`: the static warning banner (copy taken verbatim from the feature spec, static because `UpdateSchedule` has no partial-update mode), `ScheduleActionEditForm`, the edit schema and submission transform, `PUT` on the existing schedule resource route, and `getRunnableStatus: () => 'RUNNABLE'`.
- `schedule-actions.tsx` — computes `initialFormValues` via `transformDescribeScheduleResponseToFormData` when the selected action is `edit`; other actions still open blank.
- `schedule-actions-enabled.types.ts` / `.constants.ts` / `resolver-schemas.ts` — `'edit'` joins `ScheduleActionID` and the authorized, unauthorized and default-disabled configs, so the action is permission-gated like the rest.
- `ScheduleActionModalForm.formSchema` widens from `z.ZodSchema<FormData>` to `z.ZodType<FormData, z.ZodTypeDef, unknown>`. The cron expression schema uses `.catch()`, which widens its input type; a form schema parses whatever the controls hold, which is not always the shape it validates into.

## Testing

- `npm run typecheck`, `npm run lint`, `npm run format` check
- `npm run test:unit:node` (279 tests passing) and `npm run test:unit:browser` (3166 tests passing) — the full suites, since the resolver and config fixtures are shared widely.
- New `schedule-actions` tests cover both branches of the prefill wiring: selecting Edit passes `initialFormValues` carrying the schedule id from the URL, and selecting any other action passes none.
