### PR TITLE
fix(docker): correct Elasticsearch dynamic config path in compose

### DIFF
--- a/docker-compose-backend-services.yml
+++ b/docker-compose-backend-services.yml
@@ -65,7 +65,7 @@ services:
       - "PROMETHEUS_ENDPOINT_1=0.0.0.0:8001"
       - "PROMETHEUS_ENDPOINT_2=0.0.0.0:8002"
       - "PROMETHEUS_ENDPOINT_3=0.0.0.0:8003"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=dynamicconfig/development_es.yaml"
       - "ENABLE_ES=true"
       - "ES_SEEDS=elasticsearch"
       - "ES_VERSION=v7"


### PR DESCRIPTION
## Summary

- Fixes `DYNAMIC_CONFIG_FILE_PATH` for the Cadence service in `docker-compose-backend-services.yml`
- Removes the incorrect `config/` prefix so the path matches the location inside the `ubercadence/server` container (`dynamicconfig/development_es.yaml`)
- Ensures the Elasticsearch-enabled local backend stack loads the development dynamic config correctly

## Test plan

- [x] Start local backend services: `docker compose -f docker-compose-backend-services.yml up`
- [x] Confirm the Cadence container starts without dynamic config file errors
