### PR TITLE
feat(schedule-details): enable zoom in/out chart controls

### DIFF
--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/__tests__/use-schedule-runs-chart-data.test.tsx
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/__tests__/use-schedule-runs-chart-data.test.tsx
@@ -12,6 +12,31 @@ const mockCluster = 'test-cluster';
 const mockScheduleId = 'my-schedule';
 const nowMs = Date.UTC(2024, 0, 1, 12, 0);
 const hourMs = 60 * 60_000;
+// createTime is 3 hours before nowMs; every hourly slot since then has no
+// matching run except the one an hour ago, so those are inferred as skipped.
+const SKIPPED_EXECUTIONS_SINCE_CREATE_TIME = [
+  { scheduledTimeMs: nowMs - 3 * hourMs },
+  { scheduledTimeMs: nowMs - 2 * hourMs },
+  { scheduledTimeMs: nowMs },
+];
+const HOURLY_SCHEDULE_OVERRIDES = {
+  spec: {
+    cronExpression: '0 * * * *',
+    startTime: null,
+    endTime: null,
+    jitter: null,
+  },
+  info: {
+    lastRunTime: null,
+    nextRunTime: { seconds: String((nowMs + hourMs) / 1000), nanos: 0 },
+    totalRuns: '2',
+    createTime: { seconds: String((nowMs - 3 * hourMs) / 1000), nanos: 0 },
+    lastUpdateTime: null,
+    missedRuns: '0',
+    skippedRuns: '0',
+    ongoingBackfills: [],
+  },
+};
 
 describe(useScheduleRunsChartData.name, () => {
   it('starts loading before any response has resolved', () => {
@@ -26,27 +51,9 @@ describe(useScheduleRunsChartData.name, () => {
 
   it('maps live workflow runs, skipped occurrences, and the next execution once loaded', async () => {
     const { result } = setup({
-      describeScheduleResponse: getMockRunningDescribeScheduleResponse({
-        spec: {
-          cronExpression: '0 * * * *',
-          startTime: null,
-          endTime: null,
-          jitter: null,
-        },
-        info: {
-          lastRunTime: null,
-          nextRunTime: { seconds: String((nowMs + hourMs) / 1000), nanos: 0 },
-          totalRuns: '2',
-          createTime: {
-            seconds: String((nowMs - 3 * hourMs) / 1000),
-            nanos: 0,
-          },
-          lastUpdateTime: null,
-          missedRuns: '0',
-          skippedRuns: '0',
-          ongoingBackfills: [],
-        },
-      }),
+      describeScheduleResponse: getMockRunningDescribeScheduleResponse(
+        HOURLY_SCHEDULE_OVERRIDES
+      ),
       workflowsResponse: {
         workflows: [
           getMockWorkflowListItem({
@@ -57,14 +64,7 @@ describe(useScheduleRunsChartData.name, () => {
             closeTime: nowMs - hourMs + 1000,
             historyLength: 5,
             searchAttributes: {
-              // Base64 of the JSON-encoded scheduled-time string, matching
-              // how Cadence visibility search attributes are actually
-              // encoded on the wire.
-              CadenceScheduleTime: {
-                data: Buffer.from(
-                  JSON.stringify(new Date(nowMs - hourMs).toISOString())
-                ).toString('base64'),
-              },
+              CadenceScheduleTime: scheduleTimeAttribute(nowMs - hourMs),
             },
           }),
         ],
@@ -82,13 +82,10 @@ describe(useScheduleRunsChartData.name, () => {
       }),
     ]);
     expect(result.current.data.nextExecutionTimeMs).toBe(nowMs + hourMs);
-    // Every hourly slot from the schedule's create time through now has no
-    // matching run except the one hour ago, so those are inferred as skipped.
-    expect(result.current.data.skippedExecutions).toEqual([
-      { scheduledTimeMs: nowMs - 3 * hourMs },
-      { scheduledTimeMs: nowMs - 2 * hourMs },
-      { scheduledTimeMs: nowMs },
-    ]);
+    expect(result.current.data.skippedExecutions).toEqual(
+      SKIPPED_EXECUTIONS_SINCE_CREATE_TIME
+    );
+    expect(result.current.timelineStartMs).toBe(nowMs - 3 * hourMs);
   });
 
   it('keeps all runs when nextRunTime is invalid', async () => {
@@ -112,11 +109,7 @@ describe(useScheduleRunsChartData.name, () => {
             runID: 'run-1',
             startTime: nowMs - hourMs,
             searchAttributes: {
-              CadenceScheduleTime: {
-                data: Buffer.from(
-                  JSON.stringify(new Date(nowMs - hourMs).toISOString())
-                ).toString('base64'),
-              },
+              CadenceScheduleTime: scheduleTimeAttribute(nowMs - hourMs),
             },
           }),
         ],
@@ -140,30 +133,9 @@ describe(useScheduleRunsChartData.name, () => {
     const nextExecutionTimeMs = nowMs + hourMs;
 
     const { result } = setup({
-      describeScheduleResponse: getMockRunningDescribeScheduleResponse({
-        spec: {
-          cronExpression: '0 * * * *',
-          startTime: null,
-          endTime: null,
-          jitter: null,
-        },
-        info: {
-          lastRunTime: null,
-          nextRunTime: {
-            seconds: String(nextExecutionTimeMs / 1000),
-            nanos: 0,
-          },
-          totalRuns: '2',
-          createTime: {
-            seconds: String((nowMs - 3 * hourMs) / 1000),
-            nanos: 0,
-          },
-          lastUpdateTime: null,
-          missedRuns: '0',
-          skippedRuns: '0',
-          ongoingBackfills: [],
-        },
-      }),
+      describeScheduleResponse: getMockRunningDescribeScheduleResponse(
+        HOURLY_SCHEDULE_OVERRIDES
+      ),
       workflowsResponse: {
         workflows: [
           getMockWorkflowListItem({
@@ -171,11 +143,7 @@ describe(useScheduleRunsChartData.name, () => {
             runID: 'run-before',
             startTime: nowMs - hourMs,
             searchAttributes: {
-              CadenceScheduleTime: {
-                data: Buffer.from(
-                  JSON.stringify(new Date(nowMs - hourMs).toISOString())
-                ).toString('base64'),
-              },
+              CadenceScheduleTime: scheduleTimeAttribute(nowMs - hourMs),
             },
           }),
           getMockWorkflowListItem({
@@ -183,11 +151,7 @@ describe(useScheduleRunsChartData.name, () => {
             runID: 'run-at-next',
             startTime: nextExecutionTimeMs,
             searchAttributes: {
-              CadenceScheduleTime: {
-                data: Buffer.from(
-                  JSON.stringify(new Date(nextExecutionTimeMs).toISOString())
-                ).toString('base64'),
-              },
+              CadenceScheduleTime: scheduleTimeAttribute(nextExecutionTimeMs),
             },
           }),
         ],
@@ -202,15 +166,19 @@ describe(useScheduleRunsChartData.name, () => {
       expect.objectContaining({ runId: 'run-before' }),
     ]);
     expect(result.current.data.nextExecutionTimeMs).toBe(nowMs + hourMs);
-    // Every hourly slot from the schedule's create time through now has no
-    // matching run except the one hour ago, so those are inferred as skipped.
-    expect(result.current.data.skippedExecutions).toEqual([
-      { scheduledTimeMs: nowMs - 3 * hourMs },
-      { scheduledTimeMs: nowMs - 2 * hourMs },
-      { scheduledTimeMs: nowMs },
-    ]);
+    expect(result.current.data.skippedExecutions).toEqual(
+      SKIPPED_EXECUTIONS_SINCE_CREATE_TIME
+    );
   });
 });
+
+function scheduleTimeAttribute(scheduledTimeMs: number) {
+  return {
+    data: Buffer.from(
+      JSON.stringify(new Date(scheduledTimeMs).toISOString())
+    ).toString('base64'),
+  };
+}
 
 function setup({
   describeScheduleResponse,

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/__tests__/use-schedule-runs-chart-data.test.tsx
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/__tests__/use-schedule-runs-chart-data.test.tsx
@@ -14,12 +14,12 @@ const nowMs = Date.UTC(2024, 0, 1, 12, 0);
 const hourMs = 60 * 60_000;
 // createTime is 3 hours before nowMs; every hourly slot since then has no
 // matching run except the one an hour ago, so those are inferred as skipped.
-const SKIPPED_EXECUTIONS_SINCE_CREATE_TIME = [
+const skippedExecutionsSinceCreateTime = [
   { scheduledTimeMs: nowMs - 3 * hourMs },
   { scheduledTimeMs: nowMs - 2 * hourMs },
   { scheduledTimeMs: nowMs },
 ];
-const HOURLY_SCHEDULE_OVERRIDES = {
+const hourlyScheduleOverrides = {
   spec: {
     cronExpression: '0 * * * *',
     startTime: null,
@@ -52,7 +52,7 @@ describe(useScheduleRunsChartData.name, () => {
   it('maps live workflow runs, skipped occurrences, and the next execution once loaded', async () => {
     const { result } = setup({
       describeScheduleResponse: getMockRunningDescribeScheduleResponse(
-        HOURLY_SCHEDULE_OVERRIDES
+        hourlyScheduleOverrides
       ),
       workflowsResponse: {
         workflows: [
@@ -83,7 +83,7 @@ describe(useScheduleRunsChartData.name, () => {
     ]);
     expect(result.current.data.nextExecutionTimeMs).toBe(nowMs + hourMs);
     expect(result.current.data.skippedExecutions).toEqual(
-      SKIPPED_EXECUTIONS_SINCE_CREATE_TIME
+      skippedExecutionsSinceCreateTime
     );
     expect(result.current.timelineStartMs).toBe(nowMs - 3 * hourMs);
   });
@@ -134,7 +134,7 @@ describe(useScheduleRunsChartData.name, () => {
 
     const { result } = setup({
       describeScheduleResponse: getMockRunningDescribeScheduleResponse(
-        HOURLY_SCHEDULE_OVERRIDES
+        hourlyScheduleOverrides
       ),
       workflowsResponse: {
         workflows: [
@@ -167,7 +167,7 @@ describe(useScheduleRunsChartData.name, () => {
     ]);
     expect(result.current.data.nextExecutionTimeMs).toBe(nowMs + hourMs);
     expect(result.current.data.skippedExecutions).toEqual(
-      SKIPPED_EXECUTIONS_SINCE_CREATE_TIME
+      skippedExecutionsSinceCreateTime
     );
   });
 });

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-expected-schedule-times-ms.test.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-expected-schedule-times-ms.test.ts
@@ -1,7 +1,7 @@
 import { MAX_SCHEDULE_CRON_OCCURRENCES } from '../../use-schedule-runs-chart-data.constants';
 import getExpectedScheduleTimesMs from '../get-expected-schedule-times-ms';
 
-const MINUTE_MS = 60_000;
+const minuteMs = 60_000;
 
 describe(getExpectedScheduleTimesMs.name, () => {
   it('iterates Cadence cron expressions within an inclusive range', () => {
@@ -23,18 +23,18 @@ describe(getExpectedScheduleTimesMs.name, () => {
       getExpectedScheduleTimesMs({
         cronExpression: '@every 1m',
         startMs: 0,
-        endMs: 10 * MINUTE_MS,
+        endMs: 10 * minuteMs,
       })
     ).toEqual([]);
     const cappedOccurrences = getExpectedScheduleTimesMs({
       cronExpression: '* * * * *',
       startMs: 0,
-      endMs: (MAX_SCHEDULE_CRON_OCCURRENCES + 1) * MINUTE_MS,
+      endMs: (MAX_SCHEDULE_CRON_OCCURRENCES + 1) * minuteMs,
     });
 
     expect(cappedOccurrences).toHaveLength(MAX_SCHEDULE_CRON_OCCURRENCES);
     expect(cappedOccurrences.at(-1)).toBe(
-      (MAX_SCHEDULE_CRON_OCCURRENCES + 1) * MINUTE_MS
+      (MAX_SCHEDULE_CRON_OCCURRENCES + 1) * minuteMs
     );
   });
 });

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-schedule-execution-gaps.test.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-schedule-execution-gaps.test.ts
@@ -1,6 +1,6 @@
 import getScheduleExecutionGaps from '../get-schedule-execution-gaps';
 
-const HOUR_MS = 60 * 60_000;
+const hourMs = 60 * 60_000;
 
 describe(getScheduleExecutionGaps.name, () => {
   it('subtracts actual runs from expected cron occurrences', () => {
@@ -11,14 +11,14 @@ describe(getScheduleExecutionGaps.name, () => {
         scheduleEndMs: null,
         oldestLoadedScheduleTimeMs: 0,
         hasNextPage: false,
-        lastFetchedAtMs: 3 * HOUR_MS,
-        nowMs: 3 * HOUR_MS,
-        actualTimesMs: [HOUR_MS, 3 * HOUR_MS],
+        lastFetchedAtMs: 3 * hourMs,
+        nowMs: 3 * hourMs,
+        actualTimesMs: [hourMs, 3 * hourMs],
       })
     ).toEqual({
       skippedExecutions: [
         { scheduledTimeMs: 0 },
-        { scheduledTimeMs: 2 * HOUR_MS },
+        { scheduledTimeMs: 2 * hourMs },
       ],
       unconfirmedExecutions: [],
     });
@@ -35,18 +35,18 @@ describe(getScheduleExecutionGaps.name, () => {
         // The runs page was last fetched two hours ago: slots strictly after
         // that can't be confirmed skipped yet, since a run may not have
         // shown up in the response due to visibility indexing/poll lag.
-        lastFetchedAtMs: 2 * HOUR_MS,
-        nowMs: 4 * HOUR_MS,
-        actualTimesMs: [HOUR_MS],
+        lastFetchedAtMs: 2 * hourMs,
+        nowMs: 4 * hourMs,
+        actualTimesMs: [hourMs],
       })
     ).toEqual({
       skippedExecutions: [
         { scheduledTimeMs: 0 },
-        { scheduledTimeMs: 2 * HOUR_MS },
+        { scheduledTimeMs: 2 * hourMs },
       ],
       unconfirmedExecutions: [
-        { scheduledTimeMs: 3 * HOUR_MS },
-        { scheduledTimeMs: 4 * HOUR_MS },
+        { scheduledTimeMs: 3 * hourMs },
+        { scheduledTimeMs: 4 * hourMs },
       ],
     });
   });
@@ -60,15 +60,15 @@ describe(getScheduleExecutionGaps.name, () => {
         oldestLoadedScheduleTimeMs: 0,
         hasNextPage: false,
         lastFetchedAtMs: null,
-        nowMs: 2 * HOUR_MS,
+        nowMs: 2 * hourMs,
         actualTimesMs: [],
       })
     ).toEqual({
       skippedExecutions: [],
       unconfirmedExecutions: [
         { scheduledTimeMs: 0 },
-        { scheduledTimeMs: HOUR_MS },
-        { scheduledTimeMs: 2 * HOUR_MS },
+        { scheduledTimeMs: hourMs },
+        { scheduledTimeMs: 2 * hourMs },
       ],
     });
   });
@@ -79,16 +79,16 @@ describe(getScheduleExecutionGaps.name, () => {
         cronExpression: '0 * * * *',
         timelineStartMs: 0,
         scheduleEndMs: null,
-        oldestLoadedScheduleTimeMs: 2 * HOUR_MS,
+        oldestLoadedScheduleTimeMs: 2 * hourMs,
         hasNextPage: true,
-        lastFetchedAtMs: 4 * HOUR_MS,
-        nowMs: 4 * HOUR_MS,
-        actualTimesMs: [2 * HOUR_MS],
+        lastFetchedAtMs: 4 * hourMs,
+        nowMs: 4 * hourMs,
+        actualTimesMs: [2 * hourMs],
       })
     ).toEqual({
       skippedExecutions: [
-        { scheduledTimeMs: 3 * HOUR_MS },
-        { scheduledTimeMs: 4 * HOUR_MS },
+        { scheduledTimeMs: 3 * hourMs },
+        { scheduledTimeMs: 4 * hourMs },
       ],
       unconfirmedExecutions: [],
     });
@@ -102,8 +102,8 @@ describe(getScheduleExecutionGaps.name, () => {
         scheduleEndMs: null,
         oldestLoadedScheduleTimeMs: null,
         hasNextPage: true,
-        lastFetchedAtMs: 4 * HOUR_MS,
-        nowMs: 4 * HOUR_MS,
+        lastFetchedAtMs: 4 * hourMs,
+        nowMs: 4 * hourMs,
         actualTimesMs: [],
       })
     ).toEqual({ skippedExecutions: [], unconfirmedExecutions: [] });
@@ -114,17 +114,17 @@ describe(getScheduleExecutionGaps.name, () => {
       getScheduleExecutionGaps({
         cronExpression: '0 * * * *',
         timelineStartMs: 0,
-        scheduleEndMs: 2 * HOUR_MS,
+        scheduleEndMs: 2 * hourMs,
         oldestLoadedScheduleTimeMs: 0,
         hasNextPage: false,
-        lastFetchedAtMs: 4 * HOUR_MS,
-        nowMs: 4 * HOUR_MS,
-        actualTimesMs: [HOUR_MS],
+        lastFetchedAtMs: 4 * hourMs,
+        nowMs: 4 * hourMs,
+        actualTimesMs: [hourMs],
       })
     ).toEqual({
       skippedExecutions: [
         { scheduledTimeMs: 0 },
-        { scheduledTimeMs: 2 * HOUR_MS },
+        { scheduledTimeMs: 2 * hourMs },
       ],
       unconfirmedExecutions: [],
     });
@@ -138,9 +138,9 @@ describe(getScheduleExecutionGaps.name, () => {
         scheduleEndMs: null,
         oldestLoadedScheduleTimeMs: 0,
         hasNextPage: false,
-        lastFetchedAtMs: HOUR_MS,
-        nowMs: HOUR_MS,
-        actualTimesMs: [HOUR_MS, HOUR_MS],
+        lastFetchedAtMs: hourMs,
+        nowMs: hourMs,
+        actualTimesMs: [hourMs, hourMs],
       })
     ).toEqual({
       skippedExecutions: [{ scheduledTimeMs: 0 }],
@@ -156,10 +156,10 @@ describe(getScheduleExecutionGaps.name, () => {
         scheduleEndMs: null,
         oldestLoadedScheduleTimeMs: 0,
         hasNextPage: false,
-        lastFetchedAtMs: 2 * HOUR_MS,
-        nowMs: 2 * HOUR_MS,
-        nextExecutionTimeMs: 2 * HOUR_MS,
-        actualTimesMs: [0, HOUR_MS],
+        lastFetchedAtMs: 2 * hourMs,
+        nowMs: 2 * hourMs,
+        nextExecutionTimeMs: 2 * hourMs,
+        actualTimesMs: [0, hourMs],
       })
     ).toEqual({ skippedExecutions: [], unconfirmedExecutions: [] });
   });
@@ -168,12 +168,12 @@ describe(getScheduleExecutionGaps.name, () => {
     expect(
       getScheduleExecutionGaps({
         cronExpression: '0 * * * *',
-        timelineStartMs: 2 * HOUR_MS,
-        scheduleEndMs: HOUR_MS,
+        timelineStartMs: 2 * hourMs,
+        scheduleEndMs: hourMs,
         oldestLoadedScheduleTimeMs: 0,
         hasNextPage: false,
-        lastFetchedAtMs: 4 * HOUR_MS,
-        nowMs: 4 * HOUR_MS,
+        lastFetchedAtMs: 4 * hourMs,
+        nowMs: 4 * hourMs,
         actualTimesMs: [],
       })
     ).toEqual({ skippedExecutions: [], unconfirmedExecutions: [] });

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/use-schedule-runs-chart-data.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/use-schedule-runs-chart-data.ts
@@ -127,5 +127,6 @@ export default function useScheduleRunsChartData({
       describeQuery.isLoading ||
       domainQuery.isLoading ||
       workflowsQuery.isLoading,
+    timelineStartMs: timelineBounds.timelineStartMs,
   };
 }

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/use-schedule-runs-chart-data.types.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/use-schedule-runs-chart-data.types.ts
@@ -14,6 +14,8 @@ export type UseScheduleRunsChartDataParams = {
 export type UseScheduleRunsChartDataResult = {
   data: ChartSeriesData;
   isLoading: boolean;
+  /** Earliest time the visible window may navigate back to (retention/schedule creation). */
+  timelineStartMs: number | null;
 };
 
 export type GetScheduleTimelineBoundsParams = {

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-view-state/__tests__/use-schedule-runs-chart-view-state.test.tsx
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-view-state/__tests__/use-schedule-runs-chart-view-state.test.tsx
@@ -1,0 +1,182 @@
+import { act } from '@testing-library/react';
+
+import { renderHook } from '@/test-utils/rtl';
+
+import {
+  CHART_NOW_ANCHOR_RATIO,
+  CHART_ZOOM_IN_FACTOR,
+  CHART_ZOOM_OUT_FACTOR,
+} from '@/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.constants';
+
+import useScheduleRunsChartViewState from '../use-schedule-runs-chart-view-state';
+
+const hourMs = 60 * 60 * 1000;
+const mockNowMs = new Date('2024-06-15T12:00:00Z').getTime();
+const defaultBounds = {
+  minMs: mockNowMs - 12 * hourMs,
+  maxMs: mockNowMs + 4 * hourMs,
+};
+const wideBounds = {
+  minMs: mockNowMs - 28 * hourMs,
+  maxMs: mockNowMs + 4 * hourMs,
+};
+const initialSpanMs = 4 * hourMs;
+const initialWindow = {
+  minMs: mockNowMs - initialSpanMs * CHART_NOW_ANCHOR_RATIO,
+  maxMs: mockNowMs + initialSpanMs * (1 - CHART_NOW_ANCHOR_RATIO),
+};
+const generousMaxSpanMs = 100 * hourMs;
+
+describe(useScheduleRunsChartViewState.name, () => {
+  it('follows the clock from the initial window', () => {
+    const { result, rerender } = setup();
+
+    act(() => {
+      result.current.initializeWindow(initialWindow, generousMaxSpanMs);
+    });
+
+    rerender({ nowMs: mockNowMs + 1_000, bounds: defaultBounds });
+
+    expect(result.current.visibleWindow).toEqual({
+      minMs: initialWindow.minMs + 1_000,
+      maxMs: initialWindow.maxMs + 1_000,
+    });
+  });
+
+  it('keeps the next run visible while following', () => {
+    const nextExecutionMs = mockNowMs + hourMs;
+    const { result, rerender } = setup({ nextExecutionMs });
+
+    act(() => {
+      result.current.initializeWindow(initialWindow, generousMaxSpanMs);
+    });
+
+    rerender({ nowMs: mockNowMs + 1_000, bounds: defaultBounds });
+
+    const visibleWindow = result.current.visibleWindow;
+
+    if (!visibleWindow) {
+      throw new Error('Expected a visible window');
+    }
+
+    expect(visibleWindow.maxMs).toBeGreaterThan(nextExecutionMs);
+    expect(visibleWindow.minMs).toBeLessThanOrEqual(mockNowMs + 1_000);
+  });
+
+  it('anchors zoom on now', () => {
+    const { result } = setup();
+
+    act(() => {
+      result.current.initializeWindow(initialWindow, generousMaxSpanMs);
+    });
+    act(() => {
+      result.current.zoomIn();
+    });
+
+    const zoomWindow = result.current.visibleWindow;
+
+    if (!zoomWindow) {
+      throw new Error('Expected a visible window');
+    }
+
+    const zoomedSpanMs = initialSpanMs * CHART_ZOOM_IN_FACTOR;
+    expect(zoomWindow.maxMs - zoomWindow.minMs).toBeCloseTo(zoomedSpanMs, -2);
+    expect((mockNowMs - zoomWindow.minMs) / zoomedSpanMs).toBeCloseTo(
+      CHART_NOW_ANCHOR_RATIO,
+      5
+    );
+  });
+
+  it('anchors now on initialization even when bounds clamp the window', () => {
+    const tightBounds = {
+      minMs: mockNowMs - 12 * hourMs,
+      maxMs: mockNowMs + hourMs,
+    };
+    const { result } = setup({ bounds: tightBounds });
+
+    act(() => {
+      result.current.initializeWindow(initialWindow, generousMaxSpanMs);
+    });
+
+    const visibleWindow = result.current.visibleWindow;
+
+    if (!visibleWindow) {
+      throw new Error('Expected a visible window');
+    }
+
+    const spanMs = visibleWindow.maxMs - visibleWindow.minMs;
+
+    expect((mockNowMs - visibleWindow.minMs) / spanMs).toBeCloseTo(
+      CHART_NOW_ANCHOR_RATIO,
+      5
+    );
+  });
+
+  it('does not jump when navigation bounds expand while following', () => {
+    const { result, rerender } = setup();
+
+    act(() => {
+      result.current.initializeWindow(initialWindow, generousMaxSpanMs);
+    });
+
+    const initialVisibleWindow = result.current.visibleWindow;
+
+    rerender({ bounds: wideBounds, nowMs: mockNowMs });
+
+    expect(result.current.visibleWindow).toEqual(initialVisibleWindow);
+  });
+
+  it('stops zooming out at the resolved overlap span', () => {
+    const maxSpanMs = initialSpanMs * CHART_ZOOM_OUT_FACTOR;
+    const { result } = setup({ bounds: wideBounds });
+
+    act(() => {
+      result.current.initializeWindow(initialWindow, maxSpanMs);
+    });
+
+    expect(result.current.canZoomOut).toBe(true);
+
+    act(() => {
+      result.current.zoomOut();
+    });
+
+    const visibleWindow = result.current.visibleWindow;
+
+    if (!visibleWindow) {
+      throw new Error('Expected a visible window');
+    }
+
+    expect(visibleWindow.maxMs - visibleWindow.minMs).toBeCloseTo(
+      maxSpanMs,
+      -2
+    );
+    expect(result.current.canZoomOut).toBe(false);
+  });
+});
+
+function setup({
+  bounds = defaultBounds,
+  nextExecutionMs,
+}: {
+  bounds?: typeof defaultBounds;
+  nextExecutionMs?: number;
+} = {}) {
+  return renderHook(
+    (
+      {
+        nowMs,
+        bounds: hookBounds,
+      }: {
+        nowMs: number;
+        bounds: typeof defaultBounds;
+      } = { nowMs: mockNowMs, bounds: defaultBounds }
+    ) =>
+      useScheduleRunsChartViewState({
+        bounds: hookBounds,
+        nowMs,
+        nextExecutionMs,
+      }),
+    undefined,
+    { initialProps: { nowMs: mockNowMs, bounds } }
+  );
+}

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-view-state/use-schedule-runs-chart-view-state.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-view-state/use-schedule-runs-chart-view-state.ts
@@ -1,0 +1,149 @@
+'use client';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  canZoomChartIn,
+  canZoomChartOut,
+  clampChartVisibleTimeWindow,
+  getChartTimeWindowSpanMs,
+  isSameChartTimeWindow,
+  resolveChartFollowTimeWindow,
+  zoomChartTimeWindow,
+} from '@/views/schedule-details/schedule-details-runs-chart/helpers/chart-view-state';
+import {
+  CHART_ZOOM_IN_FACTOR,
+  CHART_ZOOM_OUT_FACTOR,
+} from '@/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.constants';
+import { type ChartTimeWindow } from '@/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.types';
+
+import {
+  type UseScheduleRunsChartViewStateParams,
+  type UseScheduleRunsChartViewStateResult,
+} from './use-schedule-runs-chart-view-state.types';
+
+/**
+ * Owns the chart's visible time window, always live-following `now` (and the
+ * next scheduled run, if closer to the edge). Panning away from `now` and
+ * resuming with "Now" land in a follow-up change; for now the window simply
+ * tracks the clock.
+ */
+export default function useScheduleRunsChartViewState({
+  bounds,
+  nowMs,
+  nextExecutionMs,
+}: UseScheduleRunsChartViewStateParams): UseScheduleRunsChartViewStateResult {
+  const [visibleWindow, setVisibleWindow] = useState<ChartTimeWindow | null>(
+    null
+  );
+  const [maxSpanMs, setMaxSpanMs] = useState<number | null>(null);
+  const visibleWindowRef = useRef<ChartTimeWindow | null>(null);
+
+  const updateVisibleWindow = useCallback(
+    (nextVisibleWindow: ChartTimeWindow | null) => {
+      visibleWindowRef.current = nextVisibleWindow;
+      setVisibleWindow(nextVisibleWindow);
+    },
+    []
+  );
+
+  useEffect(() => {
+    const currentVisibleWindow = visibleWindowRef.current;
+
+    if (!bounds) {
+      if (currentVisibleWindow) {
+        updateVisibleWindow(null);
+      }
+
+      return;
+    }
+
+    if (!currentVisibleWindow) {
+      return;
+    }
+
+    const clampedWindow = clampChartVisibleTimeWindow(
+      currentVisibleWindow,
+      bounds
+    );
+    const nextWindow = resolveChartFollowTimeWindow({
+      visibleWindow: clampedWindow,
+      bounds,
+      nowMs,
+      nextExecutionMs,
+    });
+
+    if (!isSameChartTimeWindow(nextWindow, currentVisibleWindow)) {
+      updateVisibleWindow(nextWindow);
+    }
+  }, [bounds, nextExecutionMs, nowMs, updateVisibleWindow]);
+
+  const initializeWindow = useCallback(
+    (window: ChartTimeWindow, resolvedMaxSpanMs: number) => {
+      if (!bounds) {
+        updateVisibleWindow(window);
+        setMaxSpanMs(resolvedMaxSpanMs);
+        return;
+      }
+
+      const boundsSpanMs = getChartTimeWindowSpanMs(bounds);
+      const clampedWindow = clampChartVisibleTimeWindow(window, bounds);
+      const initialWindow = resolveChartFollowTimeWindow({
+        visibleWindow: clampedWindow,
+        bounds,
+        nowMs,
+        nextExecutionMs,
+      });
+
+      updateVisibleWindow(initialWindow);
+      setMaxSpanMs(Math.min(boundsSpanMs, resolvedMaxSpanMs));
+    },
+    [bounds, nextExecutionMs, nowMs, updateVisibleWindow]
+  );
+
+  const zoomBy = useCallback(
+    (factor: number) => {
+      const currentVisibleWindow = visibleWindowRef.current;
+
+      if (!bounds || !currentVisibleWindow || maxSpanMs == null) {
+        return;
+      }
+
+      const zoomedWindow = zoomChartTimeWindow({
+        visibleWindow: currentVisibleWindow,
+        bounds,
+        maxSpanMs,
+        factor,
+        anchorMs: nowMs,
+      });
+
+      updateVisibleWindow(
+        resolveChartFollowTimeWindow({
+          visibleWindow: zoomedWindow,
+          bounds,
+          nowMs,
+          nextExecutionMs,
+        })
+      );
+    },
+    [bounds, maxSpanMs, nextExecutionMs, nowMs, updateVisibleWindow]
+  );
+
+  const zoomIn = useCallback(() => zoomBy(CHART_ZOOM_IN_FACTOR), [zoomBy]);
+
+  const zoomOut = useCallback(() => zoomBy(CHART_ZOOM_OUT_FACTOR), [zoomBy]);
+
+  return useMemo(
+    () => ({
+      visibleWindow,
+      canZoomIn: visibleWindow ? canZoomChartIn(visibleWindow) : false,
+      canZoomOut:
+        visibleWindow && maxSpanMs != null
+          ? canZoomChartOut(visibleWindow, maxSpanMs)
+          : false,
+      initializeWindow,
+      zoomIn,
+      zoomOut,
+    }),
+    [initializeWindow, maxSpanMs, visibleWindow, zoomIn, zoomOut]
+  );
+}

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-view-state/use-schedule-runs-chart-view-state.types.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-view-state/use-schedule-runs-chart-view-state.types.ts
@@ -1,0 +1,16 @@
+import { type ChartTimeWindow } from '@/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.types';
+
+export type UseScheduleRunsChartViewStateParams = {
+  bounds: ChartTimeWindow | null;
+  nowMs: number;
+  nextExecutionMs?: number | null;
+};
+
+export type UseScheduleRunsChartViewStateResult = {
+  visibleWindow: ChartTimeWindow | null;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
+  initializeWindow: (window: ChartTimeWindow, maxSpanMs: number) => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+};

--- a/src/views/schedule-details/schedule-details-runs-chart-glyph/__tests__/schedule-details-runs-chart-glyph.test.tsx
+++ b/src/views/schedule-details/schedule-details-runs-chart-glyph/__tests__/schedule-details-runs-chart-glyph.test.tsx
@@ -8,14 +8,14 @@ import ScheduleDetailsRunsChartGlyph from '../schedule-details-runs-chart-glyph'
 import { CHART_GLYPH_TEST_IDS } from '../schedule-details-runs-chart-glyph.constants';
 import { type Props } from '../schedule-details-runs-chart-glyph.types';
 
-const COMPLETED_LABEL = 'Completed schedule run run-1';
+const completedLabel = 'Completed schedule run run-1';
 
 describe(ScheduleDetailsRunsChartGlyph.name, () => {
   it('renders a single marker with an accessible label', () => {
-    setup({ variant: WORKFLOW_STATUSES.completed, label: COMPLETED_LABEL });
+    setup({ variant: WORKFLOW_STATUSES.completed, label: completedLabel });
 
     expect(
-      screen.getByRole('img', { name: COMPLETED_LABEL })
+      screen.getByRole('img', { name: completedLabel })
     ).toBeInTheDocument();
   });
 
@@ -33,7 +33,7 @@ describe(ScheduleDetailsRunsChartGlyph.name, () => {
     setup({
       variant: WORKFLOW_STATUSES.completed,
       isBackfill: true,
-      label: COMPLETED_LABEL,
+      label: completedLabel,
     });
 
     expect(

--- a/src/views/schedule-details/schedule-details-runs-chart-series/__tests__/schedule-details-runs-chart-series.test.tsx
+++ b/src/views/schedule-details/schedule-details-runs-chart-series/__tests__/schedule-details-runs-chart-series.test.tsx
@@ -58,9 +58,9 @@ const mockRun = (
   ...overrides,
 });
 
-const WINDOW_START_MS = Date.UTC(2024, 0, 1, 0, 0);
-const WINDOW_END_MS = Date.UTC(2024, 0, 1, 6, 0);
-const EMPTY_DATA: ChartSeriesData = {
+const windowStartMs = Date.UTC(2024, 0, 1, 0, 0);
+const windowEndMs = Date.UTC(2024, 0, 1, 6, 0);
+const emptyData: ChartSeriesData = {
   runs: [],
   skippedExecutions: [],
   unconfirmedExecutions: [],
@@ -126,7 +126,7 @@ describe(ScheduleDetailsRunsChartSeries.name, () => {
   it('renders a marker for each skipped execution', () => {
     setup({
       data: {
-        ...EMPTY_DATA,
+        ...emptyData,
         skippedExecutions: [{ scheduledTimeMs: Date.UTC(2024, 0, 1, 3, 0) }],
       },
     });
@@ -139,7 +139,7 @@ describe(ScheduleDetailsRunsChartSeries.name, () => {
   it('renders a marker for each unconfirmed execution', () => {
     setup({
       data: {
-        ...EMPTY_DATA,
+        ...emptyData,
         unconfirmedExecutions: [
           { scheduledTimeMs: Date.UTC(2024, 0, 1, 3, 0) },
         ],
@@ -154,7 +154,7 @@ describe(ScheduleDetailsRunsChartSeries.name, () => {
   it('renders the next execution marker when set', () => {
     setup({
       data: {
-        ...EMPTY_DATA,
+        ...emptyData,
         nextExecutionTimeMs: Date.UTC(2024, 0, 1, 5, 0),
       },
     });
@@ -165,7 +165,7 @@ describe(ScheduleDetailsRunsChartSeries.name, () => {
   });
 
   it('omits the next execution marker when unset', () => {
-    setup({ data: EMPTY_DATA });
+    setup({ data: emptyData });
 
     expect(
       screen.queryByTestId(CHART_SERIES_TEST_IDS.nextExecutionMarker)
@@ -175,7 +175,7 @@ describe(ScheduleDetailsRunsChartSeries.name, () => {
   it('renders a popover trigger for the next execution when set', () => {
     setup({
       data: {
-        ...EMPTY_DATA,
+        ...emptyData,
         nextExecutionTimeMs: Date.UTC(2024, 0, 1, 5, 0),
       },
     });
@@ -188,7 +188,7 @@ describe(ScheduleDetailsRunsChartSeries.name, () => {
   it('renders a popover trigger for each skipped execution', () => {
     setup({
       data: {
-        ...EMPTY_DATA,
+        ...emptyData,
         skippedExecutions: [{ scheduledTimeMs: Date.UTC(2024, 0, 1, 3, 0) }],
       },
     });
@@ -234,7 +234,7 @@ function setup({ data }: { data: ChartSeriesData }) {
   render(
     <ScheduleDetailsRunsChartSeries
       xScale={scaleLinear({
-        domain: [WINDOW_START_MS, WINDOW_END_MS],
+        domain: [windowStartMs, windowEndMs],
         range: [0, 800],
       })}
       data={data}

--- a/src/views/schedule-details/schedule-details-runs-chart/__tests__/schedule-details-runs-chart.test.tsx
+++ b/src/views/schedule-details/schedule-details-runs-chart/__tests__/schedule-details-runs-chart.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { HttpResponse } from 'msw';
 
-import { render, screen, within } from '@/test-utils/rtl';
+import { render, screen, waitFor, within } from '@/test-utils/rtl';
 
 import { getMockRunningDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
@@ -30,6 +30,24 @@ const describeScheduleWithNextRun = getMockRunningDescribeScheduleResponse({
     nextRunTime: { seconds: String((nowMs + hourMs) / 1000), nanos: 0 },
     totalRuns: '1',
     createTime: null,
+    lastUpdateTime: null,
+    missedRuns: '0',
+    skippedRuns: '0',
+    ongoingBackfills: [],
+  },
+});
+
+// A schedule created long before its most recent run gives the navigation
+// bounds enough headroom beyond the initial view to actually zoom out.
+const describeScheduleWithWideHistory = getMockRunningDescribeScheduleResponse({
+  info: {
+    lastRunTime: null,
+    nextRunTime: { seconds: String((nowMs + hourMs) / 1000), nanos: 0 },
+    totalRuns: '1',
+    createTime: {
+      seconds: String((nowMs - 30 * 24 * hourMs) / 1000),
+      nanos: 0,
+    },
     lastUpdateTime: null,
     missedRuns: '0',
     skippedRuns: '0',
@@ -131,8 +149,8 @@ describe(ScheduleDetailsRunsChart.name, () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders disabled toolbar controls', () => {
-    setup();
+  it('disables toolbar controls while the schedule data is loading', () => {
+    setup({ isLoading: true });
 
     const toolbar = screen.getByRole('toolbar', {
       name: CHART_TOOLBAR_ARIA_LABEL,
@@ -143,6 +161,32 @@ describe(ScheduleDetailsRunsChart.name, () => {
         within(toolbar).getByRole('button', { name: label })
       ).toBeDisabled();
     });
+  });
+
+  it('enables zoom controls once data has loaded, with "now" disabled', async () => {
+    setup({ describeScheduleResponse: describeScheduleWithWideHistory });
+
+    const toolbar = screen.getByRole('toolbar', {
+      name: CHART_TOOLBAR_ARIA_LABEL,
+    });
+
+    await waitFor(() =>
+      expect(
+        within(toolbar).getByRole('button', {
+          name: CHART_TOOLBAR_BUTTON_LABELS.zoomOut,
+        })
+      ).not.toBeDisabled()
+    );
+    expect(
+      within(toolbar).getByRole('button', {
+        name: CHART_TOOLBAR_BUTTON_LABELS.zoomIn,
+      })
+    ).not.toBeDisabled();
+    expect(
+      within(toolbar).getByRole('button', {
+        name: CHART_TOOLBAR_BUTTON_LABELS.now,
+      })
+    ).toBeDisabled();
   });
 });
 

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/chart-view-state.test.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/chart-view-state.test.ts
@@ -57,6 +57,20 @@ describe(clampChartVisibleTimeWindow.name, () => {
       )
     ).toEqual(bounds);
   });
+
+  it('expands a sub-min span near the lower bound without leaving bounds', () => {
+    expect(
+      clampChartVisibleTimeWindow({ minMs: 0, maxMs: 60_000 }, bounds)
+    ).toEqual({ minMs: 0, maxMs: CHART_MIN_DOMAIN_SPAN_MS });
+  });
+
+  it('returns full bounds when the minimum span exceeds the navigable range', () => {
+    const narrowBounds = { minMs: 0, maxMs: 2 * 60_000 };
+
+    expect(
+      clampChartVisibleTimeWindow({ minMs: 0, maxMs: 60_000 }, narrowBounds)
+    ).toEqual(narrowBounds);
+  });
 });
 
 describe(zoomChartTimeWindow.name, () => {

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/chart-view-state.test.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/chart-view-state.test.ts
@@ -1,0 +1,189 @@
+import { CHART_MIN_DOMAIN_SPAN_MS } from '../../schedule-details-runs-chart.constants';
+import {
+  canZoomChartIn,
+  canZoomChartOut,
+  clampChartVisibleTimeWindow,
+  getChartTimeWindowSpanMs,
+  isSameChartTimeWindow,
+  panChartTimeWindowToTime,
+  resolveChartFollowTimeWindow,
+  zoomChartTimeWindow,
+} from '../chart-view-state';
+
+const HOUR_MS = 60 * 60_000;
+const bounds = { minMs: 0, maxMs: 10 * HOUR_MS };
+
+describe(getChartTimeWindowSpanMs.name, () => {
+  it('returns the difference between max and min', () => {
+    expect(getChartTimeWindowSpanMs({ minMs: 10, maxMs: 30 })).toBe(20);
+  });
+});
+
+describe(isSameChartTimeWindow.name, () => {
+  it('compares both bounds', () => {
+    expect(
+      isSameChartTimeWindow({ minMs: 10, maxMs: 30 }, { minMs: 10, maxMs: 30 })
+    ).toBe(true);
+    expect(
+      isSameChartTimeWindow({ minMs: 10, maxMs: 30 }, { minMs: 10, maxMs: 31 })
+    ).toBe(false);
+  });
+});
+
+describe(clampChartVisibleTimeWindow.name, () => {
+  it('leaves a window fully within bounds untouched', () => {
+    expect(
+      clampChartVisibleTimeWindow(
+        { minMs: 1 * HOUR_MS, maxMs: 2 * HOUR_MS },
+        bounds
+      )
+    ).toEqual({ minMs: 1 * HOUR_MS, maxMs: 2 * HOUR_MS });
+  });
+
+  it('shifts a window that overshoots the upper bound', () => {
+    expect(
+      clampChartVisibleTimeWindow(
+        { minMs: 9 * HOUR_MS, maxMs: 12 * HOUR_MS },
+        bounds
+      )
+    ).toEqual({ minMs: 7 * HOUR_MS, maxMs: 10 * HOUR_MS });
+  });
+
+  it('returns the full bounds when the visible span exceeds it', () => {
+    expect(
+      clampChartVisibleTimeWindow(
+        { minMs: -5 * HOUR_MS, maxMs: 20 * HOUR_MS },
+        bounds
+      )
+    ).toEqual(bounds);
+  });
+});
+
+describe(zoomChartTimeWindow.name, () => {
+  const visibleWindow = { minMs: 4 * HOUR_MS, maxMs: 6 * HOUR_MS };
+
+  it('shrinks the span around the anchor when zooming in', () => {
+    const zoomed = zoomChartTimeWindow({
+      visibleWindow,
+      bounds,
+      maxSpanMs: 10 * HOUR_MS,
+      factor: 0.5,
+      anchorMs: 5 * HOUR_MS,
+    });
+
+    expect(getChartTimeWindowSpanMs(zoomed)).toBe(1 * HOUR_MS);
+    expect(zoomed).toEqual({ minMs: 4.5 * HOUR_MS, maxMs: 5.5 * HOUR_MS });
+  });
+
+  it('never zooms in past the minimum domain span', () => {
+    const zoomed = zoomChartTimeWindow({
+      visibleWindow: {
+        minMs: 5 * HOUR_MS - 60_000,
+        maxMs: 5 * HOUR_MS + 60_000,
+      },
+      bounds,
+      maxSpanMs: 10 * HOUR_MS,
+      factor: 0.1,
+      anchorMs: 5 * HOUR_MS,
+    });
+
+    expect(getChartTimeWindowSpanMs(zoomed)).toBe(CHART_MIN_DOMAIN_SPAN_MS);
+  });
+
+  it('caps the span at maxSpanMs when zooming out', () => {
+    const zoomed = zoomChartTimeWindow({
+      visibleWindow,
+      bounds,
+      maxSpanMs: 2.5 * HOUR_MS,
+      factor: 4,
+      anchorMs: 5 * HOUR_MS,
+    });
+
+    expect(getChartTimeWindowSpanMs(zoomed)).toBe(2.5 * HOUR_MS);
+  });
+
+  it('anchors on the window center when the anchor is off-screen', () => {
+    const zoomed = zoomChartTimeWindow({
+      visibleWindow,
+      bounds,
+      maxSpanMs: 10 * HOUR_MS,
+      factor: 0.5,
+      anchorMs: 9.9 * HOUR_MS,
+    });
+
+    expect(zoomed).toEqual({ minMs: 4.5 * HOUR_MS, maxMs: 5.5 * HOUR_MS });
+  });
+});
+
+describe(panChartTimeWindowToTime.name, () => {
+  it('centers the window on timeMs using the given anchor ratio', () => {
+    const panned = panChartTimeWindowToTime({
+      visibleWindow: { minMs: 0, maxMs: 1 * HOUR_MS },
+      bounds: { minMs: -100 * HOUR_MS, maxMs: 100 * HOUR_MS },
+      timeMs: 5 * HOUR_MS,
+      anchorRatio: 0.5,
+    });
+
+    expect(panned).toEqual({ minMs: 4.5 * HOUR_MS, maxMs: 5.5 * HOUR_MS });
+  });
+
+  it('clamps the panned window to bounds', () => {
+    const panned = panChartTimeWindowToTime({
+      visibleWindow: { minMs: 0, maxMs: 1 * HOUR_MS },
+      bounds,
+      timeMs: 20 * HOUR_MS,
+      anchorRatio: 0.5,
+    });
+
+    expect(panned.maxMs).toBe(bounds.maxMs);
+  });
+});
+
+describe(canZoomChartIn.name, () => {
+  it('is true while the span is above the minimum', () => {
+    expect(
+      canZoomChartIn({ minMs: 0, maxMs: CHART_MIN_DOMAIN_SPAN_MS * 2 })
+    ).toBe(true);
+    expect(canZoomChartIn({ minMs: 0, maxMs: CHART_MIN_DOMAIN_SPAN_MS })).toBe(
+      false
+    );
+  });
+});
+
+describe(canZoomChartOut.name, () => {
+  it('is true while the span is below maxSpanMs', () => {
+    expect(canZoomChartOut({ minMs: 0, maxMs: 1 * HOUR_MS }, 2 * HOUR_MS)).toBe(
+      true
+    );
+    expect(canZoomChartOut({ minMs: 0, maxMs: 2 * HOUR_MS }, 2 * HOUR_MS)).toBe(
+      false
+    );
+  });
+});
+
+describe(resolveChartFollowTimeWindow.name, () => {
+  const followBounds = { minMs: -100 * HOUR_MS, maxMs: 100 * HOUR_MS };
+
+  it('anchors on now when there is no pending next execution', () => {
+    const window = resolveChartFollowTimeWindow({
+      visibleWindow: { minMs: -1 * HOUR_MS, maxMs: 1 * HOUR_MS },
+      bounds: followBounds,
+      nowMs: 0,
+    });
+
+    expect(window.maxMs).toBeGreaterThan(0);
+    expect(window.minMs).toBeLessThan(0);
+  });
+
+  it('pulls the next execution into view when it would otherwise be cut off', () => {
+    const window = resolveChartFollowTimeWindow({
+      visibleWindow: { minMs: -1 * HOUR_MS, maxMs: 1 * HOUR_MS },
+      bounds: followBounds,
+      nowMs: 0,
+      nextExecutionMs: 1.5 * HOUR_MS,
+    });
+
+    expect(window.maxMs).toBeGreaterThanOrEqual(1.5 * HOUR_MS);
+    expect(window.minMs).toBeLessThanOrEqual(0);
+  });
+});

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/chart-view-state.test.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/chart-view-state.test.ts
@@ -10,8 +10,8 @@ import {
   zoomChartTimeWindow,
 } from '../chart-view-state';
 
-const HOUR_MS = 60 * 60_000;
-const bounds = { minMs: 0, maxMs: 10 * HOUR_MS };
+const hourMs = 60 * 60_000;
+const bounds = { minMs: 0, maxMs: 10 * hourMs };
 
 describe(getChartTimeWindowSpanMs.name, () => {
   it('returns the difference between max and min', () => {
@@ -34,25 +34,25 @@ describe(clampChartVisibleTimeWindow.name, () => {
   it('leaves a window fully within bounds untouched', () => {
     expect(
       clampChartVisibleTimeWindow(
-        { minMs: 1 * HOUR_MS, maxMs: 2 * HOUR_MS },
+        { minMs: 1 * hourMs, maxMs: 2 * hourMs },
         bounds
       )
-    ).toEqual({ minMs: 1 * HOUR_MS, maxMs: 2 * HOUR_MS });
+    ).toEqual({ minMs: 1 * hourMs, maxMs: 2 * hourMs });
   });
 
   it('shifts a window that overshoots the upper bound', () => {
     expect(
       clampChartVisibleTimeWindow(
-        { minMs: 9 * HOUR_MS, maxMs: 12 * HOUR_MS },
+        { minMs: 9 * hourMs, maxMs: 12 * hourMs },
         bounds
       )
-    ).toEqual({ minMs: 7 * HOUR_MS, maxMs: 10 * HOUR_MS });
+    ).toEqual({ minMs: 7 * hourMs, maxMs: 10 * hourMs });
   });
 
   it('returns the full bounds when the visible span exceeds it', () => {
     expect(
       clampChartVisibleTimeWindow(
-        { minMs: -5 * HOUR_MS, maxMs: 20 * HOUR_MS },
+        { minMs: -5 * hourMs, maxMs: 20 * hourMs },
         bounds
       )
     ).toEqual(bounds);
@@ -60,31 +60,31 @@ describe(clampChartVisibleTimeWindow.name, () => {
 });
 
 describe(zoomChartTimeWindow.name, () => {
-  const visibleWindow = { minMs: 4 * HOUR_MS, maxMs: 6 * HOUR_MS };
+  const visibleWindow = { minMs: 4 * hourMs, maxMs: 6 * hourMs };
 
   it('shrinks the span around the anchor when zooming in', () => {
     const zoomed = zoomChartTimeWindow({
       visibleWindow,
       bounds,
-      maxSpanMs: 10 * HOUR_MS,
+      maxSpanMs: 10 * hourMs,
       factor: 0.5,
-      anchorMs: 5 * HOUR_MS,
+      anchorMs: 5 * hourMs,
     });
 
-    expect(getChartTimeWindowSpanMs(zoomed)).toBe(1 * HOUR_MS);
-    expect(zoomed).toEqual({ minMs: 4.5 * HOUR_MS, maxMs: 5.5 * HOUR_MS });
+    expect(getChartTimeWindowSpanMs(zoomed)).toBe(1 * hourMs);
+    expect(zoomed).toEqual({ minMs: 4.5 * hourMs, maxMs: 5.5 * hourMs });
   });
 
   it('never zooms in past the minimum domain span', () => {
     const zoomed = zoomChartTimeWindow({
       visibleWindow: {
-        minMs: 5 * HOUR_MS - 60_000,
-        maxMs: 5 * HOUR_MS + 60_000,
+        minMs: 5 * hourMs - 60_000,
+        maxMs: 5 * hourMs + 60_000,
       },
       bounds,
-      maxSpanMs: 10 * HOUR_MS,
+      maxSpanMs: 10 * hourMs,
       factor: 0.1,
-      anchorMs: 5 * HOUR_MS,
+      anchorMs: 5 * hourMs,
     });
 
     expect(getChartTimeWindowSpanMs(zoomed)).toBe(CHART_MIN_DOMAIN_SPAN_MS);
@@ -94,44 +94,44 @@ describe(zoomChartTimeWindow.name, () => {
     const zoomed = zoomChartTimeWindow({
       visibleWindow,
       bounds,
-      maxSpanMs: 2.5 * HOUR_MS,
+      maxSpanMs: 2.5 * hourMs,
       factor: 4,
-      anchorMs: 5 * HOUR_MS,
+      anchorMs: 5 * hourMs,
     });
 
-    expect(getChartTimeWindowSpanMs(zoomed)).toBe(2.5 * HOUR_MS);
+    expect(getChartTimeWindowSpanMs(zoomed)).toBe(2.5 * hourMs);
   });
 
   it('anchors on the window center when the anchor is off-screen', () => {
     const zoomed = zoomChartTimeWindow({
       visibleWindow,
       bounds,
-      maxSpanMs: 10 * HOUR_MS,
+      maxSpanMs: 10 * hourMs,
       factor: 0.5,
-      anchorMs: 9.9 * HOUR_MS,
+      anchorMs: 9.9 * hourMs,
     });
 
-    expect(zoomed).toEqual({ minMs: 4.5 * HOUR_MS, maxMs: 5.5 * HOUR_MS });
+    expect(zoomed).toEqual({ minMs: 4.5 * hourMs, maxMs: 5.5 * hourMs });
   });
 });
 
 describe(panChartTimeWindowToTime.name, () => {
   it('centers the window on timeMs using the given anchor ratio', () => {
     const panned = panChartTimeWindowToTime({
-      visibleWindow: { minMs: 0, maxMs: 1 * HOUR_MS },
-      bounds: { minMs: -100 * HOUR_MS, maxMs: 100 * HOUR_MS },
-      timeMs: 5 * HOUR_MS,
+      visibleWindow: { minMs: 0, maxMs: 1 * hourMs },
+      bounds: { minMs: -100 * hourMs, maxMs: 100 * hourMs },
+      timeMs: 5 * hourMs,
       anchorRatio: 0.5,
     });
 
-    expect(panned).toEqual({ minMs: 4.5 * HOUR_MS, maxMs: 5.5 * HOUR_MS });
+    expect(panned).toEqual({ minMs: 4.5 * hourMs, maxMs: 5.5 * hourMs });
   });
 
   it('clamps the panned window to bounds', () => {
     const panned = panChartTimeWindowToTime({
-      visibleWindow: { minMs: 0, maxMs: 1 * HOUR_MS },
+      visibleWindow: { minMs: 0, maxMs: 1 * hourMs },
       bounds,
-      timeMs: 20 * HOUR_MS,
+      timeMs: 20 * hourMs,
       anchorRatio: 0.5,
     });
 
@@ -152,21 +152,21 @@ describe(canZoomChartIn.name, () => {
 
 describe(canZoomChartOut.name, () => {
   it('is true while the span is below maxSpanMs', () => {
-    expect(canZoomChartOut({ minMs: 0, maxMs: 1 * HOUR_MS }, 2 * HOUR_MS)).toBe(
+    expect(canZoomChartOut({ minMs: 0, maxMs: 1 * hourMs }, 2 * hourMs)).toBe(
       true
     );
-    expect(canZoomChartOut({ minMs: 0, maxMs: 2 * HOUR_MS }, 2 * HOUR_MS)).toBe(
+    expect(canZoomChartOut({ minMs: 0, maxMs: 2 * hourMs }, 2 * hourMs)).toBe(
       false
     );
   });
 });
 
 describe(resolveChartFollowTimeWindow.name, () => {
-  const followBounds = { minMs: -100 * HOUR_MS, maxMs: 100 * HOUR_MS };
+  const followBounds = { minMs: -100 * hourMs, maxMs: 100 * hourMs };
 
   it('anchors on now when there is no pending next execution', () => {
     const window = resolveChartFollowTimeWindow({
-      visibleWindow: { minMs: -1 * HOUR_MS, maxMs: 1 * HOUR_MS },
+      visibleWindow: { minMs: -1 * hourMs, maxMs: 1 * hourMs },
       bounds: followBounds,
       nowMs: 0,
     });
@@ -177,13 +177,13 @@ describe(resolveChartFollowTimeWindow.name, () => {
 
   it('pulls the next execution into view when it would otherwise be cut off', () => {
     const window = resolveChartFollowTimeWindow({
-      visibleWindow: { minMs: -1 * HOUR_MS, maxMs: 1 * HOUR_MS },
+      visibleWindow: { minMs: -1 * hourMs, maxMs: 1 * hourMs },
       bounds: followBounds,
       nowMs: 0,
-      nextExecutionMs: 1.5 * HOUR_MS,
+      nextExecutionMs: 1.5 * hourMs,
     });
 
-    expect(window.maxMs).toBeGreaterThanOrEqual(1.5 * HOUR_MS);
+    expect(window.maxMs).toBeGreaterThanOrEqual(1.5 * hourMs);
     expect(window.minMs).toBeLessThanOrEqual(0);
   });
 });

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/filter-chart-series-data-to-visible-window.test.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/filter-chart-series-data-to-visible-window.test.ts
@@ -1,9 +1,9 @@
 import { type ChartSeriesData } from '../../../schedule-details-runs-chart-series/schedule-details-runs-chart-series.types';
 import filterChartSeriesDataToVisibleWindow from '../filter-chart-series-data-to-visible-window';
 
-const HOUR_MS = 60 * 60_000;
+const hourMs = 60 * 60_000;
 const nowMs = Date.UTC(2024, 0, 1, 12, 0);
-const window = { minMs: nowMs - HOUR_MS, maxMs: nowMs + HOUR_MS };
+const window = { minMs: nowMs - hourMs, maxMs: nowMs + hourMs };
 
 const data: ChartSeriesData = {
   runs: [
@@ -18,33 +18,33 @@ const data: ChartSeriesData = {
     {
       workflowId: 'wf-out',
       runId: 'run-out',
-      scheduledTimeMs: nowMs - 5 * HOUR_MS,
+      scheduledTimeMs: nowMs - 5 * hourMs,
       status: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
       startedTimeMs: null,
       endedTimeMs: null,
     },
   ],
   skippedExecutions: [
-    { scheduledTimeMs: nowMs - 5 * HOUR_MS },
-    { scheduledTimeMs: nowMs - HOUR_MS },
+    { scheduledTimeMs: nowMs - 5 * hourMs },
+    { scheduledTimeMs: nowMs - hourMs },
   ],
-  unconfirmedExecutions: [{ scheduledTimeMs: nowMs + 5 * HOUR_MS }],
-  nextExecutionTimeMs: nowMs + HOUR_MS,
+  unconfirmedExecutions: [{ scheduledTimeMs: nowMs + 5 * hourMs }],
+  nextExecutionTimeMs: nowMs + hourMs,
 };
 
 describe(filterChartSeriesDataToVisibleWindow.name, () => {
   it('drops points outside the visible window and keeps points at its edges', () => {
     expect(filterChartSeriesDataToVisibleWindow(data, window)).toEqual({
       runs: [expect.objectContaining({ runId: 'run-in' })],
-      skippedExecutions: [{ scheduledTimeMs: nowMs - HOUR_MS }],
+      skippedExecutions: [{ scheduledTimeMs: nowMs - hourMs }],
       unconfirmedExecutions: [],
-      nextExecutionTimeMs: nowMs + HOUR_MS,
+      nextExecutionTimeMs: nowMs + hourMs,
     });
   });
 
   it('nulls the next execution time when it falls outside the window', () => {
     const result = filterChartSeriesDataToVisibleWindow(data, {
-      minMs: nowMs - HOUR_MS,
+      minMs: nowMs - hourMs,
       maxMs: nowMs,
     });
 

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/filter-chart-series-data-to-visible-window.test.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/__tests__/filter-chart-series-data-to-visible-window.test.ts
@@ -1,0 +1,62 @@
+import { type ChartSeriesData } from '../../../schedule-details-runs-chart-series/schedule-details-runs-chart-series.types';
+import filterChartSeriesDataToVisibleWindow from '../filter-chart-series-data-to-visible-window';
+
+const HOUR_MS = 60 * 60_000;
+const nowMs = Date.UTC(2024, 0, 1, 12, 0);
+const window = { minMs: nowMs - HOUR_MS, maxMs: nowMs + HOUR_MS };
+
+const data: ChartSeriesData = {
+  runs: [
+    {
+      workflowId: 'wf-in',
+      runId: 'run-in',
+      scheduledTimeMs: nowMs,
+      status: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
+      startedTimeMs: null,
+      endedTimeMs: null,
+    },
+    {
+      workflowId: 'wf-out',
+      runId: 'run-out',
+      scheduledTimeMs: nowMs - 5 * HOUR_MS,
+      status: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
+      startedTimeMs: null,
+      endedTimeMs: null,
+    },
+  ],
+  skippedExecutions: [
+    { scheduledTimeMs: nowMs - 5 * HOUR_MS },
+    { scheduledTimeMs: nowMs - HOUR_MS },
+  ],
+  unconfirmedExecutions: [{ scheduledTimeMs: nowMs + 5 * HOUR_MS }],
+  nextExecutionTimeMs: nowMs + HOUR_MS,
+};
+
+describe(filterChartSeriesDataToVisibleWindow.name, () => {
+  it('drops points outside the visible window and keeps points at its edges', () => {
+    expect(filterChartSeriesDataToVisibleWindow(data, window)).toEqual({
+      runs: [expect.objectContaining({ runId: 'run-in' })],
+      skippedExecutions: [{ scheduledTimeMs: nowMs - HOUR_MS }],
+      unconfirmedExecutions: [],
+      nextExecutionTimeMs: nowMs + HOUR_MS,
+    });
+  });
+
+  it('nulls the next execution time when it falls outside the window', () => {
+    const result = filterChartSeriesDataToVisibleWindow(data, {
+      minMs: nowMs - HOUR_MS,
+      maxMs: nowMs,
+    });
+
+    expect(result.nextExecutionTimeMs).toBeNull();
+  });
+
+  it('returns empty data when there is no visible window yet', () => {
+    expect(filterChartSeriesDataToVisibleWindow(data, null)).toEqual({
+      runs: [],
+      skippedExecutions: [],
+      unconfirmedExecutions: [],
+      nextExecutionTimeMs: null,
+    });
+  });
+});

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/chart-view-state.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/chart-view-state.ts
@@ -1,0 +1,156 @@
+import {
+  CHART_MIN_DOMAIN_SPAN_MS,
+  CHART_NEXT_RUN_ANCHOR_RATIO,
+  CHART_NOW_ANCHOR_RATIO,
+} from '../schedule-details-runs-chart.constants';
+import {
+  type ChartTimeWindow,
+  type PanChartTimeWindowToTimeParams,
+  type ResolveChartFollowTimeWindowParams,
+  type ZoomChartTimeWindowParams,
+} from '../schedule-details-runs-chart.types';
+
+export function getChartTimeWindowSpanMs(window: ChartTimeWindow): number {
+  return window.maxMs - window.minMs;
+}
+
+export function isSameChartTimeWindow(
+  window: ChartTimeWindow,
+  otherWindow: ChartTimeWindow
+): boolean {
+  return (
+    window.minMs === otherWindow.minMs && window.maxMs === otherWindow.maxMs
+  );
+}
+
+function getWindowCenterMs(window: ChartTimeWindow): number {
+  return (window.minMs + window.maxMs) / 2;
+}
+
+function expandWindowToMinSpan(window: ChartTimeWindow): ChartTimeWindow {
+  const spanMs = getChartTimeWindowSpanMs(window);
+
+  if (spanMs >= CHART_MIN_DOMAIN_SPAN_MS) {
+    return window;
+  }
+
+  const centerMs = getWindowCenterMs(window);
+
+  return {
+    minMs: centerMs - CHART_MIN_DOMAIN_SPAN_MS / 2,
+    maxMs: centerMs + CHART_MIN_DOMAIN_SPAN_MS / 2,
+  };
+}
+
+export function clampChartVisibleTimeWindow(
+  visibleWindow: ChartTimeWindow,
+  bounds: ChartTimeWindow
+): ChartTimeWindow {
+  const visibleSpanMs = getChartTimeWindowSpanMs(visibleWindow);
+  const boundsSpanMs = getChartTimeWindowSpanMs(bounds);
+
+  if (visibleSpanMs >= boundsSpanMs) {
+    return bounds;
+  }
+
+  let minMs = Math.max(visibleWindow.minMs, bounds.minMs);
+  let maxMs = minMs + visibleSpanMs;
+
+  if (maxMs > bounds.maxMs) {
+    maxMs = bounds.maxMs;
+    minMs = maxMs - visibleSpanMs;
+  }
+
+  return expandWindowToMinSpan({ minMs, maxMs });
+}
+
+export function zoomChartTimeWindow({
+  visibleWindow,
+  bounds,
+  maxSpanMs,
+  factor,
+  anchorMs,
+}: ZoomChartTimeWindowParams): ChartTimeWindow {
+  const currentSpanMs = getChartTimeWindowSpanMs(visibleWindow);
+  const nextSpanMs = Math.min(currentSpanMs * factor, maxSpanMs);
+  const anchorIsVisible =
+    anchorMs >= visibleWindow.minMs && anchorMs <= visibleWindow.maxMs;
+  const effectiveAnchorMs = anchorIsVisible
+    ? anchorMs
+    : getWindowCenterMs(visibleWindow);
+  const anchorRatio = anchorIsVisible
+    ? (effectiveAnchorMs - visibleWindow.minMs) / currentSpanMs
+    : 0.5;
+
+  const zoomedWindow = expandWindowToMinSpan({
+    minMs: effectiveAnchorMs - nextSpanMs * anchorRatio,
+    maxMs: effectiveAnchorMs + nextSpanMs * (1 - anchorRatio),
+  });
+
+  return clampChartVisibleTimeWindow(zoomedWindow, bounds);
+}
+
+export function panChartTimeWindowToTime({
+  visibleWindow,
+  bounds,
+  timeMs,
+  anchorRatio = CHART_NOW_ANCHOR_RATIO,
+}: PanChartTimeWindowToTimeParams): ChartTimeWindow {
+  const visibleSpanMs = getChartTimeWindowSpanMs(visibleWindow);
+  const clampedAnchorRatio = Math.min(Math.max(anchorRatio, 0), 1);
+  const pannedWindow = {
+    minMs: timeMs - visibleSpanMs * clampedAnchorRatio,
+    maxMs: timeMs + visibleSpanMs * (1 - clampedAnchorRatio),
+  };
+
+  return clampChartVisibleTimeWindow(pannedWindow, bounds);
+}
+
+/**
+ * Window used while live follow is active: `now` sits at its anchor unless
+ * the next run would fall outside the view and still fits within the current
+ * span.
+ */
+export function resolveChartFollowTimeWindow({
+  visibleWindow,
+  bounds,
+  nowMs,
+  nextExecutionMs,
+}: ResolveChartFollowTimeWindowParams): ChartTimeWindow {
+  const spanMs = getChartTimeWindowSpanMs(visibleWindow);
+  const nowAnchoredWindow = panChartTimeWindowToTime({
+    visibleWindow,
+    bounds,
+    timeMs: nowMs,
+  });
+
+  if (
+    nextExecutionMs == null ||
+    !Number.isFinite(nextExecutionMs) ||
+    nextExecutionMs <= nowAnchoredWindow.maxMs
+  ) {
+    return nowAnchoredWindow;
+  }
+
+  const nextRunAnchoredWindow = panChartTimeWindowToTime({
+    visibleWindow,
+    bounds,
+    timeMs: nextExecutionMs,
+    anchorRatio: CHART_NEXT_RUN_ANCHOR_RATIO,
+  });
+
+  return nextRunAnchoredWindow.minMs <= nowMs && spanMs > 0
+    ? nextRunAnchoredWindow
+    : nowAnchoredWindow;
+}
+
+export function canZoomChartIn(visibleWindow: ChartTimeWindow): boolean {
+  return getChartTimeWindowSpanMs(visibleWindow) > CHART_MIN_DOMAIN_SPAN_MS;
+}
+
+export function canZoomChartOut(
+  visibleWindow: ChartTimeWindow,
+  maxSpanMs: number
+): boolean {
+  return getChartTimeWindowSpanMs(visibleWindow) < maxSpanMs;
+}

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/chart-view-state.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/chart-view-state.ts
@@ -42,6 +42,22 @@ function expandWindowToMinSpan(window: ChartTimeWindow): ChartTimeWindow {
   };
 }
 
+function shiftWindowToBounds(
+  window: ChartTimeWindow,
+  bounds: ChartTimeWindow
+): ChartTimeWindow {
+  const spanMs = getChartTimeWindowSpanMs(window);
+  let minMs = Math.max(window.minMs, bounds.minMs);
+  let maxMs = minMs + spanMs;
+
+  if (maxMs > bounds.maxMs) {
+    maxMs = bounds.maxMs;
+    minMs = maxMs - spanMs;
+  }
+
+  return { minMs, maxMs };
+}
+
 export function clampChartVisibleTimeWindow(
   visibleWindow: ChartTimeWindow,
   bounds: ChartTimeWindow
@@ -53,15 +69,15 @@ export function clampChartVisibleTimeWindow(
     return bounds;
   }
 
-  let minMs = Math.max(visibleWindow.minMs, bounds.minMs);
-  let maxMs = minMs + visibleSpanMs;
+  const clampedWindow = shiftWindowToBounds(visibleWindow, bounds);
+  const expandedWindow = expandWindowToMinSpan(clampedWindow);
+  const expandedSpanMs = getChartTimeWindowSpanMs(expandedWindow);
 
-  if (maxMs > bounds.maxMs) {
-    maxMs = bounds.maxMs;
-    minMs = maxMs - visibleSpanMs;
+  if (expandedSpanMs >= boundsSpanMs) {
+    return bounds;
   }
 
-  return expandWindowToMinSpan({ minMs, maxMs });
+  return shiftWindowToBounds(expandedWindow, bounds);
 }
 
 export function zoomChartTimeWindow({

--- a/src/views/schedule-details/schedule-details-runs-chart/helpers/filter-chart-series-data-to-visible-window.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/helpers/filter-chart-series-data-to-visible-window.ts
@@ -1,0 +1,36 @@
+import { type ChartSeriesData } from '../../schedule-details-runs-chart-series/schedule-details-runs-chart-series.types';
+import { type ChartTimeWindow } from '../schedule-details-runs-chart.types';
+
+const EMPTY_DATA: ChartSeriesData = {
+  runs: [],
+  skippedExecutions: [],
+  unconfirmedExecutions: [],
+  nextExecutionTimeMs: null,
+};
+
+export default function filterChartSeriesDataToVisibleWindow(
+  data: ChartSeriesData,
+  visibleWindow: ChartTimeWindow | null
+): ChartSeriesData {
+  if (visibleWindow == null) {
+    return EMPTY_DATA;
+  }
+
+  const isVisible = (scheduledTimeMs: number) =>
+    scheduledTimeMs >= visibleWindow.minMs &&
+    scheduledTimeMs <= visibleWindow.maxMs;
+
+  return {
+    runs: data.runs.filter((run) => isVisible(run.scheduledTimeMs)),
+    skippedExecutions: data.skippedExecutions.filter((point) =>
+      isVisible(point.scheduledTimeMs)
+    ),
+    unconfirmedExecutions: data.unconfirmedExecutions.filter((point) =>
+      isVisible(point.scheduledTimeMs)
+    ),
+    nextExecutionTimeMs:
+      data.nextExecutionTimeMs != null && isVisible(data.nextExecutionTimeMs)
+        ? data.nextExecutionTimeMs
+        : null,
+  };
+}

--- a/src/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.constants.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.constants.ts
@@ -52,3 +52,15 @@ export const CHART_RUN_POPOVER_TEST_IDS = {
   skippedTrigger: 'schedule-runs-chart-skipped-popover-trigger',
   nextTrigger: 'schedule-runs-chart-next-popover-trigger',
 } as const;
+
+/** Multiplier applied when zooming in (smaller span). */
+export const CHART_ZOOM_IN_FACTOR = 0.5;
+
+/** Multiplier applied when zooming out (larger span). */
+export const CHART_ZOOM_OUT_FACTOR = 2;
+
+/** Horizontal position of `now` after panning (0 = left edge, 1 = right edge). */
+export const CHART_NOW_ANCHOR_RATIO = 0.85;
+
+/** Horizontal position of the next run when following pulls it into view. */
+export const CHART_NEXT_RUN_ANCHOR_RATIO = 0.95;

--- a/src/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.tsx
+++ b/src/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 
 import { useParentSize } from '@visx/responsive';
 import { Skeleton } from 'baseui/skeleton';
@@ -8,12 +8,15 @@ import { MdGpsFixed, MdZoomIn, MdZoomOut } from 'react-icons/md';
 import Button from '@/components/button/button';
 import useCurrentTimeMs from '@/hooks/use-current-time-ms/use-current-time-ms';
 import useScheduleRunsChartData from '@/views/schedule-details/hooks/use-schedule-runs-chart-data/use-schedule-runs-chart-data';
+import useScheduleRunsChartViewState from '@/views/schedule-details/hooks/use-schedule-runs-chart-view-state/use-schedule-runs-chart-view-state';
 
 import hasScheduleRunsChartData from '../schedule-details-runs-chart-series/helpers/has-schedule-runs-chart-data';
 import ScheduleDetailsRunsChartSeries from '../schedule-details-runs-chart-series/schedule-details-runs-chart-series';
 import ScheduleDetailsRunsChartTimeline from '../schedule-details-runs-chart-timeline/schedule-details-runs-chart-timeline';
 
+import { getChartTimeWindowSpanMs } from './helpers/chart-view-state';
 import createChartXScale from './helpers/create-chart-x-scale';
+import filterChartSeriesDataToVisibleWindow from './helpers/filter-chart-series-data-to-visible-window';
 import resolveChartPixelRange from './helpers/resolve-chart-pixel-range';
 import resolveChartTimeWindow from './helpers/resolve-chart-time-window';
 import {
@@ -26,7 +29,10 @@ import {
   CURRENT_TIME_UPDATE_INTERVAL_MS,
 } from './schedule-details-runs-chart.constants';
 import { overrides, styled } from './schedule-details-runs-chart.styles';
-import { type Props } from './schedule-details-runs-chart.types';
+import {
+  type ChartTimeWindow,
+  type Props,
+} from './schedule-details-runs-chart.types';
 
 export default function ScheduleDetailsRunsChart({ params }: Props) {
   const nowMs = useCurrentTimeMs({
@@ -36,7 +42,11 @@ export default function ScheduleDetailsRunsChart({ params }: Props) {
     initialSize: { width: 0, height: CHART_HEIGHT_PX },
   });
 
-  const { data: chartData, isLoading } = useScheduleRunsChartData({
+  const {
+    data: chartData,
+    isLoading,
+    timelineStartMs,
+  } = useScheduleRunsChartData({
     domain: params.domain,
     cluster: params.cluster,
     scheduleId: params.scheduleId,
@@ -44,8 +54,8 @@ export default function ScheduleDetailsRunsChart({ params }: Props) {
   });
   const hasChartData = hasScheduleRunsChartData(chartData);
 
-  const xScale = useMemo(() => {
-    const timestampsMs = [
+  const timestampsMs = useMemo(
+    () => [
       ...chartData.runs.map(({ scheduledTimeMs }) => scheduledTimeMs),
       ...chartData.skippedExecutions.map(
         ({ scheduledTimeMs }) => scheduledTimeMs
@@ -53,20 +63,91 @@ export default function ScheduleDetailsRunsChart({ params }: Props) {
       ...chartData.unconfirmedExecutions.map(
         ({ scheduledTimeMs }) => scheduledTimeMs
       ),
-    ];
-    const timeWindow = resolveChartTimeWindow({
-      timestampsMs,
-      nowMs,
-      nextExecutionMs: chartData.nextExecutionTimeMs,
-    });
+    ],
+    [chartData]
+  );
+
+  // The chart's current auto-fit window doubles as both the loaded-data
+  // bounds and the initial zoom level. Sizing the initial zoom from the
+  // schedule's cron cadence instead is a follow-up.
+  const loadedTimeWindow = useMemo(
+    () =>
+      resolveChartTimeWindow({
+        timestampsMs,
+        nowMs,
+        nextExecutionMs: chartData.nextExecutionTimeMs,
+        minimumTimeMs: timelineStartMs,
+      }),
+    [chartData.nextExecutionTimeMs, nowMs, timelineStartMs, timestampsMs]
+  );
+
+  const navigationBounds = useMemo<ChartTimeWindow | null>(
+    () =>
+      loadedTimeWindow
+        ? {
+            minMs: Math.min(
+              timelineStartMs ?? loadedTimeWindow.minMs,
+              loadedTimeWindow.minMs
+            ),
+            maxMs: loadedTimeWindow.maxMs,
+          }
+        : null,
+    [loadedTimeWindow, timelineStartMs]
+  );
+
+  const {
+    visibleWindow,
+    canZoomIn,
+    canZoomOut,
+    initializeWindow,
+    zoomIn,
+    zoomOut,
+  } = useScheduleRunsChartViewState({
+    bounds: navigationBounds,
+    nowMs,
+    nextExecutionMs: chartData.nextExecutionTimeMs,
+  });
+
+  useEffect(() => {
+    if (
+      visibleWindow != null ||
+      isLoading ||
+      loadedTimeWindow == null ||
+      navigationBounds == null
+    ) {
+      return;
+    }
+
+    // Zooming out is capped at the full navigable range, since there is no
+    // cron-cadence-aware sizing yet to pick a tighter max span.
+    initializeWindow(
+      loadedTimeWindow,
+      getChartTimeWindowSpanMs(navigationBounds)
+    );
+  }, [
+    initializeWindow,
+    isLoading,
+    loadedTimeWindow,
+    navigationBounds,
+    visibleWindow,
+  ]);
+
+  const toolbarEnabled = hasChartData && visibleWindow != null && !isLoading;
+
+  const xScale = useMemo(() => {
     const range = resolveChartPixelRange({ widthPx: width });
 
-    if (timeWindow === null || range === null) {
+    if (range === null || visibleWindow === null) {
       return null;
     }
 
-    return createChartXScale({ timeWindow, range });
-  }, [chartData, nowMs, width]);
+    return createChartXScale({ timeWindow: visibleWindow, range });
+  }, [visibleWindow, width]);
+
+  const visibleData = useMemo(
+    () => filterChartSeriesDataToVisibleWindow(chartData, visibleWindow),
+    [chartData, visibleWindow]
+  );
 
   const showLoadingOverlay = isLoading;
   const showEmptyState = !isLoading && (xScale === null || !hasChartData);
@@ -79,8 +160,10 @@ export default function ScheduleDetailsRunsChart({ params }: Props) {
           <Button
             size="mini"
             kind="tertiary"
-            disabled
+            disabled={!toolbarEnabled || !canZoomOut}
+            aria-disabled={!toolbarEnabled || !canZoomOut}
             overrides={overrides.toolbarButton}
+            onClick={zoomOut}
           >
             <styled.ControlContent>
               <MdZoomOut size={CHART_TOOLBAR_ICON_SIZE_PX} />
@@ -90,8 +173,10 @@ export default function ScheduleDetailsRunsChart({ params }: Props) {
           <Button
             size="mini"
             kind="tertiary"
-            disabled
+            disabled={!toolbarEnabled || !canZoomIn}
+            aria-disabled={!toolbarEnabled || !canZoomIn}
             overrides={overrides.toolbarButton}
+            onClick={zoomIn}
           >
             <styled.ControlContent>
               <MdZoomIn size={CHART_TOOLBAR_ICON_SIZE_PX} />
@@ -142,7 +227,7 @@ export default function ScheduleDetailsRunsChart({ params }: Props) {
             </styled.ChartSvg>
             <ScheduleDetailsRunsChartSeries
               xScale={xScale}
-              data={chartData}
+              data={visibleData}
               domain={params.domain}
               cluster={params.cluster}
             />

--- a/src/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.types.ts
+++ b/src/views/schedule-details/schedule-details-runs-chart/schedule-details-runs-chart.types.ts
@@ -35,3 +35,25 @@ export type CreateChartXScaleParams = {
   timeWindow: ChartTimeWindow;
   range: ChartPixelRange;
 };
+
+export type ZoomChartTimeWindowParams = {
+  visibleWindow: ChartTimeWindow;
+  bounds: ChartTimeWindow;
+  maxSpanMs: number;
+  factor: number;
+  anchorMs: number;
+};
+
+export type PanChartTimeWindowToTimeParams = {
+  visibleWindow: ChartTimeWindow;
+  bounds: ChartTimeWindow;
+  timeMs: number;
+  anchorRatio?: number;
+};
+
+export type ResolveChartFollowTimeWindowParams = {
+  visibleWindow: ChartTimeWindow;
+  bounds: ChartTimeWindow;
+  nowMs: number;
+  nextExecutionMs?: number | null;
+};


### PR DESCRIPTION
## Summary
- Enable zoom in/out toolbar controls on the schedule runs chart.
- Add `useScheduleRunsChartViewState` to own the visible window: it always live-follows `now` (and pulls the next scheduled run into view when it's closer to the edge than the anchor), and zoom always anchors on `now`.
- The initial window and max zoom-out span reuse the chart's existing auto-fit window helper rather than a cron-cadence-aware calculation — that's a smaller, independent follow-up.

## Changes
- `use-schedule-runs-chart-view-state`: new hook for zoom/follow state, replacing the disabled zoom toolbar buttons from PR09a.
- `chart-view-state` / `filter-chart-series-data-to-visible-window`: new helpers for zoom math and filtering series data to the visible window.
- `schedule-details-runs-chart`: wires the zoom in/out toolbar buttons. "Now" and pan stay disabled/absent, unchanged from today, since there's no way yet to leave live-follow mode.
- `use-schedule-runs-chart-data`: exposes `timelineStartMs`, used to bound how far the chart can navigate.

Panning, "Now", cron-aware initial zoom sizing, pagination-on-pan, and the new-marker animation all ship in #1478, stacked on this branch.

## Test plan

https://github.com/user-attachments/assets/0094cc51-0ba1-4a2c-b50c-28cfc3a78b03



## Stack
Depends on PR09f (`feat/schedule-details-pr09f-hover-popover`). Followed by #1478 (pan/now, cron-aware sizing, pagination-on-pan, new-marker pulse), stacked on top of this branch.

