### PR TITLE
feat(cron-validate): Restore CRON_TZ-aware parseCronExpression helper

### DIFF
--- a/src/utils/cron-validate/__tests__/parse-cron-expression.test.ts
+++ b/src/utils/cron-validate/__tests__/parse-cron-expression.test.ts
@@ -15,6 +15,13 @@ describe(parseCronExpression.name, () => {
     });
   });
 
+  it('falls back to UTC when CRON_TZ names an unrecognized timezone', () => {
+    expect(parseCronExpression('CRON_TZ=Not/AZone 0 5 * * 0')).toEqual({
+      expression: '0 5 * * 0',
+      timezone: 'UTC',
+    });
+  });
+
   it('returns null for unsupported expressions', () => {
     expect(parseCronExpression('@every 1m')).toBeNull();
   });

--- a/src/utils/cron-validate/__tests__/parse-cron-expression.test.ts
+++ b/src/utils/cron-validate/__tests__/parse-cron-expression.test.ts
@@ -1,0 +1,21 @@
+import parseCronExpression from '../parse-cron-expression';
+
+describe(parseCronExpression.name, () => {
+  it('returns the expression and UTC when no CRON_TZ prefix is present', () => {
+    expect(parseCronExpression('0 12 * * *')).toEqual({
+      expression: '0 12 * * *',
+      timezone: 'UTC',
+    });
+  });
+
+  it('strips a CRON_TZ prefix and returns the timezone', () => {
+    expect(parseCronExpression('CRON_TZ=America/New_York 30 1 * * *')).toEqual({
+      expression: '30 1 * * *',
+      timezone: 'America/New_York',
+    });
+  });
+
+  it('returns null for unsupported expressions', () => {
+    expect(parseCronExpression('@every 1m')).toBeNull();
+  });
+});

--- a/src/utils/cron-validate/cron-validate.types.ts
+++ b/src/utils/cron-validate/cron-validate.types.ts
@@ -1,1 +1,6 @@
 export { type CronData } from 'cron-validate';
+
+export type ParsedCronExpression = {
+  expression: string;
+  timezone: string;
+};

--- a/src/utils/cron-validate/parse-cron-expression.ts
+++ b/src/utils/cron-validate/parse-cron-expression.ts
@@ -1,6 +1,15 @@
 import { cronValidate } from './cron-validate';
 import { type ParsedCronExpression } from './cron-validate.types';
 
+function isValidTimezone(timezone: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: timezone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export default function parseCronExpression(
   cronExpression: string
 ): ParsedCronExpression | null {
@@ -13,8 +22,12 @@ export default function parseCronExpression(
     return null;
   }
 
+  const timezonePrefix = timezoneMatch?.[1];
+  const timezone =
+    timezonePrefix && isValidTimezone(timezonePrefix) ? timezonePrefix : 'UTC';
+
   return {
     expression,
-    timezone: timezoneMatch?.[1] ?? 'UTC',
+    timezone,
   };
 }

--- a/src/utils/cron-validate/parse-cron-expression.ts
+++ b/src/utils/cron-validate/parse-cron-expression.ts
@@ -1,0 +1,20 @@
+import { cronValidate } from './cron-validate';
+import { type ParsedCronExpression } from './cron-validate.types';
+
+export default function parseCronExpression(
+  cronExpression: string
+): ParsedCronExpression | null {
+  const timezoneMatch = cronExpression
+    .trim()
+    .match(/^CRON_TZ=([^\s]+)\s+(.+)$/);
+  const expression = (timezoneMatch?.[2] ?? cronExpression).trim();
+
+  if (!cronValidate(expression).isValid()) {
+    return null;
+  }
+
+  return {
+    expression,
+    timezone: timezoneMatch?.[1] ?? 'UTC',
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `parseCronExpression` to parse Cadence schedule cron strings that may include an optional `CRON_TZ=<zone> ` prefix.
- Returns `{ expression, timezone }` with the prefix stripped from the expression; defaults `timezone` to `UTC` when no prefix is present.
- Validates the captured timezone via `Intl.DateTimeFormat`; falls back to `UTC` when unrecognized (e.g. `CRON_TZ=Not/AZone`).
- Returns `null` for invalid or unsupported expressions (e.g. `@every 1m`).

This is the foundational helper for #1486, which wires timezone labels into the schedules list, schedule details, and runs chart occurrence math.

## Changes

- `src/utils/cron-validate/parse-cron-expression.ts` — new helper.
- `src/utils/cron-validate/cron-validate.types.ts` — `ParsedCronExpression` type.
- `src/utils/cron-validate/__tests__/parse-cron-expression.test.ts` — unit tests.

## Testing

```bash
npm run lint
npm run typecheck
npm run test
```

- [x] `npx jest src/utils/cron-validate/__tests__/parse-cron-expression.test.ts` — 4/4 pass (includes unrecognized-timezone fallback)

**UI verification:** N/A — pure helper; UI screenshots are in #1486.