### PR TITLE
feat(schedules): Show cron timezone labels and honor CRON_TZ in chart math

### DIFF
--- a/src/views/domain-schedules/domain-schedules-cron-expression-cell/__tests__/domain-schedules-cron-expression-cell.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-cron-expression-cell/__tests__/domain-schedules-cron-expression-cell.test.tsx
@@ -6,7 +6,15 @@ describe(DomainSchedulesCronExpressionCell.name, () => {
   it('renders the human-readable description and the expression for a valid cron expression', () => {
     setup({ cronExpression: '0 * * * *' });
 
-    expect(screen.getByText('Every hour (0 * * * *)')).toBeInTheDocument();
+    expect(screen.getByText('Every hour (0 * * * *), UTC')).toBeInTheDocument();
+  });
+
+  it('renders the timezone when a CRON_TZ prefix is present', () => {
+    setup({ cronExpression: 'CRON_TZ=America/New_York 30 1 * * *' });
+
+    expect(
+      screen.getByText('At 01:30 AM (30 1 * * *), America/New_York')
+    ).toBeInTheDocument();
   });
 
   it('renders only the raw expression when the cron expression is invalid', () => {

--- a/src/views/domain-schedules/domain-schedules-cron-expression-cell/domain-schedules-cron-expression-cell.tsx
+++ b/src/views/domain-schedules/domain-schedules-cron-expression-cell/domain-schedules-cron-expression-cell.tsx
@@ -1,4 +1,4 @@
-import { toString as cronToString } from 'cronstrue';
+import { formatScheduleCronExpression } from '@/views/schedule-details/helpers/format-schedule-cron-expression';
 
 type Props = {
   cronExpression: string;
@@ -7,9 +7,5 @@ type Props = {
 export default function DomainSchedulesCronExpressionCell({
   cronExpression,
 }: Props) {
-  try {
-    return `${cronToString(cronExpression)} (${cronExpression})`;
-  } catch {
-    return cronExpression;
-  }
+  return formatScheduleCronExpression(cronExpression) ?? cronExpression;
 }

--- a/src/views/schedule-details/helpers/__tests__/format-schedule-cron-expression.test.ts
+++ b/src/views/schedule-details/helpers/__tests__/format-schedule-cron-expression.test.ts
@@ -1,0 +1,31 @@
+import { formatScheduleCronExpression } from '../format-schedule-cron-expression';
+
+describe(formatScheduleCronExpression.name, () => {
+  it('returns null for empty input', () => {
+    expect(formatScheduleCronExpression(null)).toBeNull();
+    expect(formatScheduleCronExpression(undefined)).toBeNull();
+    expect(formatScheduleCronExpression('')).toBeNull();
+  });
+
+  it('appends UTC for expressions without a CRON_TZ prefix', () => {
+    expect(formatScheduleCronExpression('0 5 * * 0')).toBe(
+      'At 05:00 AM, only on Sunday (0 5 * * 0), UTC'
+    );
+  });
+
+  it('appends the parsed timezone for CRON_TZ-prefixed expressions', () => {
+    expect(
+      formatScheduleCronExpression('CRON_TZ=America/New_York 0 5 * * 0')
+    ).toBe('At 05:00 AM, only on Sunday (0 5 * * 0), America/New_York');
+  });
+
+  it('returns the raw expression when parsing fails', () => {
+    expect(formatScheduleCronExpression('invalid-cron')).toBe('invalid-cron');
+  });
+
+  it('falls back to UTC when CRON_TZ names an unrecognized timezone', () => {
+    expect(formatScheduleCronExpression('CRON_TZ=Not/AZone 0 5 * * 0')).toBe(
+      'At 05:00 AM, only on Sunday (0 5 * * 0), UTC'
+    );
+  });
+});

--- a/src/views/schedule-details/helpers/format-schedule-cron-expression.ts
+++ b/src/views/schedule-details/helpers/format-schedule-cron-expression.ts
@@ -1,5 +1,7 @@
 import { toString as cronToString } from 'cronstrue';
 
+import parseCronExpression from '@/utils/cron-validate/parse-cron-expression';
+
 export function formatScheduleCronExpression(
   cronExpression: string | null | undefined
 ) {
@@ -7,8 +9,14 @@ export function formatScheduleCronExpression(
     return null;
   }
 
+  const parsed = parseCronExpression(cronExpression);
+
+  if (!parsed) {
+    return cronExpression;
+  }
+
   try {
-    return `${cronToString(cronExpression)} (${cronExpression})`;
+    return `${cronToString(parsed.expression)} (${parsed.expression}), ${parsed.timezone}`;
   } catch {
     return cronExpression;
   }

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-expected-schedule-times-ms.test.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-expected-schedule-times-ms.test.ts
@@ -18,6 +18,30 @@ describe(getExpectedScheduleTimesMs.name, () => {
     ]);
   });
 
+  it('honors CRON_TZ and daylight-saving transitions', () => {
+    expect(
+      getExpectedScheduleTimesMs({
+        cronExpression: 'CRON_TZ=America/New_York 30 1 * * *',
+        startMs: Date.parse('2026-10-31T00:00:00Z'),
+        endMs: Date.parse('2026-11-02T23:59:59Z'),
+      })
+    ).toEqual([
+      Date.parse('2026-10-31T05:30:00Z'),
+      Date.parse('2026-11-01T05:30:00Z'),
+      Date.parse('2026-11-02T06:30:00Z'),
+    ]);
+  });
+
+  it('falls back to UTC when CRON_TZ names an unrecognized timezone', () => {
+    expect(
+      getExpectedScheduleTimesMs({
+        cronExpression: 'CRON_TZ=Not/AZone 0 5 * * 0',
+        startMs: Date.parse('2026-08-10T00:00:00Z'),
+        endMs: Date.parse('2026-08-17T00:00:00Z'),
+      })
+    ).toEqual([Date.parse('2026-08-16T05:00:00Z')]);
+  });
+
   it('rejects unsupported expressions and caps occurrence generation', () => {
     expect(
       getExpectedScheduleTimesMs({

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/get-expected-schedule-times-ms.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/get-expected-schedule-times-ms.ts
@@ -1,6 +1,6 @@
 import { CronExpressionParser } from 'cron-parser';
 
-import { cronValidate } from '@/utils/cron-validate/cron-validate';
+import parseCronExpression from '@/utils/cron-validate/parse-cron-expression';
 
 import { MAX_SCHEDULE_CRON_OCCURRENCES } from '../use-schedule-runs-chart-data.constants';
 import { type GetExpectedScheduleTimesMsParams } from '../use-schedule-runs-chart-data.types';
@@ -11,8 +11,10 @@ export default function getExpectedScheduleTimesMs({
   endMs,
   limit = MAX_SCHEDULE_CRON_OCCURRENCES,
 }: GetExpectedScheduleTimesMsParams): number[] {
+  const cron = parseCronExpression(cronExpression);
+
   if (
-    !cronValidate(cronExpression).isValid() ||
+    !cron ||
     !Number.isFinite(startMs) ||
     !Number.isFinite(endMs) ||
     endMs < startMs
@@ -21,11 +23,12 @@ export default function getExpectedScheduleTimesMs({
   }
 
   try {
-    // Cadence schedule cron expressions are always evaluated in UTC.
-    const forwardInterval = CronExpressionParser.parse(cronExpression, {
+    // Forward iteration is authoritative: walking backward across a DST
+    // fall-back emits the repeated wall-clock time twice.
+    const forwardInterval = CronExpressionParser.parse(cron.expression, {
       currentDate: startMs - 1,
       endDate: endMs,
-      tz: 'UTC',
+      tz: cron.timezone,
     });
     const occurrences: number[] = [];
 
@@ -41,10 +44,10 @@ export default function getExpectedScheduleTimesMs({
       return occurrences;
     }
 
-    const backwardInterval = CronExpressionParser.parse(cronExpression, {
+    const backwardInterval = CronExpressionParser.parse(cron.expression, {
       currentDate: endMs + 1,
       startDate: startMs,
-      tz: 'UTC',
+      tz: cron.timezone,
     });
     const latestOccurrences: number[] = [];
 


### PR DESCRIPTION
## Summary

- Formats cron expressions in the schedules list and schedule details with a timezone suffix (e.g. `, UTC` or `, Europe/Copenhagen`) by parsing optional `CRON_TZ=<zone> ` prefixes via `parseCronExpression`.
- Computes expected run times in the parsed timezone so the runs chart reflects daylight-saving transitions for `CRON_TZ`-prefixed schedules.


## Changes

- `format-schedule-cron-expression.ts` — append timezone to human-readable cron label.
- `domain-schedules-cron-expression-cell.tsx` — reuse shared formatter.
- `get-expected-schedule-times-ms.ts` — use parsed expression + timezone instead of hardcoded UTC.
- Unit tests for all three areas (including unrecognized-timezone fallback and DST case).

## Testing
- [x] `format-schedule-cron-expression.test.ts` — 5/5 pass
- [x] `domain-schedules-cron-expression-cell.test.tsx` — 3/3 pass
- [x] `get-expected-schedule-times-ms.test.ts` — 4/4 pass (includes DST + invalid-TZ fallback via helper)

## Manual verification

Verified locally against the docker backend and created timezone cron expressions using CLI.

### `America/New_York` — schedule `cron-tz-ui-verification`

`CRON_TZ=America/New_York 0 9 * * *` — details "Cron execution" row shows timezone suffix; next run aligns with 9:00 AM Eastern.

**Schedules list** — cron cell shows `America/New_York` timezone suffix.

![Schedules list — America/New_York timezone suffix](https://github.com/cadence-workflow/cadence-web/blob/f365c91f2e9c9cd41c64ad3e23a909e124c5dd24/cron-timezone-schedules-list.png?raw=true)

**Schedule details** — "Cron execution" row shows `America/New_York` timezone suffix.

![America/New_York schedule details](https://github.com/cadence-workflow/cadence-web/blob/a481671ed55936a0db4a7e3b59960454665a46c9/cron-tz-america-new-york-specs.png?raw=true)

### `Europe/Copenhagen` — schedule `cron-tz-copenhagen-test`

`CRON_TZ=Europe/Copenhagen 0 9 * * *` — details show `, Europe/Copenhagen`; next run at 09:00 local (07:00 UTC in August / CEST).

![Europe/Copenhagen schedule details](https://github.com/cadence-workflow/cadence-web/blob/1688941448afcf7cc6fa00441d220baafc5f4d7e/cron-tz-copenhagen-specs.png?raw=true)