### PR TITLE
feat(schedule-actions): prefill edit form from an existing schedule

### DIFF
--- a/src/route-handlers/start-workflow/helpers/__tests__/process-workflow-input.node.ts
+++ b/src/route-handlers/start-workflow/helpers/__tests__/process-workflow-input.node.ts
@@ -55,17 +55,6 @@ describe('processWorkflowInput', () => {
     ).toBe('"arg1" 42 true null');
   });
 
-  it('should join arguments with spaces when workerSDKLanguage is undefined', () => {
-    const input = ['arg1', 42, true, null];
-    expect(
-      processWorkflowInput({
-        input,
-        // @ts-expect-error Testing with wrong attribute `undefined`
-        workerSDKLanguage: undefined,
-      })
-    ).toBe('"arg1" 42 true null');
-  });
-
   it('should return JSON array for JAVA language when multiple arguments', () => {
     const input = ['arg1', 42, true];
     expect(

--- a/src/route-handlers/start-workflow/helpers/__tests__/process-workflow-input.node.ts
+++ b/src/route-handlers/start-workflow/helpers/__tests__/process-workflow-input.node.ts
@@ -55,6 +55,17 @@ describe('processWorkflowInput', () => {
     ).toBe('"arg1" 42 true null');
   });
 
+  it('should join arguments with spaces when workerSDKLanguage is undefined', () => {
+    const input = ['arg1', 42, true, null];
+    expect(
+      processWorkflowInput({
+        input,
+        // @ts-expect-error Testing with wrong attribute `undefined`
+        workerSDKLanguage: undefined,
+      })
+    ).toBe('"arg1" 42 true null');
+  });
+
   it('should return JSON array for JAVA language when multiple arguments', () => {
     const input = ['arg1', 42, true];
     expect(

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -10,6 +10,8 @@ import {
   waitFor,
 } from '@/test-utils/rtl';
 
+import { WORKER_SDK_LANGUAGES } from '@/route-handlers/start-workflow/start-workflow.constants';
+
 import { type DomainSchedulesCreateFormData } from '../../domain-schedules-create-modal/domain-schedules-create-modal.types';
 import DomainSchedulesCreateForm from '../domain-schedules-create-form';
 
@@ -171,6 +173,14 @@ describe('DomainSchedulesCreateForm', () => {
 
     expect(screen.getByLabelText('Schedule ID')).toBeDisabled();
   });
+
+  it('leaves Worker SDK unset when prefillWorkerSDKLanguage is false', async () => {
+    await setup({ prefillWorkerSDKLanguage: false });
+
+    for (const language of WORKER_SDK_LANGUAGES) {
+      expect(screen.getByRole('radio', { name: language })).not.toBeChecked();
+    }
+  });
 });
 
 type SetupProps = {
@@ -179,16 +189,19 @@ type SetupProps = {
   injectFieldErrors?: boolean;
   taskListValidation?: ReturnType<typeof mockUseTaskListFieldValidation>;
   scheduleIdReadOnly?: boolean;
+  prefillWorkerSDKLanguage?: boolean;
 };
 
 function TestWrapper({
   defaultValues,
   injectFieldErrors,
   scheduleIdReadOnly,
+  prefillWorkerSDKLanguage,
 }: {
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
   injectFieldErrors?: boolean;
   scheduleIdReadOnly?: boolean;
+  prefillWorkerSDKLanguage?: boolean;
 }) {
   const { control, trigger, setError, clearErrors } =
     useForm<DomainSchedulesCreateFormData>({
@@ -211,6 +224,7 @@ function TestWrapper({
       domain={MOCK_DOMAIN}
       cluster={MOCK_CLUSTER}
       scheduleIdReadOnly={scheduleIdReadOnly}
+      prefillWorkerSDKLanguage={prefillWorkerSDKLanguage}
     />
   );
 }
@@ -219,6 +233,7 @@ async function setup({
   defaultValues,
   injectFieldErrors = false,
   scheduleIdReadOnly,
+  prefillWorkerSDKLanguage,
   taskListValidation = {
     isTaskListLoading: false,
     taskListCaptionMessage: null,
@@ -233,6 +248,7 @@ async function setup({
       defaultValues={defaultValues}
       injectFieldErrors={injectFieldErrors}
       scheduleIdReadOnly={scheduleIdReadOnly}
+      prefillWorkerSDKLanguage={prefillWorkerSDKLanguage}
     />
   );
 

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -40,6 +40,7 @@ export default function DomainSchedulesCreateForm({
   domain,
   cluster,
   scheduleIdReadOnly,
+  prefillWorkerSDKLanguage = true,
 }: Props) {
   const { errors: fieldErrors, isSubmitted } = useFormState({ control });
 
@@ -164,7 +165,9 @@ export default function DomainSchedulesCreateForm({
         <Controller
           name="workerSDKLanguage"
           control={control}
-          defaultValue={WORKER_SDK_LANGUAGES[0]}
+          defaultValue={
+            prefillWorkerSDKLanguage ? WORKER_SDK_LANGUAGES[0] : undefined
+          }
           render={({ field: { value, onChange, ref, ...field } }) => (
             <RadioGroup
               {...field}

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -14,4 +14,6 @@ export type Props = {
   cluster: string;
   /** Renders the Schedule ID field disabled, for flows where the id is fixed. */
   scheduleIdReadOnly?: boolean;
+  /** Create pre-selects GO; edit leaves Worker SDK unset until the user picks one. */
+  prefillWorkerSDKLanguage?: boolean;
 };

--- a/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/__fixtures__/mock-editable-describe-schedule-response.ts
@@ -1,0 +1,46 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+
+/** A fully-populated schedule, used to check that every form field prefills. */
+export function getMockEditableDescribeScheduleResponse(
+  overrides: Partial<DescribeScheduleResponse> = {}
+): DescribeScheduleResponse {
+  return getMockDescribeScheduleResponse({
+    spec: {
+      cronExpression: '30 9 1 * *',
+      startTime: { seconds: '1767225600', nanos: 0 },
+      endTime: { seconds: '1767312000', nanos: 0 },
+      jitter: { seconds: '90', nanos: 0 },
+    },
+    action: {
+      startWorkflow: {
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: {
+          name: 'demo-task-list',
+          kind: 'TASK_LIST_KIND_NORMAL',
+          baseName: 'demo-task-list',
+        },
+        input: {
+          data: Buffer.from('{"a":1} {"b":2}', 'utf-8').toString('base64'),
+        },
+        workflowIdPrefix: 'scheduled-demo-',
+        executionStartToCloseTimeout: { seconds: '3600', nanos: 0 },
+        taskStartToCloseTimeout: { seconds: '30', nanos: 0 },
+        retryPolicy: null,
+        memo: null,
+        searchAttributes: null,
+      },
+    },
+    policies: {
+      overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+      catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL,
+      catchUpWindow: { seconds: '172800', nanos: 0 },
+      pauseOnFailure: true,
+      bufferLimit: 5,
+      concurrencyLimit: 0,
+    },
+    ...overrides,
+  });
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -39,6 +39,21 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
     ).toEqual(EMPTY_CRON_EXPRESSION_FIELDS);
   });
 
+  it('leaves the cron fields empty for a non-UTC timezone', () => {
+    expect(
+      transform(
+        getMockEditableDescribeScheduleResponse({
+          spec: {
+            cronExpression: 'CRON_TZ=America/New_York 30 9 1 * *',
+            startTime: null,
+            endTime: null,
+            jitter: null,
+          },
+        })
+      ).cronExpression
+    ).toEqual(EMPTY_CRON_EXPRESSION_FIELDS);
+  });
+
   it('prefills the start workflow action fields', () => {
     const formData = transform();
 
@@ -62,7 +77,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
       expect.objectContaining({
         overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
         catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL,
-        catchUpWindowDays: '2',
+        catchUpWindowSeconds: '172800',
         bufferLimit: '5',
         concurrencyLimit: '0',
         pauseOnFailure: true,
@@ -80,7 +95,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
     );
   });
 
-  it('rounds a partial catch-up window day up, so the window is never narrowed', () => {
+  it('prefills catch-up window as seconds', () => {
     expect(
       transform(
         getMockEditableDescribeScheduleResponse({
@@ -94,8 +109,8 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
             concurrencyLimit: 0,
           },
         })
-      ).catchUpWindowDays
-    ).toEqual('2');
+      ).catchUpWindowSeconds
+    ).toEqual('90000');
   });
 
   it('falls back to blank values for an empty schedule', () => {
@@ -115,7 +130,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
       bufferLimit: undefined,
       concurrencyLimit: undefined,
       catchUpPolicy: undefined,
-      catchUpWindowDays: undefined,
+      catchUpWindowSeconds: undefined,
       jitterSeconds: undefined,
       startTime: undefined,
       endTime: undefined,

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -47,7 +47,6 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
         workflowType: { name: 'DemoWorkflow' },
         taskList: { name: 'demo-task-list' },
         executionStartToCloseTimeoutSeconds: 3600,
-        taskStartToCloseTimeoutSeconds: 30,
         workflowIdPrefix: 'scheduled-demo-',
         workerSDKLanguage: 'GO',
       })
@@ -108,7 +107,6 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
       workflowType: { name: '' },
       taskList: { name: '' },
       executionStartToCloseTimeoutSeconds: 0,
-      taskStartToCloseTimeoutSeconds: 0,
       workerSDKLanguage: 'GO',
       input: [''],
       workflowIdPrefix: undefined,

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -121,7 +121,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
       cronExpression: EMPTY_CRON_EXPRESSION_FIELDS,
       workflowType: { name: '' },
       taskList: { name: '' },
-      executionStartToCloseTimeoutSeconds: 0,
+      executionStartToCloseTimeoutSeconds: undefined,
       workerSDKLanguage: undefined,
       input: [''],
       workflowIdPrefix: undefined,

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -1,0 +1,140 @@
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
+import { getMockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+
+import { getMockEditableDescribeScheduleResponse } from '../../__fixtures__/mock-editable-describe-schedule-response';
+import { EMPTY_CRON_EXPRESSION_FIELDS } from '../../schedule-action-edit-form.constants';
+import transformDescribeScheduleResponseToFormData from '../transform-describe-schedule-response-to-form-data';
+
+const MOCK_SCHEDULE_ID = 'mock-schedule-id';
+
+describe(transformDescribeScheduleResponseToFormData.name, () => {
+  it('prefills the schedule id from the route rather than the response', () => {
+    expect(transform().scheduleId).toEqual(MOCK_SCHEDULE_ID);
+  });
+
+  it('splits the cron expression into its five fields', () => {
+    expect(transform().cronExpression).toEqual({
+      minutes: '30',
+      hours: '9',
+      daysOfMonth: '1',
+      months: '*',
+      daysOfWeek: '*',
+    });
+  });
+
+  it('leaves the cron fields empty for an expression it cannot split', () => {
+    expect(
+      transform(
+        getMockEditableDescribeScheduleResponse({
+          spec: {
+            cronExpression: '@every 1h',
+            startTime: null,
+            endTime: null,
+            jitter: null,
+          },
+        })
+      ).cronExpression
+    ).toEqual(EMPTY_CRON_EXPRESSION_FIELDS);
+  });
+
+  it('prefills the start workflow action fields', () => {
+    const formData = transform();
+
+    expect(formData).toEqual(
+      expect.objectContaining({
+        workflowType: { name: 'DemoWorkflow' },
+        taskList: { name: 'demo-task-list' },
+        executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: 30,
+        workflowIdPrefix: 'scheduled-demo-',
+        workerSDKLanguage: 'GO',
+      })
+    );
+  });
+
+  it('splits a multi-argument workflow input back into separate entries', () => {
+    expect(transform().input).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it('prefills the policy fields', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        overlapPolicy: ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER,
+        catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL,
+        catchUpWindowDays: '2',
+        bufferLimit: '5',
+        concurrencyLimit: '0',
+        pauseOnFailure: true,
+      })
+    );
+  });
+
+  it('prefills the schedule period and jitter', () => {
+    expect(transform()).toEqual(
+      expect.objectContaining({
+        startTime: '2026-01-01T00:00:00.000Z',
+        endTime: '2026-01-02T00:00:00.000Z',
+        jitterSeconds: '90',
+      })
+    );
+  });
+
+  it('rounds a partial catch-up window day up, so the window is never narrowed', () => {
+    expect(
+      transform(
+        getMockEditableDescribeScheduleResponse({
+          policies: {
+            overlapPolicy:
+              ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT,
+            catchUpPolicy: ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE,
+            catchUpWindow: { seconds: '90000', nanos: 0 },
+            pauseOnFailure: false,
+            bufferLimit: 0,
+            concurrencyLimit: 0,
+          },
+        })
+      ).catchUpWindowDays
+    ).toEqual('2');
+  });
+
+  it('falls back to blank values for an empty schedule', () => {
+    const formData = transform(getMockDescribeScheduleResponse());
+
+    expect(formData).toEqual({
+      scheduleId: MOCK_SCHEDULE_ID,
+      cronExpression: EMPTY_CRON_EXPRESSION_FIELDS,
+      workflowType: { name: '' },
+      taskList: { name: '' },
+      executionStartToCloseTimeoutSeconds: 0,
+      taskStartToCloseTimeoutSeconds: 0,
+      workerSDKLanguage: 'GO',
+      input: [''],
+      workflowIdPrefix: undefined,
+      pauseOnFailure: false,
+      overlapPolicy: undefined,
+      bufferLimit: undefined,
+      concurrencyLimit: undefined,
+      catchUpPolicy: undefined,
+      catchUpWindowDays: undefined,
+      jitterSeconds: undefined,
+      startTime: undefined,
+      endTime: undefined,
+      enableRetryPolicy: false,
+      limitRetries: undefined,
+      retryPolicy: undefined,
+      searchAttributes: undefined,
+      memo: undefined,
+    });
+  });
+});
+
+function transform(
+  schedule: DescribeScheduleResponse = getMockEditableDescribeScheduleResponse()
+) {
+  return transformDescribeScheduleResponseToFormData(
+    schedule,
+    MOCK_SCHEDULE_ID
+  );
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -63,7 +63,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
         taskList: { name: 'demo-task-list' },
         executionStartToCloseTimeoutSeconds: 3600,
         workflowIdPrefix: 'scheduled-demo-',
-        workerSDKLanguage: 'GO',
+        workerSDKLanguage: undefined,
       })
     );
   });
@@ -122,7 +122,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
       workflowType: { name: '' },
       taskList: { name: '' },
       executionStartToCloseTimeoutSeconds: 0,
-      workerSDKLanguage: 'GO',
+      workerSDKLanguage: undefined,
       input: [''],
       workflowIdPrefix: undefined,
       pauseOnFailure: false,

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/map-cron-expression-to-form-fields.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/map-cron-expression-to-form-fields.ts
@@ -1,0 +1,25 @@
+import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
+import parseCronExpression from '@/utils/cron-validate/parse-cron-expression';
+
+import { EMPTY_CRON_EXPRESSION_FIELDS } from '../schedule-action-edit-form.constants';
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+export default function mapCronExpressionToFormFields(
+  cronExpression: string | undefined
+): EditScheduleFormData['cronExpression'] {
+  const parsed = parseCronExpression(cronExpression || '');
+
+  if (!parsed || parsed.timezone !== 'UTC') {
+    return EMPTY_CRON_EXPRESSION_FIELDS;
+  }
+
+  const fields = parsed.expression.split(/\s+/);
+
+  if (fields.length !== CRON_FIELD_ORDER.length) {
+    return EMPTY_CRON_EXPRESSION_FIELDS;
+  }
+
+  return Object.fromEntries(
+    CRON_FIELD_ORDER.map((field, index) => [field, fields[index]])
+  ) as EditScheduleFormData['cronExpression'];
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -1,0 +1,122 @@
+import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
+import {
+  SCHEDULE_CATCH_UP_POLICIES,
+  SCHEDULE_OVERLAP_POLICIES,
+  WORKER_SDK_LANGUAGES,
+} from '@/route-handlers/create-schedule/create-schedule.constants';
+import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
+import formatDurationToSeconds from '@/utils/data-formatters/format-duration-to-seconds';
+import formatInputPayload from '@/utils/data-formatters/format-input-payload';
+import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
+import losslessJsonStringify from '@/utils/lossless-json-stringify';
+
+import {
+  EMPTY_CRON_EXPRESSION_FIELDS,
+  SECONDS_PER_DAY,
+} from '../schedule-action-edit-form.constants';
+import {
+  type EditScheduleFormData,
+  type ExhaustiveDefaults,
+} from '../schedule-action-edit-form.types';
+
+/**
+ * Builds the edit form's default values from an existing schedule.
+ *
+ * The return type deliberately makes every key required: forgetting to map a
+ * newly-added form field then fails `npm run typecheck` instead of silently
+ * prefilling that field as blank.
+ */
+export default function transformDescribeScheduleResponseToFormData(
+  schedule: DescribeScheduleResponse,
+  scheduleId: string
+): ExhaustiveDefaults<EditScheduleFormData> {
+  const startWorkflow = schedule.action?.startWorkflow;
+  const policies = schedule.policies;
+  const parsedInput = formatInputPayload(startWorkflow?.input);
+
+  return {
+    scheduleId,
+    cronExpression: splitCronExpression(schedule.spec?.cronExpression),
+    workflowType: { name: startWorkflow?.workflowType?.name ?? '' },
+    taskList: { name: startWorkflow?.taskList?.name ?? '' },
+    executionStartToCloseTimeoutSeconds:
+      formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ?? 0,
+    taskStartToCloseTimeoutSeconds:
+      formatDurationToSeconds(startWorkflow?.taskStartToCloseTimeout) ?? 0,
+    // The worker SDK is not stored on the schedule, only the input encoding it
+    // produced, which is ambiguous between languages. Fall back to the same
+    // default the create form uses.
+    workerSDKLanguage: WORKER_SDK_LANGUAGES[0],
+    input: parsedInput?.length
+      ? parsedInput.map((value) => losslessJsonStringify(value))
+      : [''],
+    workflowIdPrefix: startWorkflow?.workflowIdPrefix || undefined,
+    pauseOnFailure: policies?.pauseOnFailure ?? false,
+
+    overlapPolicy: SCHEDULE_OVERLAP_POLICIES.find(
+      (policy) => policy === policies?.overlapPolicy
+    ),
+    bufferLimit: stringifyLimit(policies?.bufferLimit),
+    concurrencyLimit: stringifyLimit(policies?.concurrencyLimit),
+    catchUpPolicy: SCHEDULE_CATCH_UP_POLICIES.find(
+      (policy) => policy === policies?.catchUpPolicy
+    ),
+    catchUpWindowDays: formatCatchUpWindowDays(policies?.catchUpWindow),
+
+    jitterSeconds:
+      formatDurationToSeconds(schedule.spec?.jitter)?.toString() ?? undefined,
+    startTime: formatTimestampToIso(schedule.spec?.startTime),
+    endTime: formatTimestampToIso(schedule.spec?.endTime),
+
+    // TODO(PR08d): decode the schedule's retry policy, search attributes and memo.
+    enableRetryPolicy: false,
+    limitRetries: undefined,
+    retryPolicy: undefined,
+    searchAttributes: undefined,
+    memo: undefined,
+  };
+}
+
+/**
+ * ponytail: only plain 5-field cron expressions map onto the cron inputs. A
+ * schedule using another syntax (for example `@every 1h`) prefills empty, so the
+ * form asks for a cron rather than silently mangling it. Upgrade path: teach
+ * `CronScheduleInput` about the other syntaxes and widen this.
+ */
+function splitCronExpression(
+  cronExpression: string | undefined
+): EditScheduleFormData['cronExpression'] {
+  const fields = cronExpression?.trim().split(/\s+/) ?? [];
+
+  if (fields.length !== CRON_FIELD_ORDER.length) {
+    return EMPTY_CRON_EXPRESSION_FIELDS;
+  }
+
+  return Object.fromEntries(
+    CRON_FIELD_ORDER.map((field, index) => [field, fields[index]])
+  ) as EditScheduleFormData['cronExpression'];
+}
+
+function stringifyLimit(limit: number | undefined): string | undefined {
+  return limit === undefined ? undefined : String(limit);
+}
+
+/**
+ * The form only accepts whole days, so a partial day rounds up rather than down
+ * to avoid narrowing the window the schedule already runs with.
+ */
+function formatCatchUpWindowDays(
+  catchUpWindow: Parameters<typeof formatDurationToSeconds>[0]
+): string | undefined {
+  const seconds = formatDurationToSeconds(catchUpWindow);
+
+  return seconds ? String(Math.ceil(seconds / SECONDS_PER_DAY)) : undefined;
+}
+
+function formatTimestampToIso(
+  timestamp: Parameters<typeof parseGrpcTimestamp>[0] | null | undefined
+): string | undefined {
+  return timestamp
+    ? new Date(parseGrpcTimestamp(timestamp)).toISOString()
+    : undefined;
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -37,7 +37,8 @@ export default function transformDescribeScheduleResponseToFormData(
     workflowType: { name: startWorkflow?.workflowType?.name ?? '' },
     taskList: { name: startWorkflow?.taskList?.name ?? '' },
     executionStartToCloseTimeoutSeconds:
-      formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ?? 0,
+      formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ??
+      undefined,
     // Cadence stores encoded input bytes only; the worker SDK is not persisted.
     workerSDKLanguage: undefined,
     input: parsedInput?.length

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -3,7 +3,6 @@ import isNil from 'lodash/isNil';
 import {
   SCHEDULE_CATCH_UP_POLICIES,
   SCHEDULE_OVERLAP_POLICIES,
-  WORKER_SDK_LANGUAGES,
 } from '@/route-handlers/create-schedule/create-schedule.constants';
 import { type DescribeScheduleResponse } from '@/route-handlers/describe-schedule/describe-schedule.types';
 import formatDurationToSeconds from '@/utils/data-formatters/format-duration-to-seconds';
@@ -11,10 +10,7 @@ import formatInputPayload from '@/utils/data-formatters/format-input-payload';
 import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 import losslessJsonStringify from '@/utils/lossless-json-stringify';
 
-import {
-  type EditScheduleFormData,
-  type ExhaustiveDefaults,
-} from '../schedule-action-edit-form.types';
+import { type EditScheduleFormPrefillValues } from '../schedule-action-edit-form.types';
 
 import mapCronExpressionToFormFields from './map-cron-expression-to-form-fields';
 
@@ -28,7 +24,7 @@ import mapCronExpressionToFormFields from './map-cron-expression-to-form-fields'
 export default function transformDescribeScheduleResponseToFormData(
   schedule: DescribeScheduleResponse,
   scheduleId: string
-): ExhaustiveDefaults<EditScheduleFormData> {
+): EditScheduleFormPrefillValues {
   const startWorkflow = schedule.action?.startWorkflow;
   const policies = schedule.policies;
   const parsedInput = formatInputPayload(startWorkflow?.input);
@@ -42,10 +38,8 @@ export default function transformDescribeScheduleResponseToFormData(
     taskList: { name: startWorkflow?.taskList?.name ?? '' },
     executionStartToCloseTimeoutSeconds:
       formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ?? 0,
-    // The worker SDK is not stored on the schedule, only the input encoding it
-    // produced, which is ambiguous between languages. Fall back to the same
-    // default the create form uses.
-    workerSDKLanguage: WORKER_SDK_LANGUAGES[0],
+    // Cadence stores encoded input bytes only; the worker SDK is not persisted.
+    workerSDKLanguage: undefined,
     input: parsedInput?.length
       ? parsedInput.map((value) => losslessJsonStringify(value))
       : [''],

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -1,4 +1,5 @@
-import { CRON_FIELD_ORDER } from '@/components/cron-schedule-input/cron-schedule-input.constants';
+import isNil from 'lodash/isNil';
+
 import {
   SCHEDULE_CATCH_UP_POLICIES,
   SCHEDULE_OVERLAP_POLICIES,
@@ -11,13 +12,11 @@ import parseGrpcTimestamp from '@/utils/datetime/parse-grpc-timestamp';
 import losslessJsonStringify from '@/utils/lossless-json-stringify';
 
 import {
-  EMPTY_CRON_EXPRESSION_FIELDS,
-  SECONDS_PER_DAY,
-} from '../schedule-action-edit-form.constants';
-import {
   type EditScheduleFormData,
   type ExhaustiveDefaults,
 } from '../schedule-action-edit-form.types';
+
+import mapCronExpressionToFormFields from './map-cron-expression-to-form-fields';
 
 /**
  * Builds the edit form's default values from an existing schedule.
@@ -36,7 +35,9 @@ export default function transformDescribeScheduleResponseToFormData(
 
   return {
     scheduleId,
-    cronExpression: splitCronExpression(schedule.spec?.cronExpression),
+    cronExpression: mapCronExpressionToFormFields(
+      schedule.spec?.cronExpression
+    ),
     workflowType: { name: startWorkflow?.workflowType?.name ?? '' },
     taskList: { name: startWorkflow?.taskList?.name ?? '' },
     executionStartToCloseTimeoutSeconds:
@@ -54,17 +55,26 @@ export default function transformDescribeScheduleResponseToFormData(
     overlapPolicy: SCHEDULE_OVERLAP_POLICIES.find(
       (policy) => policy === policies?.overlapPolicy
     ),
-    bufferLimit: stringifyLimit(policies?.bufferLimit),
-    concurrencyLimit: stringifyLimit(policies?.concurrencyLimit),
+    bufferLimit: isNil(policies?.bufferLimit)
+      ? undefined
+      : String(policies?.bufferLimit),
+    concurrencyLimit: isNil(policies?.concurrencyLimit)
+      ? undefined
+      : String(policies.concurrencyLimit),
     catchUpPolicy: SCHEDULE_CATCH_UP_POLICIES.find(
       (policy) => policy === policies?.catchUpPolicy
     ),
-    catchUpWindowDays: formatCatchUpWindowDays(policies?.catchUpWindow),
+    catchUpWindowSeconds:
+      formatDurationToSeconds(policies?.catchUpWindow)?.toString() ?? undefined,
 
     jitterSeconds:
       formatDurationToSeconds(schedule.spec?.jitter)?.toString() ?? undefined,
-    startTime: formatTimestampToIso(schedule.spec?.startTime),
-    endTime: formatTimestampToIso(schedule.spec?.endTime),
+    startTime: schedule.spec?.startTime
+      ? new Date(parseGrpcTimestamp(schedule.spec.startTime)).toISOString()
+      : undefined,
+    endTime: schedule.spec?.endTime
+      ? new Date(parseGrpcTimestamp(schedule.spec.endTime)).toISOString()
+      : undefined,
 
     // TODO(PR08d): decode the schedule's retry policy, search attributes and memo.
     enableRetryPolicy: false,
@@ -73,48 +83,4 @@ export default function transformDescribeScheduleResponseToFormData(
     searchAttributes: undefined,
     memo: undefined,
   };
-}
-
-/**
- * ponytail: only plain 5-field cron expressions map onto the cron inputs. A
- * schedule using another syntax (for example `@every 1h`) prefills empty, so the
- * form asks for a cron rather than silently mangling it. Upgrade path: teach
- * `CronScheduleInput` about the other syntaxes and widen this.
- */
-function splitCronExpression(
-  cronExpression: string | undefined
-): EditScheduleFormData['cronExpression'] {
-  const fields = cronExpression?.trim().split(/\s+/) ?? [];
-
-  if (fields.length !== CRON_FIELD_ORDER.length) {
-    return EMPTY_CRON_EXPRESSION_FIELDS;
-  }
-
-  return Object.fromEntries(
-    CRON_FIELD_ORDER.map((field, index) => [field, fields[index]])
-  ) as EditScheduleFormData['cronExpression'];
-}
-
-function stringifyLimit(limit: number | undefined): string | undefined {
-  return limit === undefined ? undefined : String(limit);
-}
-
-/**
- * The form only accepts whole days, so a partial day rounds up rather than down
- * to avoid narrowing the window the schedule already runs with.
- */
-function formatCatchUpWindowDays(
-  catchUpWindow: Parameters<typeof formatDurationToSeconds>[0]
-): string | undefined {
-  const seconds = formatDurationToSeconds(catchUpWindow);
-
-  return seconds ? String(Math.ceil(seconds / SECONDS_PER_DAY)) : undefined;
-}
-
-function formatTimestampToIso(
-  timestamp: Parameters<typeof parseGrpcTimestamp>[0] | null | undefined
-): string | undefined {
-  return timestamp
-    ? new Date(parseGrpcTimestamp(timestamp)).toISOString()
-    : undefined;
 }

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -41,8 +41,6 @@ export default function transformDescribeScheduleResponseToFormData(
     taskList: { name: startWorkflow?.taskList?.name ?? '' },
     executionStartToCloseTimeoutSeconds:
       formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ?? 0,
-    taskStartToCloseTimeoutSeconds:
-      formatDurationToSeconds(startWorkflow?.taskStartToCloseTimeout) ?? 0,
     // The worker SDK is not stored on the schedule, only the input encoding it
     // produced, which is ambiguous between languages. Fall back to the same
     // default the create form uses.

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
@@ -1,5 +1,3 @@
-export const SECONDS_PER_DAY = 24 * 60 * 60;
-
 export const EMPTY_CRON_EXPRESSION_FIELDS = {
   minutes: '',
   hours: '',

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.constants.ts
@@ -1,0 +1,9 @@
+export const SECONDS_PER_DAY = 24 * 60 * 60;
+
+export const EMPTY_CRON_EXPRESSION_FIELDS = {
+  minutes: '',
+  hours: '',
+  daysOfMonth: '',
+  months: '',
+  daysOfWeek: '',
+} as const;

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -19,12 +19,14 @@ export type EditScheduleSubmissionData = Omit<
 /**
  * Prefill values for the edit form. `workerSDKLanguage` is explicitly unset
  * because Cadence does not persist it; the field is still required on submit.
+ * `executionStartToCloseTimeoutSeconds` may be unset when describe has no timeout.
  */
 export type EditScheduleFormPrefillValues = Omit<
   ExhaustiveDefaults<EditScheduleFormData>,
-  'workerSDKLanguage'
+  'workerSDKLanguage' | 'executionStartToCloseTimeoutSeconds'
 > & {
   workerSDKLanguage: undefined;
+  executionStartToCloseTimeoutSeconds: number | undefined;
 };
 
 /**

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -17,6 +17,17 @@ export type EditScheduleSubmissionData = Omit<
 >;
 
 /**
+ * Prefill values for the edit form. `workerSDKLanguage` is explicitly unset
+ * because Cadence does not persist it; the field is still required on submit.
+ */
+export type EditScheduleFormPrefillValues = Omit<
+  ExhaustiveDefaults<EditScheduleFormData>,
+  'workerSDKLanguage'
+> & {
+  workerSDKLanguage: undefined;
+};
+
+/**
  * Forces every key of T to be explicitly assigned, including optional fields,
  * whose value may still be `undefined`. Adding a field to T without updating a
  * literal typed as `ExhaustiveDefaults<T>` is a compile error, which is what


### PR DESCRIPTION
## Summary

Adds the transform that turns a describe-schedule response into the **Edit Schedule** form's default values. This slice covers the spec, action and policy fields; retry policy, search attributes and memo prefill blank for now and are decoded in [#1494](https://github.com/cadence-workflow/cadence-web/pull/1494). Nothing imports this transform yet, so there is no user-visible change.


## Changes

- `helpers/transform-describe-schedule-response-to-form-data.ts`: maps cron, workflow type, task list, execution timeout, input, workflow id prefix, pause on failure, overlap/catch-up policies, catch-up window (seconds), jitter, and schedule period
- `schedule-action-edit-form.types.ts`: adds `EditScheduleFormPrefillValues` for describe prefill vs validated submit data
- `schedule-action-edit-form.constants.ts`: empty cron fields fallback
- `helpers/map-cron-expression-to-form-fields.ts`: splits cron via shared `parseCronExpression`; leaves fields empty when the expression is not five plain UTC fields
- `DomainSchedulesCreateForm`: adds `prefillWorkerSDKLanguage` (default `true`) so create still pre-selects GO while edit can start with no Worker SDK selected
- Fixture for a fully populated schedule, plus unit tests

Decisions worth flagging:

- **Worker SDK** is not stored on a schedule. Prefill sets `workerSDKLanguage: undefined` instead of defaulting to GO. The field stays **required on submit** (same schema as create); [#1495](https://github.com/cadence-workflow/cadence-web/pull/1495) passes `prefillWorkerSDKLanguage={false}` when reusing the shared form.
- **Cron expressions that are not five plain fields** (for example `@every 1h` or non-UTC `CRON_TZ`) prefill empty so the form asks for a valid cron rather than mangling it into the wrong boxes.
- Multi-argument workflow input is split back into separate entries via existing `formatInputPayload`.

## Testing

- `npm run test:unit:browser -- schedule-action-edit-form`
- `npm run test:unit:browser -- domain-schedules-create-form`
