### PR TITLE
feat(schedule-actions): add the edit schedule form component

### DIFF
--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect } from 'react';
 
-import { useForm, type FieldPath } from 'react-hook-form';
+import {
+  type FieldError,
+  type FieldErrors,
+  type FieldPath,
+  useForm,
+} from 'react-hook-form';
 
 import {
   fireEvent,
@@ -24,15 +29,6 @@ jest.mock(
 
 const MOCK_DOMAIN = 'test-domain';
 const MOCK_CLUSTER = 'test-cluster';
-
-/** Required fields rendered by `DomainSchedulesCreateForm` (excludes optional input / pause / prefix / SDK default). */
-const REQUIRED_FORM_FIELD_PATHS: FieldPath<DomainSchedulesCreateFormData>[] = [
-  'workflowType.name',
-  'taskList.name',
-  'executionStartToCloseTimeoutSeconds',
-  'cronExpression',
-  'input',
-];
 
 describe('DomainSchedulesCreateForm', () => {
   beforeEach(() => {
@@ -71,7 +67,17 @@ describe('DomainSchedulesCreateForm', () => {
   });
 
   it('displays field errors wired from react-hook-form state', async () => {
-    await setup({ injectFieldErrors: true });
+    await setup({
+      fieldErrors: {
+        'workflowType.name': { type: 'required', message: 'required' },
+        'taskList.name': { type: 'required', message: 'required' },
+        executionStartToCloseTimeoutSeconds: {
+          type: 'required',
+          message: 'required',
+        },
+        cronExpression: { type: 'custom', message: 'required' },
+      },
+    });
 
     await waitFor(() => {
       expect(
@@ -181,12 +187,25 @@ describe('DomainSchedulesCreateForm', () => {
       expect(screen.getByRole('radio', { name: language })).not.toBeChecked();
     }
   });
+
+  it('displays worker SDK error when unset and validation fails', async () => {
+    await setup({
+      prefillWorkerSDKLanguage: false,
+      fieldErrors: {
+        workerSDKLanguage: {
+          type: 'required',
+          message: 'Worker SDK is required',
+        },
+      },
+    });
+
+    expect(screen.getByText('Worker SDK is required')).toBeInTheDocument();
+  });
 });
 
 type SetupProps = {
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
-  /** Applies fixed `setError` calls (same role as passing `fieldErrors` into start form tests). */
-  injectFieldErrors?: boolean;
+  fieldErrors?: FieldErrors<DomainSchedulesCreateFormData>;
   taskListValidation?: ReturnType<typeof mockUseTaskListFieldValidation>;
   scheduleIdReadOnly?: boolean;
   prefillWorkerSDKLanguage?: boolean;
@@ -194,27 +213,25 @@ type SetupProps = {
 
 function TestWrapper({
   defaultValues,
-  injectFieldErrors,
+  fieldErrors,
   scheduleIdReadOnly,
   prefillWorkerSDKLanguage,
-}: {
-  defaultValues?: Partial<DomainSchedulesCreateFormData>;
-  injectFieldErrors?: boolean;
-  scheduleIdReadOnly?: boolean;
-  prefillWorkerSDKLanguage?: boolean;
-}) {
-  const { control, trigger, setError, clearErrors } =
-    useForm<DomainSchedulesCreateFormData>({
-      defaultValues: { ...defaultValues },
-      mode: 'onSubmit',
-    });
+}: Pick<
+  SetupProps,
+  'defaultValues' | 'fieldErrors' | 'scheduleIdReadOnly' | 'prefillWorkerSDKLanguage'
+>) {
+  const { control, trigger, setError, clearErrors } = useForm<DomainSchedulesCreateFormData>({
+    defaultValues: { ...defaultValues },
+    mode: 'onSubmit',
+  });
 
   useEffect(() => {
-    if (!injectFieldErrors) return;
-    for (const path of REQUIRED_FORM_FIELD_PATHS) {
-      setError(path, { type: 'required', message: 'is required' });
+    if (!fieldErrors) return;
+    for (const [path, error] of Object.entries(fieldErrors)) {
+      if (!error || Array.isArray(error) || !('message' in error)) continue;
+      setError(path as FieldPath<DomainSchedulesCreateFormData>, error as FieldError);
     }
-  }, [injectFieldErrors, setError]);
+  }, [fieldErrors, setError]);
 
   return (
     <DomainSchedulesCreateForm
@@ -231,7 +248,7 @@ function TestWrapper({
 
 async function setup({
   defaultValues,
-  injectFieldErrors = false,
+  fieldErrors,
   scheduleIdReadOnly,
   prefillWorkerSDKLanguage,
   taskListValidation = {
@@ -246,7 +263,7 @@ async function setup({
   render(
     <TestWrapper
       defaultValues={defaultValues}
-      injectFieldErrors={injectFieldErrors}
+      fieldErrors={fieldErrors}
       scheduleIdReadOnly={scheduleIdReadOnly}
       prefillWorkerSDKLanguage={prefillWorkerSDKLanguage}
     />

--- a/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/__tests__/domain-schedules-create-form.test.tsx
@@ -1,11 +1,6 @@
 import React, { useEffect } from 'react';
 
-import {
-  type FieldError,
-  type FieldErrors,
-  type FieldPath,
-  useForm,
-} from 'react-hook-form';
+import { type FieldError, type FieldPath, useForm } from 'react-hook-form';
 
 import {
   fireEvent,
@@ -205,7 +200,9 @@ describe('DomainSchedulesCreateForm', () => {
 
 type SetupProps = {
   defaultValues?: Partial<DomainSchedulesCreateFormData>;
-  fieldErrors?: FieldErrors<DomainSchedulesCreateFormData>;
+  fieldErrors?: Partial<
+    Record<FieldPath<DomainSchedulesCreateFormData>, FieldError>
+  >;
   taskListValidation?: ReturnType<typeof mockUseTaskListFieldValidation>;
   scheduleIdReadOnly?: boolean;
   prefillWorkerSDKLanguage?: boolean;
@@ -218,18 +215,22 @@ function TestWrapper({
   prefillWorkerSDKLanguage,
 }: Pick<
   SetupProps,
-  'defaultValues' | 'fieldErrors' | 'scheduleIdReadOnly' | 'prefillWorkerSDKLanguage'
+  | 'defaultValues'
+  | 'fieldErrors'
+  | 'scheduleIdReadOnly'
+  | 'prefillWorkerSDKLanguage'
 >) {
-  const { control, trigger, setError, clearErrors } = useForm<DomainSchedulesCreateFormData>({
-    defaultValues: { ...defaultValues },
-    mode: 'onSubmit',
-  });
+  const { control, trigger, setError, clearErrors } =
+    useForm<DomainSchedulesCreateFormData>({
+      defaultValues: { ...defaultValues },
+      mode: 'onSubmit',
+    });
 
   useEffect(() => {
     if (!fieldErrors) return;
     for (const [path, error] of Object.entries(fieldErrors)) {
-      if (!error || Array.isArray(error) || !('message' in error)) continue;
-      setError(path as FieldPath<DomainSchedulesCreateFormData>, error as FieldError);
+      if (!error) continue;
+      setError(path as FieldPath<DomainSchedulesCreateFormData>, error);
     }
   }, [fieldErrors, setError]);
 

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -161,6 +161,7 @@ export default function DomainSchedulesCreateForm({
       <DomainSchedulesHorizontalField
         label="Worker SDK"
         description={CREATE_SCHEDULE_MAIN_FIELD_DESCRIPTIONS.workerSDK}
+        error={getFieldErrorMessage(fieldErrors, 'workerSDKLanguage')}
       >
         <Controller
           name="workerSDKLanguage"

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.tsx
@@ -106,7 +106,7 @@ export default function DomainSchedulesCreateForm({
               onChange={(value) => {
                 field.onChange(value);
                 // If form is submitted, trigger the validation to show fix immediately
-                if (isSubmitted) trigger('cronExpression');
+                if (isSubmitted) trigger?.('cronExpression');
               }}
               onBlur={field.onBlur}
               error={cronExpressionError}
@@ -215,7 +215,7 @@ export default function DomainSchedulesCreateForm({
               value={field.value}
               onChange={(value) => {
                 field.onChange(value);
-                if (isSubmitted) trigger('input');
+                if (isSubmitted) trigger?.('input');
               }}
               error={inputError}
               addButtonText="Add argument"

--- a/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
+++ b/src/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form.types.ts
@@ -8,7 +8,7 @@ import { type DomainSchedulesCreateFormData } from '../domain-schedules-create-m
 
 export type Props = {
   control: Control<DomainSchedulesCreateFormData>;
-  trigger: UseFormTrigger<DomainSchedulesCreateFormData>;
+  trigger?: UseFormTrigger<DomainSchedulesCreateFormData>;
   clearErrors: UseFormClearErrors<DomainSchedulesCreateFormData>;
   domain: string;
   cluster: string;

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -83,7 +83,10 @@ export const createScheduleFormFieldsSchema = z.object({
     })
     .positive('Execution timeout must be positive'),
   // TODO(refactor): WORKER_SDK_LANGUAGES imported from start-workflow — extract to shared constants
-  workerSDKLanguage: z.enum(WORKER_SDK_LANGUAGES),
+  workerSDKLanguage: z.enum(WORKER_SDK_LANGUAGES, {
+    required_error: 'Worker SDK is required',
+    invalid_type_error: 'Worker SDK is required',
+  }),
   input: z
     .array(z.string())
     .optional()

--- a/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.test.tsx
+++ b/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.test.tsx
@@ -37,6 +37,14 @@ describe(ScheduleActionEditForm.name, () => {
     );
   });
 
+  it('does not pre-select worker SDK, since schedules do not persist it', () => {
+    setup();
+
+    expect(mockCreateForm).toHaveBeenCalledWith(
+      expect.objectContaining({ prefillWorkerSDKLanguage: false })
+    );
+  });
+
   it('forwards the domain, cluster and form handles', () => {
     setup();
 

--- a/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.test.tsx
+++ b/src/views/schedule-actions/schedule-action-edit-form/__tests__/schedule-action-edit-form.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { useForm } from 'react-hook-form';
+
+import { render, screen } from '@/test-utils/rtl';
+
+import ScheduleActionEditForm from '../schedule-action-edit-form';
+import { type EditScheduleFormData } from '../schedule-action-edit-form.types';
+
+const mockCreateForm = jest.fn();
+
+jest.mock(
+  '@/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form',
+  () =>
+    function MockDomainSchedulesCreateForm(props: any) {
+      mockCreateForm(props);
+      return <div>mock create form</div>;
+    }
+);
+
+describe(ScheduleActionEditForm.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the create schedule form', () => {
+    setup();
+
+    expect(screen.getByText('mock create form')).toBeInTheDocument();
+  });
+
+  it('makes the schedule id read-only, since it cannot be changed', () => {
+    setup();
+
+    expect(mockCreateForm).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduleIdReadOnly: true })
+    );
+  });
+
+  it('forwards the domain, cluster and form handles', () => {
+    setup();
+
+    expect(mockCreateForm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        control: expect.any(Object),
+        trigger: expect.any(Function),
+        clearErrors: expect.any(Function),
+      })
+    );
+  });
+});
+
+function setup() {
+  function Wrapper() {
+    const { control, trigger, clearErrors } = useForm<EditScheduleFormData>();
+
+    return (
+      <ScheduleActionEditForm
+        control={control}
+        trigger={trigger}
+        clearErrors={clearErrors}
+        domain="mock-domain"
+        cluster="mock-cluster"
+      />
+    );
+  }
+
+  render(<Wrapper />);
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.tsx
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.tsx
@@ -21,6 +21,7 @@ export default function ScheduleActionEditForm({
       domain={domain}
       cluster={cluster}
       scheduleIdReadOnly
+      prefillWorkerSDKLanguage={false}
     />
   );
 }

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.tsx
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+
+import DomainSchedulesCreateForm from '@/views/domain-schedules/domain-schedules-create-form/domain-schedules-create-form';
+
+import { type Props } from './schedule-action-edit-form.types';
+
+export default function ScheduleActionEditForm({
+  control,
+  trigger,
+  clearErrors,
+  domain,
+  cluster,
+}: Props) {
+  return (
+    <DomainSchedulesCreateForm
+      control={control}
+      trigger={trigger}
+      clearErrors={clearErrors}
+      domain={domain}
+      cluster={cluster}
+      scheduleIdReadOnly
+    />
+  );
+}

--- a/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/schedule-action-edit-form.types.ts
@@ -2,6 +2,8 @@ import { type z } from 'zod';
 
 import { type CreateScheduleRequestBody } from '@/route-handlers/create-schedule/create-schedule.types';
 
+import { type ScheduleActionFormProps } from '../schedule-actions.types';
+
 import { type editScheduleFormSchema } from './schemas/edit-schedule-form-schema';
 
 export type EditScheduleFormData = z.infer<typeof editScheduleFormSchema>;
@@ -36,3 +38,8 @@ export type EditScheduleFormPrefillValues = Omit<
  * stops a newly-added form field from silently prefilling as blank.
  */
 export type ExhaustiveDefaults<T> = { [K in keyof Required<T>]: T[K] };
+
+export type Props = Pick<
+  ScheduleActionFormProps<EditScheduleFormData>,
+  'control' | 'trigger' | 'clearErrors' | 'domain' | 'cluster'
+>;

--- a/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
+++ b/src/views/schedule-actions/schedule-actions-modal-content/schedule-actions-modal-content.tsx
@@ -41,6 +41,7 @@ export default function ScheduleActionsModalContent<
     formState: { errors: validationErrors, isSubmitting, isSubmitted },
     control,
     trigger,
+    clearErrors,
   } = useForm<OptionalFormData>({
     resolver: action.modal.formSchema
       ? zodResolver(action.modal.formSchema)
@@ -151,6 +152,7 @@ export default function ScheduleActionsModalContent<
                 fieldErrors={validationErrors}
                 control={control}
                 trigger={trigger}
+                clearErrors={clearErrors}
                 cluster={params.cluster}
                 domain={params.domain}
                 scheduleId={params.scheduleId}

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -8,6 +8,7 @@ import {
   type Control,
   type FieldErrors,
   type FieldValues,
+  type UseFormClearErrors,
   type UseFormTrigger,
 } from 'react-hook-form';
 import { type z } from 'zod';
@@ -37,6 +38,7 @@ export type ScheduleActionFormProps<FormData extends FieldValues> = {
   fieldErrors: FieldErrors<FormData>;
   control: Control<FormData>;
   trigger?: UseFormTrigger<FormData>;
+  clearErrors: UseFormClearErrors<FormData>;
   isSubmitted?: boolean;
   cluster: string;
   domain: string;


### PR DESCRIPTION
## Summary

Adds `ScheduleActionEditForm`, the form the **Edit Schedule** action will render. It wraps the existing create-schedule form with a read-only Schedule Id and without pre-selecting Worker SDK, so there is no second copy of the schedule fields to keep in sync. The action config does not reference it yet, so nothing renders for users.

Part of the Edit Schedule stack (PR08e). **Stacked on [#1494](https://github.com/cadence-workflow/cadence-web/pull/1494)** — review the last commit only; merge the parents first.

## Changes

- `schedule-action-edit-form.tsx` plus its `Props`, derived from `ScheduleActionFormProps`
- Passes `scheduleIdReadOnly` and `prefillWorkerSDKLanguage={false}` to `DomainSchedulesCreateForm`. Cadence does not persist worker SDK on schedules; the field stays required on submit but starts unset in edit.
- `ScheduleActionFormProps` gains `clearErrors`, passed through by `schedule-actions-modal-content`. The reused retry policy fields need it to reset validation when the policy is toggled off; the existing pause, resume and backfill forms simply do not pick it up.
- `DomainSchedulesCreateForm`'s `trigger` becomes optional, matching how its own advanced-form child already declares it, so it lines up with the action form contract

## Testing

### Automated

- `npm run typecheck`
- `npm run lint`
- `npm run test:unit:browser -- schedule-actions` and `npm run test:unit:browser -- domain-schedules-create-form`, confirming the create-schedule flow is unaffected by the optional `trigger`.
- `npm run test:unit:browser -- schedule-action-edit-form` (4 component tests). Mocks `DomainSchedulesCreateForm` per the fork-friendly assertion rule and checks forwarded props: `scheduleIdReadOnly`, `prefillWorkerSDKLanguage: false`, domain, cluster and form handles.

### Manual E2E (edit form)

This PR only adds the form component; nothing renders for users until the action is wired in. The end-to-end recordings (TC-01…TC-07) therefore live on the wiring PR [#1496](https://github.com/cadence-workflow/cadence-web/pull/1496), where the Edit action becomes reachable in the Schedule Actions menu. Test cases: `.agents/features/edit-schedule/e2e-test-cases.md` (local only — not committed to branch).

<sub>Stack created with [GitHub Stacks CLI](https://github.com/github/gh-stack) • [Give Feedback 💬](https://gh.io/stacks-feedback)</sub>
