### PR TITLE
feat(schedule-actions): add the edit schedule action

### DIFF
--- a/src/config/dynamic/resolvers/__tests__/schedule-actions-enabled.node.ts
+++ b/src/config/dynamic/resolvers/__tests__/schedule-actions-enabled.node.ts
@@ -29,6 +29,7 @@ describe(scheduleActionsEnabled.name, () => {
       delete: 'ENABLED',
       backfill: 'ENABLED',
       start: 'ENABLED',
+      edit: 'ENABLED',
     });
   });
 
@@ -46,6 +47,7 @@ describe(scheduleActionsEnabled.name, () => {
       delete: 'DISABLED_UNAUTHORIZED',
       backfill: 'DISABLED_UNAUTHORIZED',
       start: 'DISABLED_UNAUTHORIZED',
+      edit: 'DISABLED_UNAUTHORIZED',
     });
   });
 
@@ -63,6 +65,7 @@ describe(scheduleActionsEnabled.name, () => {
       delete: 'DISABLED_DEFAULT',
       backfill: 'DISABLED_DEFAULT',
       start: 'DISABLED_DEFAULT',
+      edit: 'DISABLED_DEFAULT',
     });
   });
 });

--- a/src/config/dynamic/resolvers/schedule-actions-enabled.constants.ts
+++ b/src/config/dynamic/resolvers/schedule-actions-enabled.constants.ts
@@ -7,6 +7,7 @@ export const AUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
     delete: 'ENABLED',
     backfill: 'ENABLED',
     start: 'ENABLED',
+    edit: 'ENABLED',
   };
 
 export const UNAUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
@@ -16,6 +17,7 @@ export const UNAUTHORIZED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig 
     delete: 'DISABLED_UNAUTHORIZED',
     backfill: 'DISABLED_UNAUTHORIZED',
     start: 'DISABLED_UNAUTHORIZED',
+    edit: 'DISABLED_UNAUTHORIZED',
   };
 
 export const DEFAULT_DISABLED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledConfig =
@@ -25,4 +27,5 @@ export const DEFAULT_DISABLED_SCHEDULE_ACTIONS_CONFIG: ScheduleActionsEnabledCon
     delete: 'DISABLED_DEFAULT',
     backfill: 'DISABLED_DEFAULT',
     start: 'DISABLED_DEFAULT',
+    edit: 'DISABLED_DEFAULT',
   };

--- a/src/config/dynamic/resolvers/schedule-actions-enabled.types.ts
+++ b/src/config/dynamic/resolvers/schedule-actions-enabled.types.ts
@@ -5,7 +5,8 @@ export type ScheduleActionID =
   | 'resume'
   | 'delete'
   | 'backfill'
-  | 'start';
+  | 'start'
+  | 'edit';
 
 export type ScheduleActionDisabledValue =
   (typeof SCHEDULE_ACTIONS_DISABLED_VALUES_CONFIG)[number];

--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -76,6 +76,7 @@ const resolverSchemas: ResolverSchemas = {
       delete: scheduleActionsEnabledValueSchema,
       backfill: scheduleActionsEnabledValueSchema,
       start: scheduleActionsEnabledValueSchema,
+      edit: scheduleActionsEnabledValueSchema,
     }),
   },
   CRON_LIST_ENABLED: {

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -55,6 +55,7 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
     delete: 'ENABLED',
     backfill: 'ENABLED',
     start: 'ENABLED',
+    edit: 'ENABLED',
   },
   SCHEDULES_ENABLED: false,
   WORKFLOWS_LIST_ENABLED: false,

--- a/src/views/schedule-actions/__tests__/schedule-actions.test.tsx
+++ b/src/views/schedule-actions/__tests__/schedule-actions.test.tsx
@@ -7,7 +7,16 @@ import { render, screen, userEvent, waitFor } from '@/test-utils/rtl';
 import { mockDescribeScheduleResponse } from '@/route-handlers/describe-schedule/__fixtures__/mock-describe-schedule-response';
 
 import { mockScheduleActionsConfig } from '../__fixtures__/schedule-actions-config';
+import scheduleActionsConfig from '../config/schedule-actions.config';
 import ScheduleActions from '../schedule-actions';
+
+const editScheduleAction = scheduleActionsConfig.find(
+  (action) => action.id === 'edit'
+);
+
+if (!editScheduleAction) {
+  throw new Error('the edit action is not registered in the actions config');
+}
 
 const mockScheduleParams = {
   domain: 'mock-domain',
@@ -20,8 +29,16 @@ jest.mock('next/navigation', () => ({
   useParams: () => mockScheduleParams,
 }));
 
+const mockModalProps = jest.fn();
+
+/** Action the mocked menu selects when clicked; defaults to the first one. */
+let actionToSelect:
+  | (typeof mockScheduleActionsConfig)[number]
+  | NonNullable<typeof editScheduleAction> = mockScheduleActionsConfig[0];
+
 jest.mock('../schedule-actions-modal/schedule-actions-modal', () =>
   jest.fn((props) => {
+    mockModalProps(props);
     return props.action ? (
       <div data-testid="actions-modal">Actions Modal</div>
     ) : null;
@@ -38,7 +55,7 @@ jest.mock('../schedule-actions-menu/schedule-actions-menu', () =>
 
     return (
       <div
-        onClick={() => props.onActionSelect(mockScheduleActionsConfig[0])}
+        onClick={() => props.onActionSelect(actionToSelect)}
         data-testid="actions-menu"
       >
         Actions Menu{areAllActionsDisabled ? ' (disabled)' : ''}
@@ -50,6 +67,7 @@ jest.mock('../schedule-actions-menu/schedule-actions-menu', () =>
 describe(ScheduleActions.name, () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    actionToSelect = mockScheduleActionsConfig[0];
   });
 
   it('renders the button with the correct text', async () => {
@@ -99,6 +117,39 @@ describe(ScheduleActions.name, () => {
     await user.click(await screen.findByTestId('actions-menu'));
 
     expect(await screen.findByTestId('actions-modal')).toBeInTheDocument();
+  });
+
+  it('prefills the modal from the schedule when the edit action is selected', async () => {
+    actionToSelect = editScheduleAction;
+    const { user } = setup({});
+
+    const actionsButton = await screen.findByRole('button');
+    await user.click(actionsButton);
+    await user.click(await screen.findByTestId('actions-menu'));
+
+    await waitFor(() => {
+      expect(mockModalProps).toHaveBeenCalledWith(
+        expect.objectContaining({
+          initialFormValues: expect.objectContaining({
+            scheduleId: mockScheduleParams.scheduleId,
+          }),
+        })
+      );
+    });
+  });
+
+  it('does not prefill the modal for other actions', async () => {
+    const { user } = setup({});
+
+    const actionsButton = await screen.findByRole('button');
+    await user.click(actionsButton);
+    await user.click(await screen.findByTestId('actions-menu'));
+
+    expect(mockModalProps).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialFormValues: expect.anything(),
+      })
+    );
   });
 
   it('renders nothing if describeSchedule fails', async () => {
@@ -155,6 +206,7 @@ function setup({
               delete: 'ENABLED',
               backfill: 'ENABLED',
               start: 'ENABLED',
+              edit: 'ENABLED',
             },
             { status: 200 }
           );

--- a/src/views/schedule-actions/config/schedule-actions.config.ts
+++ b/src/views/schedule-actions/config/schedule-actions.config.ts
@@ -1,6 +1,7 @@
 import {
   MdDeleteOutline,
   MdHistory,
+  MdOutlineEdit,
   MdOutlineWarningAmber,
   MdPauseCircleOutline,
   MdPlayCircleOutline,
@@ -10,11 +11,19 @@ import { type BackfillScheduleResponse } from '@/route-handlers/backfill-schedul
 import { type DeleteScheduleResponse } from '@/route-handlers/delete-schedule/delete-schedule.types';
 import { type PauseScheduleResponse } from '@/route-handlers/pause-schedule/pause-schedule.types';
 import { type UnpauseScheduleResponse } from '@/route-handlers/unpause-schedule/unpause-schedule.types';
+import { type UpdateScheduleResponse } from '@/route-handlers/update-schedule/update-schedule.types';
 
 import transformBackfillScheduleFormToSubmission from '../schedule-action-backfill-form/helpers/transform-backfill-schedule-form-to-submission';
 import ScheduleActionBackfillForm from '../schedule-action-backfill-form/schedule-action-backfill-form';
 import { type BackfillScheduleFormData } from '../schedule-action-backfill-form/schedule-action-backfill-form.types';
 import { backfillScheduleFormSchema } from '../schedule-action-backfill-form/schemas/backfill-schedule-form-schema';
+import transformEditScheduleFormToSubmission from '../schedule-action-edit-form/helpers/transform-edit-schedule-form-to-submission';
+import ScheduleActionEditForm from '../schedule-action-edit-form/schedule-action-edit-form';
+import {
+  type EditScheduleFormData,
+  type EditScheduleSubmissionData,
+} from '../schedule-action-edit-form/schedule-action-edit-form.types';
+import { editScheduleFormSchema } from '../schedule-action-edit-form/schemas/edit-schedule-form-schema';
 import ScheduleActionPauseForm from '../schedule-action-pause-form/schedule-action-pause-form';
 import { type PauseScheduleFormData } from '../schedule-action-pause-form/schedule-action-pause-form.types';
 import { pauseScheduleFormSchema } from '../schedule-action-pause-form/schemas/pause-schedule-form-schema';
@@ -136,11 +145,42 @@ const backfillScheduleActionConfig: ScheduleAction<
   renderSuccessMessage: () => 'Schedule backfill has been started.',
 };
 
+const editScheduleActionConfig: ScheduleAction<
+  UpdateScheduleResponse,
+  EditScheduleFormData,
+  EditScheduleSubmissionData
+> = {
+  id: 'edit',
+  label: 'Edit',
+  subtitle: 'Edit this schedule’s configuration',
+  modal: {
+    banner: {
+      kind: 'warning',
+      icon: MdOutlineWarningAmber,
+      // Static rather than shown only on cron changes: UpdateSchedule has no
+      // partial-update mode, so any save has these consequences.
+      render: () =>
+        'Attention: Updating this schedule replaces the entire specification and clears all pending backfills. Ensure any critical backfills are completed or documented before saving changes.',
+    },
+    withForm: true,
+    form: ScheduleActionEditForm,
+    formSchema: editScheduleFormSchema,
+    transformFormDataToSubmission: transformEditScheduleFormToSubmission,
+  },
+  icon: MdOutlineEdit,
+  getRunnableStatus: () => 'RUNNABLE',
+  apiRoute: (params) =>
+    `/api/domains/${encodeURIComponent(params.domain)}/${encodeURIComponent(params.cluster)}/schedules/${encodeURIComponent(params.scheduleId)}`,
+  httpMethod: 'PUT',
+  renderSuccessMessage: () => 'Schedule has been updated.',
+};
+
 const scheduleActionsConfig = [
   pauseScheduleActionConfig,
   resumeScheduleActionConfig,
   deleteScheduleActionConfig,
   backfillScheduleActionConfig,
+  editScheduleActionConfig,
 ] as const;
 
 /** Discriminated union of configured actions; use at menu/selection boundaries. */

--- a/src/views/schedule-actions/schedule-actions-menu/__tests__/schedule-actions-menu.test.tsx
+++ b/src/views/schedule-actions/schedule-actions-menu/__tests__/schedule-actions-menu.test.tsx
@@ -70,6 +70,7 @@ describe(ScheduleActionsMenu.name, () => {
         delete: 'DISABLED_DEFAULT',
         backfill: 'DISABLED_DEFAULT',
         start: 'DISABLED_DEFAULT',
+        edit: 'DISABLED_DEFAULT',
       },
     });
 

--- a/src/views/schedule-actions/schedule-actions.tsx
+++ b/src/views/schedule-actions/schedule-actions.tsx
@@ -15,6 +15,7 @@ import { type SchedulePageParams } from '@/views/schedule-page/schedule-page.typ
 import useDescribeSchedule from '@/views/shared/hooks/use-describe-schedule/use-describe-schedule';
 
 import { type SelectableScheduleAction } from './config/schedule-actions.config';
+import transformDescribeScheduleResponseToFormData from './schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data';
 import ScheduleActionsMenu from './schedule-actions-menu/schedule-actions-menu';
 import ScheduleActionsModal from './schedule-actions-modal/schedule-actions-modal';
 import { overrides } from './schedule-actions.styles';
@@ -78,6 +79,14 @@ export default function ScheduleActions() {
         {...scheduleDetailsParams}
         schedule={schedule}
         action={selectedAction as ErasedScheduleAction | undefined}
+        initialFormValues={
+          selectedAction?.id === 'edit' && schedule
+            ? transformDescribeScheduleResponseToFormData(
+                schedule,
+                params.scheduleId
+              )
+            : undefined
+        }
         onClose={() => setSelectedAction(undefined)}
       />
     </>

--- a/src/views/schedule-actions/schedule-actions.types.ts
+++ b/src/views/schedule-actions/schedule-actions.types.ts
@@ -79,7 +79,9 @@ export type ScheduleActionModalForm<FormData, SubmissionData> =
           FormData extends FieldValues ? FormData : FieldValues
         >
       ) => ReactNode;
-      formSchema: z.ZodSchema<FormData>;
+      // Input is unknown rather than FormData: a form schema parses whatever
+      // the controls hold, which is not always the shape it validates into.
+      formSchema: z.ZodType<FormData, z.ZodTypeDef, unknown>;
       transformFormDataToSubmission: (formData: FormData) => SubmissionData;
     }
   | {


### PR DESCRIPTION
## Summary

Turns on the **Edit Schedule** action. This is the first user-visible slice of the stack: `edit` gains a config entry, so it now shows up in the Schedule Actions menu, opens the reused create-schedule form pre-filled from the described schedule with a read-only Schedule Id, and saves through `PUT .../schedules/{scheduleId}`.


## Changes

- `schedule-actions.config.ts` — `editScheduleActionConfig`: the static warning banner (copy taken verbatim from the feature spec, static because `UpdateSchedule` has no partial-update mode), `ScheduleActionEditForm`, the edit schema and submission transform, `PUT` on the existing schedule resource route, and `getRunnableStatus: () => 'RUNNABLE'`.
- `schedule-actions.tsx` — computes `initialFormValues` via `transformDescribeScheduleResponseToFormData` when the selected action is `edit`; other actions still open blank.
- `schedule-actions-enabled.types.ts` / `.constants.ts` / `resolver-schemas.ts` — `'edit'` joins `ScheduleActionID` alongside the existing actions, permission-gated like the rest.
- `ScheduleActionModalForm.formSchema` widens from `z.ZodSchema<FormData>` to `z.ZodType<FormData, z.ZodTypeDef, unknown>`. The cron expression schema uses `.catch()`, which widens its input type; a form schema parses whatever the controls hold, which is not always the shape it validates into.


## Testing

### Automated

- `npm run typecheck`
- `npm run lint`
- `npm run test:unit:node -- schedule-actions-enabled` (3 tests passing)
- `npm run test:unit:browser -- schedule-actions` (54 tests passing). New tests cover both branches of the prefill wiring: selecting Edit passes `initialFormValues` carrying the schedule id from the URL, and selecting any other action passes none.

### Manual E2E (edit form)

Test cases: `.agents/features/edit-schedule/e2e-test-cases.md` (local only — not committed to branch). Recordings were captured on this branch (`feat/schedule-actions-pr08f-edit-wire-up`, which wires the edit action into Schedule Actions) against the local docker backend.

| Case | Result | Recording |
|---|---|---|
| TC-01 Edit modal shell + warning banner | Pass | below |
| TC-02 Schedule ID read-only | Pass | below |
| TC-03 Worker SDK not pre-selected | Pass | below |
| TC-04 Core fields prefilled from describe | Pass | below |
| TC-05 Submit blocked without Worker SDK | Pass — submit blocked; Worker SDK flagged as required | below |
| TC-06 Successful edit saves changes | Pass | below |
| TC-07 Advanced section prefill | Pass (overlap/catch-up; no schedules with retry/memo in local data) | below |

**TC-01** — Edit modal header, static warning banner, and footer buttons.

https://github.com/user-attachments/assets/929675d4-0936-44ea-9a33-cbcb3fc33f6a

**TC-02** — Schedule ID disabled with immutable-id caption.

https://github.com/user-attachments/assets/33742e7d-9c9f-476a-ae5b-3edb968edb2b

**TC-03** — Worker SDK radios unset on open (no GO default).

https://github.com/user-attachments/assets/ec6f6a8e-7d33-4fb8-86d5-c58cf64ae740

**TC-04** — Workflow type, cron, task list, and JSON input prefilled.

https://github.com/user-attachments/assets/ee1bd729-ec63-48ed-b871-6c34cfead020

**TC-05** — Submit without Worker SDK blocked; field flagged as required.

https://github.com/user-attachments/assets/bb002d65-be73-4640-ba58-b8376c865d93

**TC-06** — Select GO, change workflow id prefix, success toast, value persists on re-open.

https://github.com/user-attachments/assets/cbff4811-054d-48ed-80b3-0a632dd35af0

**TC-07** — Advanced overlap/catch-up policies prefilled.

https://github.com/user-attachments/assets/dc34bef7-2a0b-49ac-9ff4-2c16f24f8db3

