### PR TITLE
fix(schedule-details): Delay skipped-run inference for visibility lag

### DIFF
--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-schedule-execution-gaps.test.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/__tests__/get-schedule-execution-gaps.test.ts
@@ -1,3 +1,4 @@
+import { SKIPPED_INFERENCE_VISIBILITY_BUFFER_MS } from '../../use-schedule-runs-chart-data.constants';
 import getScheduleExecutionGaps from '../get-schedule-execution-gaps';
 
 const hourMs = 60 * 60_000;
@@ -32,23 +33,42 @@ describe(getScheduleExecutionGaps.name, () => {
         scheduleEndMs: null,
         oldestLoadedScheduleTimeMs: 0,
         hasNextPage: false,
-        // The runs page was last fetched two hours ago: slots strictly after
-        // that can't be confirmed skipped yet, since a run may not have
-        // shown up in the response due to visibility indexing/poll lag.
+        // The runs page was last fetched two hours ago: slots at or shortly
+        // before that boundary can't be confirmed skipped yet, since a run may
+        // not have shown up in the response due to visibility indexing/poll lag.
         lastFetchedAtMs: 2 * hourMs,
         nowMs: 4 * hourMs,
         actualTimesMs: [hourMs],
       })
     ).toEqual({
-      skippedExecutions: [
-        { scheduledTimeMs: 0 },
-        { scheduledTimeMs: 2 * hourMs },
-      ],
+      skippedExecutions: [{ scheduledTimeMs: 0 }],
       unconfirmedExecutions: [
+        { scheduledTimeMs: 2 * hourMs },
         { scheduledTimeMs: 3 * hourMs },
         { scheduledTimeMs: 4 * hourMs },
       ],
     });
+  });
+
+  it('treats a slot within the visibility buffer before last fetch as unconfirmed', () => {
+    const lastFetchedAtMs = 2 * hourMs;
+
+    expect(
+      getScheduleExecutionGaps({
+        cronExpression: '0 * * * *',
+        timelineStartMs: 0,
+        scheduleEndMs: null,
+        oldestLoadedScheduleTimeMs: 0,
+        hasNextPage: false,
+        lastFetchedAtMs,
+        nowMs: lastFetchedAtMs,
+        actualTimesMs: [hourMs],
+      })
+    ).toEqual({
+      skippedExecutions: [{ scheduledTimeMs: 0 }],
+      unconfirmedExecutions: [{ scheduledTimeMs: lastFetchedAtMs }],
+    });
+    expect(SKIPPED_INFERENCE_VISIBILITY_BUFFER_MS).toBe(2_000);
   });
 
   it('treats a missing fetch timestamp as fully unconfirmed', () => {
@@ -86,11 +106,8 @@ describe(getScheduleExecutionGaps.name, () => {
         actualTimesMs: [2 * hourMs],
       })
     ).toEqual({
-      skippedExecutions: [
-        { scheduledTimeMs: 3 * hourMs },
-        { scheduledTimeMs: 4 * hourMs },
-      ],
-      unconfirmedExecutions: [],
+      skippedExecutions: [{ scheduledTimeMs: 3 * hourMs }],
+      unconfirmedExecutions: [{ scheduledTimeMs: 4 * hourMs }],
     });
   });
 

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/get-schedule-execution-gaps.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/helpers/get-schedule-execution-gaps.ts
@@ -1,3 +1,4 @@
+import { SKIPPED_INFERENCE_VISIBILITY_BUFFER_MS } from '../use-schedule-runs-chart-data.constants';
 import {
   type GetScheduleExecutionGapsParams,
   type ScheduleExecutionGaps,
@@ -46,11 +47,15 @@ export default function getScheduleExecutionGaps({
   // A slot due after our last successful fetch may already have a real run
   // that just hasn't shown up yet (visibility indexing/poll lag), so it's
   // reported as unconfirmed until a later fetch confirms it either way. With no
-  // fetch to anchor on at all, nothing is confirmed.
+  // fetch to anchor on at all, nothing is confirmed. A short buffer before the
+  // fetch timestamp keeps near-boundary slots unconfirmed instead of skipped.
   const knownEndMs =
     lastFetchedAtMs == null
       ? knownStartMs - 1
-      : Math.min(trustworthyEndMs, lastFetchedAtMs);
+      : Math.min(
+          trustworthyEndMs,
+          lastFetchedAtMs - SKIPPED_INFERENCE_VISIBILITY_BUFFER_MS
+        );
 
   const coveredTimesMs = new Set([
     ...actualTimesMs,
@@ -69,9 +74,13 @@ export default function getScheduleExecutionGaps({
       continue;
     }
 
+    if (coveredTimesMs.has(scheduledTimeMs)) {
+      continue;
+    }
+
     if (scheduledTimeMs > knownEndMs) {
       unconfirmedExecutions.push({ scheduledTimeMs });
-    } else if (!coveredTimesMs.has(scheduledTimeMs)) {
+    } else {
       skippedExecutions.push({ scheduledTimeMs });
     }
   }

--- a/src/views/schedule-details/hooks/use-schedule-runs-chart-data/use-schedule-runs-chart-data.constants.ts
+++ b/src/views/schedule-details/hooks/use-schedule-runs-chart-data/use-schedule-runs-chart-data.constants.ts
@@ -16,3 +16,10 @@ export const CHART_WORKFLOWS_REFRESH_INTERVAL_MS = 60_000;
 
 /** Upper bound on cron occurrences walked when inferring skipped/unconfirmed slots. */
 export const MAX_SCHEDULE_CRON_OCCURRENCES = 10_000;
+
+/**
+ * Slots due within this window before the last runs fetch are treated as
+ * unconfirmed rather than skipped, so visibility indexing lag does not surface
+ * a false skipped marker for a run that has not appeared in the response yet.
+ */
+export const SKIPPED_INFERENCE_VISIBILITY_BUFFER_MS = 2_000;


### PR DESCRIPTION
## Summary

Schedule runs chart gap inference now treats slots within two seconds of the last workflows fetch as unconfirmed instead of skipped, so visibility indexing lag does not show a false skipped marker for a run that has not appeared in the response yet.

## Changes

- Added `SKIPPED_INFERENCE_VISIBILITY_BUFFER_MS` (2 seconds) to the schedule runs chart constants.
- Applied the buffer when computing `knownEndMs` in `getScheduleExecutionGaps`, and skip covered runs before classifying gaps so confirmed runs in the buffer window are not marked unconfirmed.
- Extended unit tests for the buffer boundary and updated expectations where the fetch timestamp aligns with an hourly slot.

## Testing

- `npm run typecheck`
- `npm run test`
- `npm run test:unit:browser get-schedule-execution-gaps.test.ts`
- `npx eslint` on changed files (full-repo `npm run lint` reports pre-existing unresolved `@/__generated__` import paths in this worktree environment)
- Manual UI verification on schedule details runs chart (`/domains/default/cluster0/schedules/ea08957e-b045-4ac9-b517-562f1821d0ec/details`): recent slots at 00:44 and 00:45 render as loading/unconfirmed markers, not skipped.

![runs-chart-unconfirmed-slot.png](https://github.com/cadence-workflow/cadence-web/blob/aa386a195c69074fc6f9841ec5ff8cf312202913/runs-chart-unconfirmed-slot.png?raw=true)
