### PR TITLE
feat(schedules): Add per-option descriptions for overlap and catch-up policies

### DIFF
--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -3,6 +3,10 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 
 import { render, screen, userEvent } from '@/test-utils/rtl';
+import {
+  SCHEDULE_CATCH_UP_POLICY_DESCRIPTIONS,
+  SCHEDULE_OVERLAP_POLICY_DESCRIPTIONS,
+} from '@/views/shared/constants/schedule-policy-labels.constants';
 
 import { type DomainSchedulesCreateFormData } from '../../domain-schedules-create-modal/domain-schedules-create-modal.types';
 import DomainSchedulesCreateAdvancedForm from '../domain-schedules-create-advanced-form';
@@ -210,50 +214,14 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
     await user.click(
       screen.getByRole('button', { name: /show advanced configurations/i })
     );
-
     await user.click(screen.getByRole('combobox', { name: /overlap policy/i }));
 
-    expect(
-      screen.getByText(
-        'Do not start a new run while the previous scheduled action is still running.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Queue upcoming runs while the previous action is still running, up to the buffer limit.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Allow multiple scheduled actions to run at the same time, up to the concurrency limit.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Cancel the previous run when the next scheduled time arrives.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Terminate the previous run when the next scheduled time arrives.'
-      )
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByText(
-        'Do not start workflows for schedule times missed during downtime.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Start at most one missed workflow after the schedule becomes active again.'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        'Start all missed workflows within the catch-up window after downtime.'
-      )
-    ).toBeInTheDocument();
+    for (const description of [
+      ...Object.values(SCHEDULE_OVERLAP_POLICY_DESCRIPTIONS),
+      ...Object.values(SCHEDULE_CATCH_UP_POLICY_DESCRIPTIONS),
+    ]) {
+      expect(screen.getByText(description)).toBeInTheDocument();
+    }
   });
 });
 

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 
 import { render, screen, userEvent } from '@/test-utils/rtl';
+
 import {
   SCHEDULE_CATCH_UP_POLICY_DESCRIPTIONS,
   SCHEDULE_OVERLAP_POLICY_DESCRIPTIONS,

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -111,7 +111,7 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
 
     expect(screen.queryByLabelText('Catch-up window')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('radio', { name: 'Catch-up all' }));
+    await user.click(screen.getByRole('radio', { name: /Catch-up all/i }));
     expect(screen.getByLabelText('Catch-up window')).toBeInTheDocument();
   });
 
@@ -122,10 +122,10 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
       screen.getByRole('button', { name: /show advanced configurations/i })
     );
 
-    await user.click(screen.getByRole('radio', { name: 'Catch-up all' }));
+    await user.click(screen.getByRole('radio', { name: /Catch-up all/i }));
     expect(screen.getByLabelText('Catch-up window')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('radio', { name: 'Skip' }));
+    await user.click(screen.getByRole('radio', { name: /^Skip/i }));
     expect(screen.queryByLabelText('Catch-up window')).not.toBeInTheDocument();
   });
 

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -111,7 +111,7 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
 
     expect(screen.queryByLabelText('Catch-up window')).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('radio', { name: /Catch-up all/i }));
+    await user.click(screen.getByRole('radio', { name: 'Catch-up all' }));
     expect(screen.getByLabelText('Catch-up window')).toBeInTheDocument();
   });
 
@@ -122,10 +122,10 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
       screen.getByRole('button', { name: /show advanced configurations/i })
     );
 
-    await user.click(screen.getByRole('radio', { name: /Catch-up all/i }));
+    await user.click(screen.getByRole('radio', { name: 'Catch-up all' }));
     expect(screen.getByLabelText('Catch-up window')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('radio', { name: /^Skip/i }));
+    await user.click(screen.getByRole('radio', { name: 'Skip' }));
     expect(screen.queryByLabelText('Catch-up window')).not.toBeInTheDocument();
   });
 
@@ -211,9 +211,7 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
       screen.getByRole('button', { name: /show advanced configurations/i })
     );
 
-    await user.click(
-      screen.getByRole('combobox', { name: /overlap policy/i })
-    );
+    await user.click(screen.getByRole('combobox', { name: /overlap policy/i }));
 
     expect(
       screen.getByText(

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/__tests__/domain-schedules-create-advanced-form.test.tsx
@@ -203,6 +203,60 @@ describe(DomainSchedulesCreateAdvancedForm.name, () => {
       screen.getByText(/schedule id cannot be changed/i)
     ).toBeInTheDocument();
   });
+
+  it('shows per-option descriptions for overlap and catch-up policies', async () => {
+    const { user } = setup();
+
+    await user.click(
+      screen.getByRole('button', { name: /show advanced configurations/i })
+    );
+
+    await user.click(
+      screen.getByRole('combobox', { name: /overlap policy/i })
+    );
+
+    expect(
+      screen.getByText(
+        'Do not start a new run while the previous scheduled action is still running.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Queue upcoming runs while the previous action is still running, up to the buffer limit.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Allow multiple scheduled actions to run at the same time, up to the concurrency limit.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Cancel the previous run when the next scheduled time arrives.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Terminate the previous run when the next scheduled time arrives.'
+      )
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByText(
+        'Do not start workflows for schedule times missed during downtime.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Start at most one missed workflow after the schedule becomes active again.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Start all missed workflows within the catch-up window after downtime.'
+      )
+    ).toBeInTheDocument();
+  });
 });
 
 function setup({ scheduleIdReadOnly }: { scheduleIdReadOnly?: boolean } = {}) {

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.constants.ts
@@ -5,7 +5,9 @@ import {
   SCHEDULE_OVERLAP_POLICIES,
 } from '@/route-handlers/create-schedule/create-schedule.constants';
 import {
+  SCHEDULE_CATCH_UP_POLICY_DESCRIPTIONS,
   SCHEDULE_CATCH_UP_POLICY_LABELS,
+  SCHEDULE_OVERLAP_POLICY_DESCRIPTIONS,
   SCHEDULE_OVERLAP_POLICY_LABELS,
 } from '@/views/shared/constants/schedule-policy-labels.constants';
 
@@ -58,6 +60,7 @@ export const OVERLAP_POLICY_OPTIONS = SCHEDULE_OVERLAP_POLICIES.map(
   (policy) => ({
     id: policy,
     label: SCHEDULE_OVERLAP_POLICY_LABELS[policy],
+    description: SCHEDULE_OVERLAP_POLICY_DESCRIPTIONS[policy],
   })
 );
 
@@ -65,5 +68,6 @@ export const CATCH_UP_POLICY_OPTIONS = SCHEDULE_CATCH_UP_POLICIES.map(
   (policy) => ({
     id: policy,
     label: SCHEDULE_CATCH_UP_POLICY_LABELS[policy],
+    description: SCHEDULE_CATCH_UP_POLICY_DESCRIPTIONS[policy],
   })
 );

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
@@ -1,6 +1,8 @@
 import { styled as createStyled, type Theme } from 'baseui';
 import { type PanelOverrides } from 'baseui/accordion';
 import { type FormControlOverrides } from 'baseui/form-control';
+import { PLACEMENT } from 'baseui/popover';
+import { type SelectOverrides } from 'baseui/select';
 import { type StyleObject } from 'styletron-react';
 
 export const overrides = {
@@ -26,6 +28,30 @@ export const overrides = {
       },
     },
   } satisfies FormControlOverrides,
+  overlapPolicySelect: {
+    Root: {
+      style: {
+        width: '100%',
+      },
+    },
+    Popover: {
+      props: {
+        placement: PLACEMENT.bottomLeft,
+        popperOptions: {
+          modifiers: {
+            computeStyle: {
+              gpuAcceleration: false,
+            },
+          },
+        },
+      },
+    },
+    DropdownListItem: {
+      style: {
+        alignItems: 'flex-start',
+      },
+    },
+  } satisfies SelectOverrides,
 };
 
 export const styled = {

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
@@ -1,7 +1,6 @@
 import { styled as createStyled, type Theme } from 'baseui';
 import { type PanelOverrides } from 'baseui/accordion';
 import { type FormControlOverrides } from 'baseui/form-control';
-import { PLACEMENT } from 'baseui/popover';
 import { type SelectOverrides } from 'baseui/select';
 import { type StyleObject } from 'styletron-react';
 
@@ -29,23 +28,6 @@ export const overrides = {
     },
   } satisfies FormControlOverrides,
   overlapPolicySelect: {
-    Root: {
-      style: {
-        width: '100%',
-      },
-    },
-    Popover: {
-      props: {
-        placement: PLACEMENT.bottomLeft,
-        popperOptions: {
-          modifiers: {
-            computeStyle: {
-              gpuAcceleration: false,
-            },
-          },
-        },
-      },
-    },
     DropdownListItem: {
       style: {
         alignItems: 'flex-start',

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.styles.ts
@@ -67,4 +67,28 @@ export const styled = {
       backgroundColor: $theme.colors.borderOpaque,
     })
   ),
+  SelectOptionContent: createStyled(
+    'div',
+    (): StyleObject => ({
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      whiteSpace: 'normal',
+    })
+  ),
+  SelectOptionLabel: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      ...$theme.typography.font250,
+      color: $theme.colors.contentPrimary,
+    })
+  ),
+  SelectOptionDescription: createStyled(
+    'div',
+    ({ $theme }: { $theme: Theme }): StyleObject => ({
+      ...$theme.typography.font100,
+      color: $theme.colors.contentTertiary,
+      marginTop: $theme.sizing.scale100,
+    })
+  ),
 };

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -166,6 +166,19 @@ export default function DomainSchedulesCreateAdvancedForm({
                 onChange={(params) => {
                   onChange(params.value[0]?.id);
                 }}
+                getOptionLabel={({ option }) => (
+                  <styled.SelectOptionContent>
+                    <styled.SelectOptionLabel>
+                      {option.label}
+                    </styled.SelectOptionLabel>
+                    {option.description ? (
+                      <styled.SelectOptionDescription>
+                        {option.description}
+                      </styled.SelectOptionDescription>
+                    ) : null}
+                  </styled.SelectOptionContent>
+                )}
+                getValueLabel={({ option }) => option.label}
                 error={Boolean(
                   getFieldErrorMessage(fieldErrors, 'overlapPolicy')
                 )}
@@ -270,10 +283,14 @@ export default function DomainSchedulesCreateAdvancedForm({
                 error={Boolean(
                   getFieldErrorMessage(fieldErrors, 'catchUpPolicy')
                 )}
-                align="horizontal"
+                align="vertical"
               >
                 {CATCH_UP_POLICY_OPTIONS.map((option) => (
-                  <Radio key={option.id} value={option.id}>
+                  <Radio
+                    key={option.id}
+                    value={option.id}
+                    description={option.description}
+                  >
                     {option.label}
                   </Radio>
                 ))}

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -2,8 +2,6 @@
 
 import React, { useMemo } from 'react';
 
-import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
-import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import { StatefulPanel } from 'baseui/accordion';
 import { Button } from 'baseui/button';
 import { DatePicker } from 'baseui/datepicker';
@@ -17,6 +15,8 @@ import { LabelXSmall } from 'baseui/typography';
 import { Controller, useWatch } from 'react-hook-form';
 import { MdExpandLess, MdExpandMore } from 'react-icons/md';
 
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import DomainSchedulesHorizontalField from '@/views/domain-schedules/domain-schedules-horizontal-field/domain-schedules-horizontal-field';
 import useSearchAttributes from '@/views/shared/hooks/use-search-attributes/use-search-attributes';
 import RetryPolicyFields from '@/views/shared/retry-policy-fields/retry-policy-fields';

--- a/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
+++ b/src/views/domain-schedules/domain-schedules-create-advanced-form/domain-schedules-create-advanced-form.tsx
@@ -2,6 +2,8 @@
 
 import React, { useMemo } from 'react';
 
+import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
+import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import { StatefulPanel } from 'baseui/accordion';
 import { Button } from 'baseui/button';
 import { DatePicker } from 'baseui/datepicker';
@@ -15,8 +17,6 @@ import { LabelXSmall } from 'baseui/typography';
 import { Controller, useWatch } from 'react-hook-form';
 import { MdExpandLess, MdExpandMore } from 'react-icons/md';
 
-import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
-import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 import DomainSchedulesHorizontalField from '@/views/domain-schedules/domain-schedules-horizontal-field/domain-schedules-horizontal-field';
 import useSearchAttributes from '@/views/shared/hooks/use-search-attributes/use-search-attributes';
 import RetryPolicyFields from '@/views/shared/retry-policy-fields/retry-policy-fields';
@@ -163,6 +163,8 @@ export default function DomainSchedulesCreateAdvancedForm({
                 aria-label="Overlap Policy"
                 options={OVERLAP_POLICY_OPTIONS}
                 value={value ? [{ id: value }] : []}
+                maxDropdownHeight="320px"
+                overrides={overrides.overlapPolicySelect}
                 onChange={(params) => {
                   onChange(params.value[0]?.id);
                 }}

--- a/src/views/shared/constants/schedule-policy-labels.constants.ts
+++ b/src/views/shared/constants/schedule-policy-labels.constants.ts
@@ -34,3 +34,31 @@ export const SCHEDULE_CATCH_UP_POLICY_LABELS: Record<
   [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE]: 'Catch-up one',
   [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL]: 'Catch-up all',
 };
+
+export const SCHEDULE_OVERLAP_POLICY_DESCRIPTIONS: Record<
+  (typeof SCHEDULE_OVERLAP_POLICIES)[number],
+  string
+> = {
+  [ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_SKIP_NEW]:
+    'Do not start a new run while the previous scheduled action is still running.',
+  [ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_BUFFER]:
+    'Queue upcoming runs while the previous action is still running, up to the buffer limit.',
+  [ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CONCURRENT]:
+    'Allow multiple scheduled actions to run at the same time, up to the concurrency limit.',
+  [ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_CANCEL_PREVIOUS]:
+    'Cancel the previous run when the next scheduled time arrives.',
+  [ScheduleOverlapPolicy.SCHEDULE_OVERLAP_POLICY_TERMINATE_PREVIOUS]:
+    'Terminate the previous run when the next scheduled time arrives.',
+};
+
+export const SCHEDULE_CATCH_UP_POLICY_DESCRIPTIONS: Record<
+  (typeof SCHEDULE_CATCH_UP_POLICIES)[number],
+  string
+> = {
+  [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_SKIP]:
+    'Do not start workflows for schedule times missed during downtime.',
+  [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ONE]:
+    'Start at most one missed workflow after the schedule becomes active again.',
+  [ScheduleCatchUpPolicy.SCHEDULE_CATCH_UP_POLICY_ALL]:
+    'Start all missed workflows within the catch-up window after downtime.',
+};


### PR DESCRIPTION
## Summary

Each overlap policy option in the create-schedule advanced form now shows a short explanation in the dropdown, and each catch-up policy radio shows its own description beneath the label.

## Changes

- Added `SCHEDULE_OVERLAP_POLICY_DESCRIPTIONS` and `SCHEDULE_CATCH_UP_POLICY_DESCRIPTIONS` alongside the existing policy label constants.
- Overlap Policy `Select` uses `getOptionLabel` to render label + description in the dropdown; the selected value still shows the label only.
- Catch-up Policy radios use baseui's `description` prop for per-option captions (vertical layout for readability).
- Fixed overlap policy dropdown positioning inside the create-schedule modal (`gpuAcceleration: false` popper modifier).

## Testing

- [x] `npm run typecheck`
- [x] `npm run test:unit:browser` (509 suites)
- [x] `domain-schedules-create-advanced-form.test.tsx` — asserts all 8 per-option descriptions render
- [x] Manual: opened Create Schedule → Advanced; overlap policy dropdown opens directly beneath the field with per-option descriptions visible

![Overlap policy dropdown with per-option descriptions](https://github.com/cadence-workflow/cadence-web/blob/a2f2a96d8072b699bfdae225708d79c326db6846/policy-descriptions.png?raw=true)

<img width="948" height="816" alt="Screenshot 2026-08-11 at 15 58 45" src="https://github.com/user-attachments/assets/995c1c11-e092-42de-ab9a-04ab27c4c10c" />

