### PR TITLE
fix(describe-workflow): Make Run ID an optional parameter

### DIFF
--- a/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/route.ts
+++ b/src/app/api/domains/[domain]/[cluster]/workflows/[workflowId]/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import describeWorkflow from '@/route-handlers/describe-workflow/describe-workflow';
+import { type RouteParams } from '@/route-handlers/describe-workflow/describe-workflow.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function GET(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    describeWorkflow,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/route-handlers/describe-workflow/__fixtures__/describe-workflow-grpc-responses.ts
+++ b/src/route-handlers/describe-workflow/__fixtures__/describe-workflow-grpc-responses.ts
@@ -1,0 +1,174 @@
+import { type DescribeWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeWorkflowExecutionResponse';
+import { type GetWorkflowExecutionHistoryResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/GetWorkflowExecutionHistoryResponse';
+import { type WorkflowExecutionStartedEventAttributes } from '@/__generated__/proto-ts/uber/cadence/api/v1/WorkflowExecutionStartedEventAttributes';
+
+export const mockDescribeWorkflowOpenResponse: DescribeWorkflowExecutionResponse =
+  {
+    executionConfiguration: {
+      taskList: {
+        name: 'mock-tasklist',
+        kind: 'TASK_LIST_KIND_INVALID',
+        baseName: '',
+      },
+      executionStartToCloseTimeout: { seconds: '86400', nanos: 0 },
+      taskStartToCloseTimeout: { seconds: '10', nanos: 0 },
+    },
+    workflowExecutionInfo: {
+      workflowExecution: {
+        workflowId: 'mock-wfid',
+        runId: 'mock-runid',
+      },
+      type: { name: 'mock-workflow-type' },
+      startTime: { seconds: '1717408148', nanos: 0 },
+      closeTime: null,
+      closeStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID',
+      historyLength: '5',
+      parentExecutionInfo: null,
+      executionTime: { seconds: '1717408150', nanos: 0 },
+      memo: null,
+      searchAttributes: null,
+      autoResetPoints: null,
+      taskList: 'mock-tasklist',
+      isCron: false,
+      updateTime: { seconds: '1717408200', nanos: 0 },
+      partitionConfig: {},
+      taskListInfo: null,
+      activeClusterSelectionPolicy: null,
+      cronOverlapPolicy: 'CRON_OVERLAP_POLICY_INVALID',
+      cronSchedule: '',
+      executionStatus: 'WORKFLOW_EXECUTION_STATUS_INVALID',
+      scheduledExecutionTime: null,
+    },
+    pendingActivities: [],
+    pendingChildren: [],
+    pendingDecision: null,
+  };
+
+export const mockDescribeWorkflowClosedResponse: DescribeWorkflowExecutionResponse =
+  {
+    ...mockDescribeWorkflowOpenResponse,
+    workflowExecutionInfo: {
+      ...mockDescribeWorkflowOpenResponse.workflowExecutionInfo!,
+      closeTime: { seconds: '1717409148', nanos: 0 },
+      closeStatus: 'WORKFLOW_EXECUTION_CLOSE_STATUS_COMPLETED',
+      historyLength: '42',
+    },
+  };
+
+// What the backend returns when the caller omits runId: it resolves the request
+// to the workflow's current run, which is a different run to MOCK_RUN_ID.
+export const MOCK_CURRENT_RUN_ID = 'mock-current-runid';
+
+export const mockDescribeWorkflowClosedCurrentRunResponse: DescribeWorkflowExecutionResponse =
+  {
+    ...mockDescribeWorkflowClosedResponse,
+    workflowExecutionInfo: {
+      ...mockDescribeWorkflowClosedResponse.workflowExecutionInfo!,
+      workflowExecution: {
+        workflowId: 'mock-wfid',
+        runId: MOCK_CURRENT_RUN_ID,
+      },
+    },
+  };
+
+export const MOCK_ORIGINAL_EXECUTION_RUN_ID = 'mock-original-execution-runid';
+
+// A closed workflow whose describe data carries no execution to resolve a run
+// from, forcing the close event lookup back onto the requested runId.
+export const mockDescribeWorkflowClosedWithoutExecutionResponse: DescribeWorkflowExecutionResponse =
+  {
+    ...mockDescribeWorkflowClosedResponse,
+    workflowExecutionInfo: {
+      ...mockDescribeWorkflowClosedResponse.workflowExecutionInfo!,
+      workflowExecution: null,
+    },
+  };
+
+const startedEventAttributes: WorkflowExecutionStartedEventAttributes = {
+  workflowType: { name: 'mock-workflow-type' },
+  parentExecutionInfo: null,
+  taskList: {
+    name: 'mock-tasklist',
+    kind: 'TASK_LIST_KIND_INVALID',
+    baseName: '',
+  },
+  input: null,
+  executionStartToCloseTimeout: { seconds: '86400', nanos: 0 },
+  taskStartToCloseTimeout: { seconds: '10', nanos: 0 },
+  continuedExecutionRunId: '',
+  initiator: 'CONTINUE_AS_NEW_INITIATOR_INVALID',
+  continuedFailure: null,
+  lastCompletionResult: null,
+  originalExecutionRunId: MOCK_ORIGINAL_EXECUTION_RUN_ID,
+  identity: '',
+  firstExecutionRunId: '',
+  retryPolicy: null,
+  attempt: 0,
+  expirationTime: null,
+  cronSchedule: '',
+  firstDecisionTaskBackoff: null,
+  memo: null,
+  searchAttributes: null,
+  prevAutoResetPoints: null,
+  header: null,
+  firstScheduledTime: null,
+  partitionConfig: {},
+  requestId: '',
+  cronOverlapPolicy: 'CRON_OVERLAP_POLICY_INVALID',
+  activeClusterSelectionPolicy: null,
+};
+
+// First page of history for a workflow whose describe data is unavailable —
+// drives the archived-workflow fallback.
+export const mockStartedEventHistory: GetWorkflowExecutionHistoryResponse = {
+  history: {
+    events: [
+      {
+        eventId: '1',
+        eventTime: { seconds: '1717408148', nanos: 0 },
+        version: '0',
+        taskId: '0',
+        attributes: 'workflowExecutionStartedEventAttributes',
+        workflowExecutionStartedEventAttributes: startedEventAttributes,
+      },
+    ],
+  },
+  archived: true,
+  rawHistory: [],
+  nextPageToken: '',
+};
+
+export const mockCloseEventHistory: GetWorkflowExecutionHistoryResponse = {
+  history: {
+    events: [
+      {
+        eventId: '42',
+        eventTime: { seconds: '1717409148', nanos: 0 },
+        version: '0',
+        taskId: '0',
+        attributes: 'workflowExecutionCompletedEventAttributes',
+        workflowExecutionCompletedEventAttributes: {
+          result: null,
+          decisionTaskCompletedEventId: '41',
+        },
+      },
+    ],
+  },
+  archived: false,
+  rawHistory: [],
+  nextPageToken: '',
+};
+
+export const mockEmptyHistory: GetWorkflowExecutionHistoryResponse = {
+  history: { events: [] },
+  archived: false,
+  rawHistory: [],
+  nextPageToken: '',
+};
+
+export const mockNullHistory: GetWorkflowExecutionHistoryResponse = {
+  history: null,
+  archived: false,
+  rawHistory: [],
+  nextPageToken: '',
+};

--- a/src/route-handlers/describe-workflow/__tests__/describe-workflow.node.ts
+++ b/src/route-handlers/describe-workflow/__tests__/describe-workflow.node.ts
@@ -1,0 +1,303 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+
+import { type DescribeWorkflowExecutionResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/DescribeWorkflowExecutionResponse';
+import { type GetWorkflowExecutionHistoryResponse } from '@/__generated__/proto-ts/uber/cadence/api/v1/GetWorkflowExecutionHistoryResponse';
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+
+import {
+  MOCK_CURRENT_RUN_ID,
+  MOCK_ORIGINAL_EXECUTION_RUN_ID,
+  mockCloseEventHistory,
+  mockDescribeWorkflowClosedCurrentRunResponse,
+  mockDescribeWorkflowClosedResponse,
+  mockDescribeWorkflowClosedWithoutExecutionResponse,
+  mockDescribeWorkflowOpenResponse,
+  mockEmptyHistory,
+  mockNullHistory,
+  mockStartedEventHistory,
+} from '../__fixtures__/describe-workflow-grpc-responses';
+import describeWorkflow from '../describe-workflow';
+import { type Context } from '../describe-workflow.types';
+
+jest.mock('@/utils/logger');
+
+const notFoundError = () =>
+  new GRPCError('Workflow execution not found', {
+    grpcStatusCode: status.NOT_FOUND,
+  });
+
+describe(describeWorkflow.name, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('describes an open workflow without looking up a close event', async () => {
+    const { res, mockDescribeWorkflow, mockGetHistory } = await setup({
+      describeResponse: mockDescribeWorkflowOpenResponse,
+    });
+
+    expect(mockDescribeWorkflow).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      workflowExecution: {
+        workflowId: 'mock-wfid',
+        runId: 'mock-runid',
+      },
+    });
+    expect(mockGetHistory).not.toHaveBeenCalled();
+
+    expect(res.status).toEqual(200);
+    const responseJson = await res.json();
+    expect(responseJson.workflowExecutionInfo).toEqual(
+      expect.objectContaining({ isArchived: false, closeEvent: null })
+    );
+  });
+
+  it('attaches the close event when the workflow is closed', async () => {
+    const { res, mockGetHistory } = await setup({
+      describeResponse: mockDescribeWorkflowClosedResponse,
+      historyResponse: mockCloseEventHistory,
+    });
+
+    expect(mockGetHistory).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      workflowExecution: {
+        workflowId: 'mock-wfid',
+        runId: 'mock-runid',
+      },
+      historyEventFilterType: 'EVENT_FILTER_TYPE_CLOSE_EVENT',
+    });
+
+    const responseJson = await res.json();
+    expect(responseJson.workflowExecutionInfo).toEqual(
+      expect.objectContaining({
+        isArchived: false,
+        closeEvent: mockCloseEventHistory.history?.events?.[0],
+      })
+    );
+  });
+
+  it('describes the current run when the runId param is omitted', async () => {
+    const { res, mockDescribeWorkflow } = await setup({
+      omitRunId: true,
+      describeResponse: mockDescribeWorkflowOpenResponse,
+    });
+
+    expect(mockDescribeWorkflow).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      workflowExecution: {
+        workflowId: 'mock-wfid',
+        runId: undefined,
+      },
+    });
+    expect(res.status).toEqual(200);
+  });
+
+  it('pins the close event lookup to the run resolved by describeWorkflow when the runId param is omitted', async () => {
+    const { mockGetHistory } = await setup({
+      omitRunId: true,
+      describeResponse: mockDescribeWorkflowClosedCurrentRunResponse,
+      historyResponse: mockCloseEventHistory,
+    });
+
+    expect(mockGetHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowExecution: {
+          workflowId: 'mock-wfid',
+          runId: MOCK_CURRENT_RUN_ID,
+        },
+      })
+    );
+  });
+
+  it('falls back to the requested runId for the close event lookup when describeWorkflow returns no execution', async () => {
+    const { mockGetHistory } = await setup({
+      describeResponse: mockDescribeWorkflowClosedWithoutExecutionResponse,
+      historyResponse: mockCloseEventHistory,
+    });
+
+    expect(mockGetHistory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workflowExecution: {
+          workflowId: 'mock-wfid',
+          runId: 'mock-runid',
+        },
+      })
+    );
+  });
+
+  it('falls back to history when describeWorkflow data is unavailable', async () => {
+    const { res, mockGetHistory } = await setup({
+      describeError: notFoundError(),
+      historyResponse: mockStartedEventHistory,
+    });
+
+    expect(mockGetHistory).toHaveBeenCalledWith({
+      domain: 'mock-domain',
+      workflowExecution: {
+        workflowId: 'mock-wfid',
+        runId: 'mock-runid',
+      },
+      pageSize: 1,
+    });
+
+    expect(res.status).toEqual(200);
+    const responseJson = await res.json();
+    expect(responseJson.workflowExecutionInfo).toEqual(
+      expect.objectContaining({
+        isArchived: true,
+        workflowExecution: {
+          workflowId: 'mock-wfid',
+          runId: 'mock-runid',
+        },
+        type: { name: 'mock-workflow-type' },
+      })
+    );
+  });
+
+  it('reports the started event run in the archived fallback when the runId param is omitted', async () => {
+    const { res } = await setup({
+      omitRunId: true,
+      describeError: notFoundError(),
+      historyResponse: mockStartedEventHistory,
+    });
+
+    const responseJson = await res.json();
+    expect(responseJson.workflowExecutionInfo.workflowExecution).toEqual({
+      workflowId: 'mock-wfid',
+      runId: MOCK_ORIGINAL_EXECUTION_RUN_ID,
+    });
+  });
+
+  it('returns 404 when neither describeWorkflow nor history have the workflow', async () => {
+    const { res } = await setup({
+      describeError: notFoundError(),
+      historyError: notFoundError(),
+    });
+
+    expect(res.status).toEqual(404);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Requested workflow history not found',
+      })
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when history has no started event to build an archived response from', async () => {
+    const { res } = await setup({
+      describeError: notFoundError(),
+      historyResponse: mockEmptyHistory,
+    });
+
+    expect(res.status).toEqual(404);
+  });
+
+  it('returns 404 when the archived history response has no history at all', async () => {
+    const { res } = await setup({
+      describeError: notFoundError(),
+      historyResponse: mockNullHistory,
+    });
+
+    expect(res.status).toEqual(404);
+  });
+
+  it('treats an unconfigured archive as 404', async () => {
+    const { res } = await setup({
+      describeError: notFoundError(),
+      historyError: new GRPCError(
+        'Requested workflow history not found, may have passed retention period.',
+        { grpcStatusCode: status.INVALID_ARGUMENT }
+      ),
+    });
+
+    expect(res.status).toEqual(404);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Requested workflow history not found',
+      })
+    );
+  });
+
+  it('does not attempt the archived fallback for non-404 backend errors', async () => {
+    const { res, mockGetHistory } = await setup({
+      describeError: new GRPCError('Cluster is unavailable', {
+        grpcStatusCode: status.UNAVAILABLE,
+      }),
+    });
+
+    expect(mockGetHistory).not.toHaveBeenCalled();
+
+    expect(res.status).toEqual(503);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({ message: 'Cluster is unavailable' })
+    );
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('returns 500 for unexpected errors', async () => {
+    const { res } = await setup({
+      describeError: new Error('something went wrong'),
+      historyResponse: mockEmptyHistory,
+    });
+
+    expect(res.status).toEqual(500);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual(
+      expect.objectContaining({
+        message: 'Error fetching workflow execution info',
+      })
+    );
+    expect(logger.error).toHaveBeenCalled();
+  });
+});
+
+async function setup({
+  omitRunId,
+  describeResponse,
+  describeError,
+  historyResponse,
+  historyError,
+}: {
+  omitRunId?: boolean;
+  describeResponse?: DescribeWorkflowExecutionResponse;
+  describeError?: Error;
+  historyResponse?: GetWorkflowExecutionHistoryResponse;
+  historyError?: Error;
+}) {
+  const mockDescribeWorkflow = jest
+    .spyOn(mockGrpcClusterMethods, 'describeWorkflow')
+    .mockImplementation(async () => {
+      if (describeError) throw describeError;
+      return describeResponse ?? mockDescribeWorkflowOpenResponse;
+    });
+
+  const mockGetHistory = jest
+    .spyOn(mockGrpcClusterMethods, 'getHistory')
+    .mockImplementation(async () => {
+      if (historyError) throw historyError;
+      return historyResponse ?? mockEmptyHistory;
+    });
+
+  const res = await describeWorkflow(
+    new NextRequest('http://localhost', { method: 'GET' }),
+    {
+      params: {
+        domain: 'mock-domain',
+        cluster: 'mock-cluster',
+        workflowId: 'mock-wfid',
+        runId: omitRunId ? undefined : 'mock-runid',
+      },
+    },
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockDescribeWorkflow, mockGetHistory };
+}

--- a/src/route-handlers/describe-workflow/describe-workflow.ts
+++ b/src/route-handlers/describe-workflow/describe-workflow.ts
@@ -41,11 +41,18 @@ export default async function describeWorkflow(
       res.workflowExecutionInfo.closeStatus !==
         'WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID'
     ) {
+      // When runId is omitted the backend resolves it to the last run, so we pin
+      // the close event lookup to the run we just described rather than letting
+      // it resolve "last run" a second time.
+      const resolvedRunId =
+        describeWorkflowResponse.workflowExecutionInfo?.workflowExecution
+          ?.runId ?? params.runId;
+
       const closeEventResponse = await ctx.grpcClusterMethods.getHistory({
         domain: params.domain,
         workflowExecution: {
           workflowId: params.workflowId,
-          runId: params.runId,
+          runId: resolvedRunId,
         },
         historyEventFilterType: 'EVENT_FILTER_TYPE_CLOSE_EVENT',
       });
@@ -84,6 +91,7 @@ export default async function describeWorkflow(
           executionStartToCloseTimeout,
           taskStartToCloseTimeout,
           workflowType: type,
+          originalExecutionRunId,
         },
       } = archivedHistoryEvents[0];
 
@@ -95,7 +103,8 @@ export default async function describeWorkflow(
         },
         workflowExecutionInfo: {
           workflowExecution: {
-            runId: params.runId,
+            // Falls back to the started event's run when the caller omitted runId
+            runId: params.runId ?? originalExecutionRunId,
             workflowId: params.workflowId,
           },
           isArchived: true,

--- a/src/route-handlers/describe-workflow/describe-workflow.types.ts
+++ b/src/route-handlers/describe-workflow/describe-workflow.types.ts
@@ -7,7 +7,9 @@ export type RouteParams = {
   domain: string;
   cluster: string;
   workflowId: string;
-  runId: string;
+  // Omitted when describing via the run-less route, meaning "the current
+  // run of workflowId" per Cadence API semantics.
+  runId?: string;
 };
 
 export type RequestParams = {


### PR DESCRIPTION
Part of a fix for https://github.com/cadence-workflow/cadence-web/issues/36 and https://github.com/cadence-workflow/cadence/issues/8403.

## Summary
### Problem

Cadence lets you call `DescribeWorkflowExecution` without a run ID. When you omit it, the server returns the workflow's latest run.

The UI route handler does not allow this. It requires `runId` as a route param, and the only route is `.../workflows/:workflowId/:runId`. So a caller who knows just the workflow ID cannot describe it.

### Solution

- Make the `runId` parameter optional in the `describeWorkflow` route handler
- Add a second route without the run ID segment: `GET /api/domains/:domain/:cluster/workflows/:workflowId`

Both routes point at the same handler. This follows the pattern already used by `signal-workflow` in #1434.

## Test plan
Unit tests + invoked the new API route through `curl`.

### Command
`curl "http://localhost:8090/api/domains/cadence-samples/cluster0/workflows/helloworld_7d46bdd8-fcca-4899-a2b3-580616402a12"`

### Response
```
{"pendingActivities":[{"activityId":"0","activityType":{"name":"main.helloWorldActivity"},"state":"PENDING_ACTIVITY_STATE_SCHEDULED","heartbeatDetails":null,"lastHeartbeatTime":null,"lastStartedTime":null,"attempt":0,"maximumAttempts":0,"scheduledTime":{"seconds":"1786456698","nanos":717418793},"expirationTime":null,"lastFailure":null,"lastWorkerIdentity":"","startedWorkerIdentity":"","scheduleId":"5"}],"pendingChildren":[],"executionConfiguration":{"taskList":{"name":"helloWorldGroup","kind":"TASK_LIST_KIND_NORMAL","baseName":""},"executionStartToCloseTimeout":{"seconds":"300","nanos":0},"taskStartToCloseTimeout":{"seconds":"60","nanos":0}},"workflowExecutionInfo":{"partitionConfig":{},"workflowExecution":{"workflowId":"helloworld_7d46bdd8-fcca-4899-a2b3-580616402a12","runId":"563325a6-325b-4553-8954-dfeca29cbdb3"},"type":{"name":"helloWorldWorkflow"},"startTime":{"seconds":"1786456698","nanos":618000000},"closeTime":null,"closeStatus":"WORKFLOW_EXECUTION_CLOSE_STATUS_INVALID","historyLength":"5","parentExecutionInfo":null,"executionTime":{"seconds":"1786456698","nanos":618000000},"memo":{"fields":{}},"searchAttributes":{"indexedFields":{"BinaryChecksums":{"data":"WyI4MzkyMzEyYzZhNDhlOGNlNmNlYzAyMTExYmU0ODlmZiJd"}}},"autoResetPoints":{"points":[{"binaryChecksum":"8392312c6a48e8ce6cec02111be489ff","runId":"563325a6-325b-4553-8954-dfeca29cbdb3","firstDecisionCompletedId":"4","createdTime":{"seconds":"1786456698","nanos":717305959},"expiringTime":null,"resettable":true}]},"taskList":"helloWorldGroup","isCron":false,"updateTime":null,"cronOverlapPolicy":"CRON_OVERLAP_POLICY_SKIPPED","taskListInfo":{"name":"helloWorldGroup","kind":"TASK_LIST_KIND_NORMAL","baseName":""},"activeClusterSelectionPolicy":null,"cronSchedule":"","executionStatus":"WORKFLOW_EXECUTION_STATUS_INVALID","scheduledExecutionTime":null,"closeEvent":null,"isArchived":false},"pendingDecision":null}
```