### PR TITLE
feat: Allow redirecting to current run of workflow when Run ID is not available

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -28,13 +28,27 @@ const nextConfig = {
     }
     return config;
   },
+  /**
+   * Redirects are matched top-down; the first match wins.
+   *
+   * Some rules fill in a missing URL part by sending the request to a resolver
+   * page under /redirects, which looks up the value and redirects again.
+   *
+   * A missing cluster goes to /redirects/domain,
+   * and a missing run ID goes to /redirects/workflow.
+   *
+   * The tab names below are copied by hand from domain-page-tabs.config.ts and
+   * workflow-page-tabs.config.ts. Add new tabs here too, otherwise a cluster-less
+   * domain tab is read as a cluster name, and a workflow tab is read as a run ID,
+   * breaking URLs.
+   *
+   * TODO - load tabs configs here to dynamically define redirects.
+   */
   redirects: async () => {
-    // TODO - load tabs configs here to dynamically define redirects
     return [
       {
-        // This regex matches paths that try to load a domain or workflow without specifying the active cluster
         source:
-          '/domains/:path((?:[^/]+)(?:/(?:workflows|metadata|settings|archival|task-lists)(?:/.*)?)?)',
+          '/domains/:path((?:[^/]+)(?:/(?:workflows|schedules|cron-list|metadata|failovers|settings|archival|batch-actions|task-lists)(?:/.*)?)?)',
         destination: '/redirects/domain/:path',
         permanent: true,
       },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -44,6 +44,12 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source:
+          '/domains/:domain/:cluster/workflows/:workflowPath([^/]+(?:/(?:summary|history|queries|stack-trace|diagnostics))?)',
+        destination: '/redirects/workflow/:domain/:cluster/:workflowPath',
+        permanent: true,
+      },
+      {
         source: '/domains/:domain/:cluster/workflows/:workflowId/:runId',
         destination:
           '/domains/:domain/:cluster/workflows/:workflowId/:runId/summary',
@@ -51,8 +57,7 @@ const nextConfig = {
       },
       {
         source: '/domains/:domain/:cluster/schedules/:scheduleId',
-        destination:
-          '/domains/:domain/:cluster/schedules/:scheduleId/details',
+        destination: '/domains/:domain/:cluster/schedules/:scheduleId/details',
         permanent: true,
       },
     ];

--- a/src/app/(Home)/redirects/workflow/[...workflowParams]/error.tsx
+++ b/src/app/(Home)/redirects/workflow/[...workflowParams]/error.tsx
@@ -1,0 +1,4 @@
+'use client';
+import RedirectWorkflowError from '@/views/redirect-workflow/redirect-workflow-error/redirect-workflow-error';
+
+export default RedirectWorkflowError;

--- a/src/app/(Home)/redirects/workflow/[...workflowParams]/loading.tsx
+++ b/src/app/(Home)/redirects/workflow/[...workflowParams]/loading.tsx
@@ -1,0 +1,3 @@
+import SectionLoadingIndicator from '@/components/section-loading-indicator/section-loading-indicator';
+
+export default SectionLoadingIndicator;

--- a/src/app/(Home)/redirects/workflow/[...workflowParams]/not-found.tsx
+++ b/src/app/(Home)/redirects/workflow/[...workflowParams]/not-found.tsx
@@ -1,0 +1,3 @@
+import RedirectWorkflowNotFound from '@/views/redirect-workflow/redirect-workflow-not-found/redirect-workflow-not-found';
+
+export default RedirectWorkflowNotFound;

--- a/src/app/(Home)/redirects/workflow/[...workflowParams]/page.tsx
+++ b/src/app/(Home)/redirects/workflow/[...workflowParams]/page.tsx
@@ -1,0 +1,3 @@
+import RedirectWorkflow from '@/views/redirect-workflow/redirect-workflow';
+
+export default RedirectWorkflow;

--- a/src/views/redirect-workflow/__tests__/redirect-workflow.node.ts
+++ b/src/views/redirect-workflow/__tests__/redirect-workflow.node.ts
@@ -93,6 +93,10 @@ describe(RedirectWorkflow.name, () => {
           test.assertOnError?.(e);
         } else if (e instanceof Error && e.message === 'Redirected') {
           expect(mockRedirect).toHaveBeenCalledWith(test.expectedRedirect);
+        } else {
+          throw new Error(
+            `test failure: ${e instanceof Error ? e.message : 'unknown reason'}`
+          );
         }
       }
 

--- a/src/views/redirect-workflow/__tests__/redirect-workflow.node.ts
+++ b/src/views/redirect-workflow/__tests__/redirect-workflow.node.ts
@@ -1,0 +1,153 @@
+import { type DescribeWorkflowResponse } from '@/route-handlers/describe-workflow/describe-workflow.types';
+import request from '@/utils/request';
+import { RequestError } from '@/utils/request/request-error';
+
+import RedirectWorkflow from '../redirect-workflow';
+
+jest.mock('@/utils/request', () => jest.fn());
+
+const mockRequest = jest.mocked(request);
+
+const mockRedirect = jest.fn();
+jest.mock('next/navigation', () => ({
+  redirect: (url: string) => {
+    mockRedirect(url);
+    // Server component stops rendering after a redirect is called
+    throw new Error('Redirected');
+  },
+  notFound: () => {
+    // Server component stops rendering after notFound is called
+    throw new Error('Not found');
+  },
+}));
+
+function mockDescribeWorkflowResponse(runId: string | null) {
+  mockRequest.mockResolvedValue({
+    json: jest.fn().mockResolvedValue({
+      workflowExecutionInfo: {
+        workflowExecution: { runId },
+      },
+    } as Partial<DescribeWorkflowResponse>),
+  } as any);
+}
+
+describe(RedirectWorkflow.name, () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const tests: Array<{
+    name: string;
+    urlParams: Array<string>;
+    queryParams?: { [key: string]: string | string[] | undefined };
+    assertOnError?: (e: Error) => void;
+    expectedRedirect?: string;
+    expectedRequestUrl?: string;
+  }> = [
+    {
+      name: 'should redirect to the current run',
+      urlParams: ['mock-domain', 'mock-cluster', 'mock-wfid'],
+      expectedRedirect:
+        '/domains/mock-domain/mock-cluster/workflows/mock-wfid/mock-runid',
+      expectedRequestUrl:
+        '/api/domains/mock-domain/mock-cluster/workflows/mock-wfid',
+    },
+    {
+      name: 'should redirect to a specific tab of the current run',
+      urlParams: ['mock-domain', 'mock-cluster', 'mock-wfid', 'history'],
+      expectedRedirect:
+        '/domains/mock-domain/mock-cluster/workflows/mock-wfid/mock-runid/history',
+    },
+    {
+      name: 'should redirect with query params preserved',
+      urlParams: ['mock-domain', 'mock-cluster', 'mock-wfid', 'history'],
+      queryParams: {
+        hs: 'COMPLETED',
+        ht: 'ACTIVITY',
+      },
+      expectedRedirect:
+        '/domains/mock-domain/mock-cluster/workflows/mock-wfid/mock-runid/history?hs=COMPLETED&ht=ACTIVITY',
+    },
+    {
+      name: 'should encode special characters exactly once',
+      urlParams: ['mock domain', 'mock-cluster', 'mock/wfid@1'],
+      expectedRedirect:
+        '/domains/mock%20domain/mock-cluster/workflows/mock%2Fwfid%401/mock-runid',
+      expectedRequestUrl:
+        '/api/domains/mock%20domain/mock-cluster/workflows/mock%2Fwfid%401',
+    },
+  ];
+
+  tests.forEach((test) =>
+    it(test.name, async () => {
+      mockDescribeWorkflowResponse('mock-runid');
+
+      try {
+        await RedirectWorkflow({
+          params: { workflowParams: test.urlParams },
+          searchParams: test.queryParams ?? undefined,
+        });
+      } catch (e) {
+        if (e instanceof Error && e.message !== 'Redirected') {
+          expect(test.assertOnError).toBeDefined();
+          test.assertOnError?.(e);
+        } else if (e instanceof Error && e.message === 'Redirected') {
+          expect(mockRedirect).toHaveBeenCalledWith(test.expectedRedirect);
+        }
+      }
+
+      if (test.expectedRequestUrl) {
+        expect(mockRequest).toHaveBeenCalledWith(test.expectedRequestUrl);
+      }
+    })
+  );
+
+  it('should call notFound if the workflow is not found', async () => {
+    mockRequest.mockRejectedValue(
+      new RequestError('Not found', '/api/mock-url', 404)
+    );
+
+    await expect(
+      RedirectWorkflow({
+        params: {
+          workflowParams: ['mock-domain', 'mock-cluster', 'mock-wfid'],
+        },
+      })
+    ).rejects.toThrow('Not found');
+  });
+
+  it('should call notFound if the response has no runId', async () => {
+    mockDescribeWorkflowResponse(null);
+
+    await expect(
+      RedirectWorkflow({
+        params: {
+          workflowParams: ['mock-domain', 'mock-cluster', 'mock-wfid'],
+        },
+      })
+    ).rejects.toThrow('Not found');
+  });
+
+  it('should rethrow non-404 request errors', async () => {
+    mockRequest.mockRejectedValue(
+      new RequestError('Internal error', '/api/mock-url', 500)
+    );
+
+    await expect(
+      RedirectWorkflow({
+        params: {
+          workflowParams: ['mock-domain', 'mock-cluster', 'mock-wfid'],
+        },
+      })
+    ).rejects.toThrow('Internal error');
+  });
+
+  it('should throw if the workflow URL params are incomplete', async () => {
+    await expect(
+      RedirectWorkflow({
+        params: { workflowParams: ['mock-domain', 'mock-cluster'] },
+      })
+    ).rejects.toThrow('Invalid workflow URL param');
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/redirect-workflow/redirect-workflow-error/redirect-workflow-error.tsx
+++ b/src/views/redirect-workflow/redirect-workflow-error/redirect-workflow-error.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useParams } from 'next/navigation';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+
+import { type RouteParams } from '../redirect-workflow.types';
+
+import { type Props } from './redirect-workflow-error.types';
+
+export default function RedirectWorkflowError({ error }: Props) {
+  const { workflowParams } = useParams<RouteParams>();
+
+  const [domain, cluster, workflowId] = workflowParams;
+
+  return (
+    <ErrorPanel
+      error={error}
+      message={`Could not redirect to workflow "${workflowId}"`}
+      actions={[
+        {
+          kind: 'link-internal',
+          label: 'Go to domain page',
+          link: `/domains/${domain}/${cluster}`,
+        },
+      ]}
+      omitLogging={true}
+    />
+  );
+}

--- a/src/views/redirect-workflow/redirect-workflow-error/redirect-workflow-error.types.ts
+++ b/src/views/redirect-workflow/redirect-workflow-error/redirect-workflow-error.types.ts
@@ -1,0 +1,3 @@
+export type Props = {
+  error: Error;
+};

--- a/src/views/redirect-workflow/redirect-workflow-not-found/redirect-workflow-not-found.tsx
+++ b/src/views/redirect-workflow/redirect-workflow-not-found/redirect-workflow-not-found.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useParams } from 'next/navigation';
+
+import ErrorPanel from '@/components/error-panel/error-panel';
+
+import { type RouteParams } from '../redirect-workflow.types';
+
+export default function RedirectWorkflowNotFound() {
+  const { workflowParams } = useParams<RouteParams>();
+
+  const [domain, cluster, workflowId] = workflowParams;
+
+  return (
+    <ErrorPanel
+      message={`The workflow "${workflowId}" was not found, it may have passed retention period`}
+      actions={[
+        {
+          kind: 'link-internal',
+          label: 'Go to domain page',
+          link: `/domains/${domain}/${cluster}`,
+        },
+      ]}
+      omitLogging={true}
+    />
+  );
+}

--- a/src/views/redirect-workflow/redirect-workflow.tsx
+++ b/src/views/redirect-workflow/redirect-workflow.tsx
@@ -1,0 +1,46 @@
+import { notFound, redirect } from 'next/navigation';
+import queryString from 'query-string';
+
+import { type DescribeWorkflowResponse } from '@/route-handlers/describe-workflow/describe-workflow.types';
+import request from '@/utils/request';
+import { RequestError } from '@/utils/request/request-error';
+
+import { type Props } from './redirect-workflow.types';
+
+export default async function RedirectWorkflow(props: Props) {
+  const [domain, cluster, workflowId, ...restParams] =
+    props.params.workflowParams;
+
+  if (!domain || !cluster || !workflowId) {
+    throw new Error('Invalid workflow URL param');
+  }
+
+  let runId: string | null | undefined;
+
+  try {
+    const describeWorkflowResponse: DescribeWorkflowResponse = await request(
+      `/api/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows/${encodeURIComponent(workflowId)}`
+    ).then((res) => res.json());
+
+    runId =
+      describeWorkflowResponse.workflowExecutionInfo?.workflowExecution?.runId;
+  } catch (e) {
+    if (e instanceof RequestError && e.status === 404) {
+      notFound();
+    }
+    throw e;
+  }
+
+  if (!runId) {
+    notFound();
+  }
+
+  const baseUrl = `/domains/${encodeURIComponent(domain)}/${encodeURIComponent(cluster)}/workflows/${encodeURIComponent(workflowId)}/${encodeURIComponent(runId)}`;
+
+  redirect(
+    queryString.stringifyUrl({
+      url: baseUrl + (restParams.length > 0 ? `/${restParams.join('/')}` : ''),
+      query: props.searchParams,
+    })
+  );
+}

--- a/src/views/redirect-workflow/redirect-workflow.types.ts
+++ b/src/views/redirect-workflow/redirect-workflow.types.ts
@@ -1,0 +1,8 @@
+export type RouteParams = {
+  workflowParams: Array<string>;
+};
+
+export type Props = {
+  params: RouteParams;
+  searchParams?: { [key: string]: string | string[] | undefined };
+};


### PR DESCRIPTION
## Summary
### Problem
Opening a workflow in the UI requires knowing its exact run ID. Every workflow URL includes one:
```
/domains/<domain>/<cluster>/workflows/<workflowId>/<runId>/...
```

Omitting the run ID returns a 404. This is inconvenient in practice, since alerts, runbooks, and logs typically carry only the workflow ID, requiring users to look up the run ID before navigating to the page.

Cadence itself does not require it. When the run ID is omitted in a call to `DescribeWorkflowExecution`, the request resolves to the workflow's latest run. 

#### Prior Work
#1504 made Run ID optional in the `describeWorkflow` route handler.

### Solution
Add a `RedirectWorkflow` server component that resolves the current run and redirects to the workflow page, mirroring the existing `RedirectDomain` pattern.

- **`src/views/redirect-workflow/`** — server component that invokes the run-less describe endpoint via `request()`, reads the resolved run ID, and redirects to `/domains/<domain>/<cluster>/workflows/<workflowId>/<runId>`. Also includes error/not-found screens.
- **`src/app/(Home)/redirects/workflow/[...workflowParams]/`** — instantiating the redirect within the App Router.
- **`next.config.mjs`** — add a new redirect rule sending the run-less URL to the resolver, allowing an optional tab segment to carry through.

#### Misc
- Update domain page tabs in `next.config.mjs`
- Add docstring in `next.config.mjs` explaining that domain/workflow tabs need to be updated by hand

## Test Plan
- Builds + unit tests.
- Manual verification of redirects.

### Redirection without run ID

https://github.com/user-attachments/assets/7b338624-cf68-4bdb-ad94-cc858fadc377

### Redirection to specific workflow tab without either run ID or cluster name

https://github.com/user-attachments/assets/3e480f41-2f32-4509-a3a4-ed2c9e1b627c

## Additional info
Fixes https://github.com/cadence-workflow/cadence-web/issues/36 
Fixes https://github.com/cadence-workflow/cadence/issues/8403