### PR TITLE
feat(task-list): Extract workers badge on task list header

### DIFF
--- a/src/views/shared/task-list-label/__tests__/task-list-label.test.tsx
+++ b/src/views/shared/task-list-label/__tests__/task-list-label.test.tsx
@@ -1,64 +1,53 @@
 import React from 'react';
 
-import { type TagKind } from 'baseui/tag';
-
 import { render, screen } from '@/test-utils/rtl';
 
 import { mockTaskList } from '@/views/task-list-page/__fixtures__/mock-task-list';
 
 import TaskListLabel from '../task-list-label';
 
-jest.mock('baseui/tag', () => ({
-  ...jest.requireActual('baseui/tag'),
-  Tag: jest.fn(({ kind, children }) => (
-    <div data-testid={`mock-tag-${kind}`}>{children}</div>
-  )),
-}));
+jest.mock(
+  '@/views/shared/task-list-workers-badge/task-list-workers-badge',
+  () =>
+    function MockTaskListWorkersBadge({
+      variant,
+      count,
+    }: {
+      variant: string;
+      count?: number;
+    }) {
+      return (
+        <div data-testid="task-list-workers-badge">{`${variant}:${count}`}</div>
+      );
+    }
+);
 
 describe(TaskListLabel.name, () => {
-  afterEach(() => {
-    jest.clearAllMocks();
+  it('renders the task list name and workers badge', () => {
+    setup({ numWorkers: 2 });
+
+    expect(screen.getByText(mockTaskList.name)).toBeInTheDocument();
+    expect(screen.getByTestId('task-list-workers-badge')).toHaveTextContent(
+      'workers:2'
+    );
   });
 
-  const tests: Array<{
-    name: string;
-    numWorkers: number;
-    text: string;
-    kind: TagKind;
-  }> = [
-    {
-      name: 'should render multiple workers correctly',
-      numWorkers: 2,
-      text: '2 workers',
-      kind: 'accent',
-    },
-    {
-      name: 'should render one worker correctly',
-      numWorkers: 1,
-      text: '1 worker',
-      kind: 'accent',
-    },
-    {
-      name: 'should render no workers correctly',
-      numWorkers: 0,
-      text: '0 workers',
-      kind: 'negative',
-    },
-  ];
+  it('passes a zero worker count to the badge', () => {
+    setup({ numWorkers: 0 });
 
-  tests.forEach((test) => {
-    it(test.name, () => {
-      render(
-        <TaskListLabel
-          taskList={{
-            ...mockTaskList,
-            workers: mockTaskList.workers.slice(0, test.numWorkers),
-          }}
-        />
-      );
-
-      expect(screen.getByText(test.text)).toBeInTheDocument();
-      expect(screen.getByTestId(`mock-tag-${test.kind}`)).toBeInTheDocument();
-    });
+    expect(screen.getByTestId('task-list-workers-badge')).toHaveTextContent(
+      'workers:0'
+    );
   });
 });
+
+function setup({ numWorkers }: { numWorkers: number }) {
+  render(
+    <TaskListLabel
+      taskList={{
+        ...mockTaskList,
+        workers: mockTaskList.workers.slice(0, numWorkers),
+      }}
+    />
+  );
+}

--- a/src/views/shared/task-list-label/task-list-label.styles.ts
+++ b/src/views/shared/task-list-label/task-list-label.styles.ts
@@ -1,6 +1,4 @@
 import { type Theme, styled as createStyled } from 'baseui';
-import type { TagKind, TagOverrides } from 'baseui/tag/types';
-import { type StyleObject } from 'styletron-react';
 
 export const styled = {
   LabelContainer: createStyled<'div', { $isHighlighted?: boolean }>(
@@ -20,35 +18,4 @@ export const styled = {
       ...($isHighlighted && { fontWeight: 700 }),
     })
   ),
-};
-
-export const overrides = {
-  tag: {
-    Root: {
-      style: ({
-        $theme,
-        $kind,
-      }: {
-        $theme: Theme;
-        $kind: TagKind;
-      }): StyleObject => ({
-        color:
-          $kind === 'negative' ? $theme.colors.red700 : $theme.colors.blue700,
-        backgroundColor:
-          $kind === 'negative' ? $theme.colors.red100 : $theme.colors.blue100,
-        height: $theme.sizing.scale700,
-        borderRadius: $theme.borders.radius400,
-        paddingRight: $theme.sizing.scale300,
-        paddingLeft: $theme.sizing.scale300,
-        paddingTop: $theme.sizing.scale0,
-        paddingBottom: $theme.sizing.scale0,
-        margin: 0,
-      }),
-    },
-    Text: {
-      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
-        ...$theme.typography.LabelXSmall,
-      }),
-    },
-  } satisfies TagOverrides,
 };

--- a/src/views/shared/task-list-label/task-list-label.tsx
+++ b/src/views/shared/task-list-label/task-list-label.tsx
@@ -1,21 +1,18 @@
-import { Tag } from 'baseui/tag';
+'use client';
 
-import { styled, overrides } from './task-list-label.styles';
+import TaskListWorkersBadge from '@/views/shared/task-list-workers-badge/task-list-workers-badge';
+
+import { styled } from './task-list-label.styles';
 import { type Props } from './task-list-label.types';
 
 export default function TaskListLabel(props: Props) {
-  const numWorkers = props.taskList.workers.length;
   return (
     <styled.LabelContainer $isHighlighted={props.isHighlighted}>
       {props.taskList.name}
-      <Tag
-        kind={numWorkers === 0 ? 'negative' : 'accent'}
-        hierarchy="primary"
-        closeable={false}
-        overrides={overrides.tag}
-      >
-        {`${numWorkers} ${numWorkers === 1 ? 'worker' : 'workers'}`}
-      </Tag>
+      <TaskListWorkersBadge
+        variant="workers"
+        count={props.taskList.workers.length}
+      />
     </styled.LabelContainer>
   );
 }

--- a/src/views/shared/task-list-workers-badge/__tests__/task-list-workers-badge.test.tsx
+++ b/src/views/shared/task-list-workers-badge/__tests__/task-list-workers-badge.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@/test-utils/rtl';
+
+import TaskListWorkersBadge from '../task-list-workers-badge';
+import { TASK_LIST_WORKERS_BADGE_TOOLTIPS } from '../task-list-workers-badge.constants';
+import { type Props } from '../task-list-workers-badge.types';
+
+jest.mock('baseui/tag', () => ({
+  ...jest.requireActual('baseui/tag'),
+  Tag: jest.fn(({ kind, children }) => (
+    <div data-testid={`mock-tag-${kind}`}>{children}</div>
+  )),
+}));
+
+jest.mock('baseui/tooltip', () => ({
+  StatefulTooltip: jest.fn(({ content, children }) => (
+    <div>
+      <div data-testid="tooltip-content">{content}</div>
+      {children}
+    </div>
+  )),
+}));
+
+describe(TaskListWorkersBadge.name, () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const cases: Array<{
+    name: string;
+    props: Props;
+    text: string;
+    kind: string;
+    tooltip: string;
+  }> = [
+    {
+      name: 'renders multiple workers',
+      props: { variant: 'workers', count: 2 },
+      text: '2 workers',
+      kind: 'accent',
+      tooltip: TASK_LIST_WORKERS_BADGE_TOOLTIPS.workers,
+    },
+    {
+      name: 'renders one worker',
+      props: { variant: 'workers', count: 1 },
+      text: '1 worker',
+      kind: 'accent',
+      tooltip: TASK_LIST_WORKERS_BADGE_TOOLTIPS.workers,
+    },
+    {
+      name: 'renders zero workers as negative',
+      props: { variant: 'workers', count: 0 },
+      text: '0 workers',
+      kind: 'negative',
+      tooltip: TASK_LIST_WORKERS_BADGE_TOOLTIPS.workers,
+    },
+  ];
+
+  cases.forEach((test) => {
+    it(test.name, () => {
+      setup(test.props);
+
+      expect(screen.getByText(test.text)).toBeInTheDocument();
+      expect(screen.getByTestId(`mock-tag-${test.kind}`)).toBeInTheDocument();
+      expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+        test.tooltip
+      );
+    });
+  });
+
+});
+
+function setup(props: Props) {
+  render(<TaskListWorkersBadge {...props} />);
+}

--- a/src/views/shared/task-list-workers-badge/__tests__/task-list-workers-badge.test.tsx
+++ b/src/views/shared/task-list-workers-badge/__tests__/task-list-workers-badge.test.tsx
@@ -66,7 +66,6 @@ describe(TaskListWorkersBadge.name, () => {
       );
     });
   });
-
 });
 
 function setup(props: Props) {

--- a/src/views/shared/task-list-workers-badge/helpers/__tests__/get-task-list-workers-badge-label.test.ts
+++ b/src/views/shared/task-list-workers-badge/helpers/__tests__/get-task-list-workers-badge-label.test.ts
@@ -5,8 +5,8 @@ describe(getTaskListWorkersBadgeLabel.name, () => {
     expect(getTaskListWorkersBadgeLabel({ variant: 'workers', count: 0 })).toBe(
       '0 workers'
     );
-    expect(
-      getTaskListWorkersBadgeLabel({ variant: 'workers', count: 1 })
-    ).toBe('1 worker');
+    expect(getTaskListWorkersBadgeLabel({ variant: 'workers', count: 1 })).toBe(
+      '1 worker'
+    );
   });
 });

--- a/src/views/shared/task-list-workers-badge/helpers/__tests__/get-task-list-workers-badge-label.test.ts
+++ b/src/views/shared/task-list-workers-badge/helpers/__tests__/get-task-list-workers-badge-label.test.ts
@@ -1,0 +1,12 @@
+import getTaskListWorkersBadgeLabel from '../get-task-list-workers-badge-label';
+
+describe(getTaskListWorkersBadgeLabel.name, () => {
+  it('pluralizes workers', () => {
+    expect(getTaskListWorkersBadgeLabel({ variant: 'workers', count: 0 })).toBe(
+      '0 workers'
+    );
+    expect(
+      getTaskListWorkersBadgeLabel({ variant: 'workers', count: 1 })
+    ).toBe('1 worker');
+  });
+});

--- a/src/views/shared/task-list-workers-badge/helpers/get-task-list-workers-badge-label.ts
+++ b/src/views/shared/task-list-workers-badge/helpers/get-task-list-workers-badge-label.ts
@@ -1,0 +1,8 @@
+export default function getTaskListWorkersBadgeLabel({
+  count,
+}: {
+  variant: 'workers';
+  count: number;
+}): string {
+  return count === 1 ? '1 worker' : `${count} workers`;
+}

--- a/src/views/shared/task-list-workers-badge/task-list-workers-badge.constants.ts
+++ b/src/views/shared/task-list-workers-badge/task-list-workers-badge.constants.ts
@@ -1,0 +1,4 @@
+export const TASK_LIST_WORKERS_BADGE_TOOLTIPS = {
+  workers:
+    'This is the current number of workers. It can change and may have been different earlier.',
+} as const;

--- a/src/views/shared/task-list-workers-badge/task-list-workers-badge.styles.ts
+++ b/src/views/shared/task-list-workers-badge/task-list-workers-badge.styles.ts
@@ -1,0 +1,34 @@
+import { type Theme } from 'baseui';
+import type { TagKind, TagOverrides } from 'baseui/tag/types';
+import { type StyleObject } from 'styletron-react';
+
+export const overrides = {
+  tag: {
+    Root: {
+      style: ({
+        $theme,
+        $kind,
+      }: {
+        $theme: Theme;
+        $kind: TagKind;
+      }): StyleObject => ({
+        color:
+          $kind === 'negative' ? $theme.colors.red700 : $theme.colors.blue700,
+        backgroundColor:
+          $kind === 'negative' ? $theme.colors.red100 : $theme.colors.blue100,
+        height: $theme.sizing.scale700,
+        borderRadius: $theme.borders.radius400,
+        paddingRight: $theme.sizing.scale300,
+        paddingLeft: $theme.sizing.scale300,
+        paddingTop: $theme.sizing.scale0,
+        paddingBottom: $theme.sizing.scale0,
+        margin: 0,
+      }),
+    },
+    Text: {
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        ...$theme.typography.LabelXSmall,
+      }),
+    },
+  } satisfies TagOverrides,
+};

--- a/src/views/shared/task-list-workers-badge/task-list-workers-badge.tsx
+++ b/src/views/shared/task-list-workers-badge/task-list-workers-badge.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Tag } from 'baseui/tag';
+import { StatefulTooltip } from 'baseui/tooltip';
+
+import getTaskListWorkersBadgeLabel from './helpers/get-task-list-workers-badge-label';
+import { TASK_LIST_WORKERS_BADGE_TOOLTIPS } from './task-list-workers-badge.constants';
+import { overrides } from './task-list-workers-badge.styles';
+import { type Props } from './task-list-workers-badge.types';
+
+export default function TaskListWorkersBadge({
+  variant,
+  count,
+}: Props) {
+  const label = getTaskListWorkersBadgeLabel({ variant, count });
+
+  return (
+    <StatefulTooltip
+      content={TASK_LIST_WORKERS_BADGE_TOOLTIPS[variant]}
+      showArrow
+      accessibilityType="tooltip"
+    >
+      <span>
+        <Tag
+          kind={count === 0 ? 'negative' : 'accent'}
+          hierarchy="primary"
+          closeable={false}
+          overrides={overrides.tag}
+        >
+          {label}
+        </Tag>
+      </span>
+    </StatefulTooltip>
+  );
+}

--- a/src/views/shared/task-list-workers-badge/task-list-workers-badge.tsx
+++ b/src/views/shared/task-list-workers-badge/task-list-workers-badge.tsx
@@ -8,10 +8,7 @@ import { TASK_LIST_WORKERS_BADGE_TOOLTIPS } from './task-list-workers-badge.cons
 import { overrides } from './task-list-workers-badge.styles';
 import { type Props } from './task-list-workers-badge.types';
 
-export default function TaskListWorkersBadge({
-  variant,
-  count,
-}: Props) {
+export default function TaskListWorkersBadge({ variant, count }: Props) {
   const label = getTaskListWorkersBadgeLabel({ variant, count });
 
   return (

--- a/src/views/shared/task-list-workers-badge/task-list-workers-badge.types.ts
+++ b/src/views/shared/task-list-workers-badge/task-list-workers-badge.types.ts
@@ -1,0 +1,4 @@
+export type Props = {
+  variant: 'workers';
+  count: number;
+};


### PR DESCRIPTION
## Summary

Extract the task-list worker count tag into a shared badge component while preserving the task-list header behavior.

## Changes

- Reuse one badge component for worker count labels and styling.
- Explain that worker counts are current and may differ from historical values.
- Keep zero-worker counts visually negative.

## Testing

- `npm run test:unit:browser -- --testPathPattern='task-list-workers-badge|task-list-label' --coverage=false`
- `npm run typecheck`

### Screenshots

![Task-list header worker badge](https://github.com/cadence-workflow/cadence-web/blob/48c9c9f6f8dfd7fcc6def1c36fa875b598943153/tc-06-task-list-header-workers.png?raw=true)

