### PR TITLE
feat(workflow-summary): add copy icons for workflow IDs

### DIFF
--- a/src/views/workflow-summary/config/workflow-summary-details.config.ts
+++ b/src/views/workflow-summary/config/workflow-summary-details.config.ts
@@ -51,17 +51,21 @@ const workflowSummaryDetailsConfig: WorkflowSummaryDetailsConfig[] = [
     getLabel: () => 'Workflow ID',
     valueComponent: ({ decodedPageUrlParams }) =>
       decodedPageUrlParams.workflowId,
+    getCopyText: ({ decodedPageUrlParams }) => decodedPageUrlParams.workflowId,
   },
   {
     key: 'workflowType',
     getLabel: () => 'Workflow type',
     valueComponent: ({ firstEvent }) =>
       firstEvent?.workflowExecutionStartedEventAttributes?.workflowType?.name,
+    getCopyText: ({ firstEvent }) =>
+      firstEvent?.workflowExecutionStartedEventAttributes?.workflowType?.name,
   },
   {
     key: 'runId',
     getLabel: () => 'Run ID',
     valueComponent: ({ decodedPageUrlParams }) => decodedPageUrlParams.runId,
+    getCopyText: ({ decodedPageUrlParams }) => decodedPageUrlParams.runId,
   },
   {
     key: 'startTime',

--- a/src/views/workflow-summary/workflow-summary-details/__tests__/workflow-summary-details.test.tsx
+++ b/src/views/workflow-summary/workflow-summary-details/__tests__/workflow-summary-details.test.tsx
@@ -24,6 +24,7 @@ jest.mock(
         key: 'testKey1',
         getLabel: () => 'Test Label 1',
         valueComponent: () => <span>Test Value 1</span>,
+        getCopyText: () => 'Test Copy Text 1',
       },
       {
         key: 'testKey2',
@@ -37,7 +38,26 @@ jest.mock(
         getLabel: () => 'Hidden Label 3',
         valueComponent: () => <span>Hidden Value 3</span>,
       },
+      {
+        key: 'testKey4',
+        getLabel: () => 'Test Label 4',
+        valueComponent: () => <span>Test Value 4</span>,
+        getCopyText: () => undefined,
+      },
     ] satisfies WorkflowSummaryDetailsConfig[]
+);
+
+jest.mock(
+  '@/components/copy-text-button/copy-text-button',
+  () =>
+    function MockCopyTextButton({
+      textToCopy,
+      ...buttonProps
+    }: {
+      textToCopy: string;
+    }) {
+      return <button {...buttonProps}>{textToCopy}</button>;
+    }
 );
 
 const params: Props['decodedPageUrlParams'] = {
@@ -57,36 +77,15 @@ const mockWorkflowDetails: DescribeWorkflowResponse = {
 };
 
 describe('WorkflowSummaryDetails', () => {
-  const formattedCloseHistoryEvent = formatWorkflowHistoryEvent(
-    completeWorkflowExecutionEvent
-  );
   it('should render workflow type name from firstHistoryEvent', () => {
-    render(
-      <WorkflowSummaryDetails
-        firstHistoryEvent={startWorkflowExecutionEvent}
-        closeHistoryEvent={completeWorkflowExecutionEvent}
-        formattedFirstHistoryEvent={mockFormattedFirstEvent}
-        formattedCloseHistoryEvent={formattedCloseHistoryEvent}
-        workflowDetails={mockWorkflowDetails}
-        decodedPageUrlParams={params}
-      />
-    );
+    setup();
 
     expect(screen.getByText(/Workflow:/)).toBeInTheDocument();
     expect(screen.getByText('workflow.cron')).toBeInTheDocument();
   });
 
   it('should render all detail rows that are not hidden', () => {
-    render(
-      <WorkflowSummaryDetails
-        firstHistoryEvent={startWorkflowExecutionEvent}
-        closeHistoryEvent={completeWorkflowExecutionEvent}
-        formattedFirstHistoryEvent={mockFormattedFirstEvent}
-        formattedCloseHistoryEvent={formattedCloseHistoryEvent}
-        workflowDetails={mockWorkflowDetails}
-        decodedPageUrlParams={params}
-      />
-    );
+    setup();
 
     expect(screen.getByText('Test Label 1')).toBeInTheDocument();
     expect(screen.getByText('Test Value 1')).toBeInTheDocument();
@@ -95,18 +94,43 @@ describe('WorkflowSummaryDetails', () => {
   });
 
   it('should not render detail rows that are hidden', () => {
-    render(
-      <WorkflowSummaryDetails
-        firstHistoryEvent={startWorkflowExecutionEvent}
-        closeHistoryEvent={completeWorkflowExecutionEvent}
-        formattedFirstHistoryEvent={mockFormattedFirstEvent}
-        formattedCloseHistoryEvent={formattedCloseHistoryEvent}
-        workflowDetails={mockWorkflowDetails}
-        decodedPageUrlParams={params}
-      />
-    );
+    setup();
 
     expect(screen.queryByText('Hidden Label 3')).not.toBeInTheDocument();
     expect(screen.queryByText('Hidden Value 3')).not.toBeInTheDocument();
   });
+
+  it('should render a copy button for rows that provide copy text', () => {
+    setup();
+
+    expect(
+      screen.getByRole('button', { name: 'Copy Test Label 1' })
+    ).toHaveTextContent('Test Copy Text 1');
+  });
+
+  it('should not render a copy button for rows without copy text', () => {
+    setup();
+
+    expect(
+      screen.queryByRole('button', { name: 'Copy Test Label 2' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Copy Test Label 4' })
+    ).not.toBeInTheDocument();
+  });
 });
+
+function setup() {
+  render(
+    <WorkflowSummaryDetails
+      firstHistoryEvent={startWorkflowExecutionEvent}
+      closeHistoryEvent={completeWorkflowExecutionEvent}
+      formattedFirstHistoryEvent={mockFormattedFirstEvent}
+      formattedCloseHistoryEvent={formatWorkflowHistoryEvent(
+        completeWorkflowExecutionEvent
+      )}
+      workflowDetails={mockWorkflowDetails}
+      decodedPageUrlParams={params}
+    />
+  );
+}

--- a/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.styles.ts
+++ b/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.styles.ts
@@ -1,7 +1,25 @@
+import { type Theme } from 'baseui';
+import { type ButtonOverrides } from 'baseui/button';
+import { type StyleObject } from 'styletron-react';
+
 import type {
   StyletronCSSObject,
   StyletronCSSObjectOf,
 } from '@/hooks/use-styletron-classes';
+
+export const overrides = {
+  copyButton: {
+    BaseButton: {
+      // sized to the value's line height so copy rows stay as tall as the rest
+      style: ({ $theme }: { $theme: Theme }): StyleObject => ({
+        height: $theme.sizing.scale650,
+        width: $theme.sizing.scale650,
+        padding: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0)',
+      }),
+    },
+  } satisfies ButtonOverrides,
+};
 
 const cssStylesObj = {
   pageContainer: (theme) => ({
@@ -20,6 +38,11 @@ const cssStylesObj = {
     paddingTop: theme.sizing.scale400,
     paddingBottom: theme.sizing.scale400,
     wordBreak: 'break-word',
+    // keep these as two keys: styletron prepends the row's class to the start of
+    // a key, not to each selector in a comma-separated list, so joining them
+    // would emit ':focus-within ...' unprefixed and match every row on the page
+    ':hover [data-copy-button]': { opacity: 1 },
+    ':focus-within [data-copy-button]': { opacity: 1 },
   }),
   detailsLabel: (theme) => ({
     minWidth: '120px',
@@ -31,7 +54,15 @@ const cssStylesObj = {
   detailsValue: (theme) => ({
     ...theme.typography.ParagraphXSmall,
     display: 'flex',
+    alignItems: 'center',
+    gap: theme.sizing.scale100,
     flex: '1 0 300px',
+  }),
+  copyButton: () => ({
+    opacity: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
+    transition: 'opacity 150ms',
   }),
   workflowTitle: (theme) => ({
     ...theme.typography.LabelMedium,

--- a/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.styles.ts
+++ b/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.styles.ts
@@ -15,7 +15,7 @@ export const overrides = {
         height: $theme.sizing.scale650,
         width: $theme.sizing.scale650,
         padding: 0,
-        backgroundColor: 'rgba(0, 0, 0, 0)',
+        backgroundColor: 'transparent',
       }),
     },
   } satisfies ButtonOverrides,

--- a/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.tsx
+++ b/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.tsx
@@ -1,8 +1,6 @@
 'use client';
 import React from 'react';
 
-import { KIND } from 'baseui/button';
-
 import CopyTextButton from '@/components/copy-text-button/copy-text-button';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 
@@ -57,7 +55,7 @@ export default function WorkflowSummaryDetails({
                       <CopyTextButton
                         textToCopy={copyText}
                         aria-label={`Copy ${c.getLabel()}`}
-                        kind={KIND.tertiary}
+                        kind="tertiary"
                         overrides={overrides.copyButton}
                       />
                     </span>

--- a/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.tsx
+++ b/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.tsx
@@ -1,12 +1,18 @@
 'use client';
 import React from 'react';
 
+import { KIND } from 'baseui/button';
+
+import CopyTextButton from '@/components/copy-text-button/copy-text-button';
 import useStyletronClasses from '@/hooks/use-styletron-classes';
 
 import workflowSummaryDetailsConfig from '../config/workflow-summary-details.config';
 
-import { cssStyles } from './workflow-summary-details.styles';
-import { type Props } from './workflow-summary-details.types';
+import { cssStyles, overrides } from './workflow-summary-details.styles';
+import {
+  type Props,
+  type WorkflowSummaryFieldArgs,
+} from './workflow-summary-details.types';
 
 export default function WorkflowSummaryDetails({
   firstHistoryEvent,
@@ -17,6 +23,15 @@ export default function WorkflowSummaryDetails({
   workflowDetails,
 }: Props) {
   const { cls } = useStyletronClasses(cssStyles);
+
+  const fieldArgs: WorkflowSummaryFieldArgs = {
+    firstEvent: firstHistoryEvent,
+    closeEvent: closeHistoryEvent,
+    formattedFirstEvent: formattedFirstHistoryEvent,
+    formattedCloseEvent: formattedCloseHistoryEvent,
+    workflowDetails,
+    decodedPageUrlParams,
+  };
 
   return (
     <div className={cls.pageContainer}>
@@ -29,33 +44,28 @@ export default function WorkflowSummaryDetails({
       </div>
       <div>
         {workflowSummaryDetailsConfig
-          .filter(
-            (c) =>
-              !c.hide ||
-              !c.hide({
-                firstEvent: firstHistoryEvent,
-                formattedFirstEvent: formattedFirstHistoryEvent,
-                formattedCloseEvent: formattedCloseHistoryEvent,
-                closeEvent: closeHistoryEvent,
-                workflowDetails,
-                decodedPageUrlParams,
-              })
-          )
-          .map((c) => (
-            <div className={cls.detailsRow} key={c.key}>
-              <div className={cls.detailsLabel}>{c.getLabel()}</div>
-              <div className={cls.detailsValue}>
-                <c.valueComponent
-                  firstEvent={firstHistoryEvent}
-                  closeEvent={closeHistoryEvent}
-                  formattedFirstEvent={formattedFirstHistoryEvent}
-                  formattedCloseEvent={formattedCloseHistoryEvent}
-                  workflowDetails={workflowDetails}
-                  decodedPageUrlParams={decodedPageUrlParams}
-                />
+          .filter((c) => !c.hide || !c.hide(fieldArgs))
+          .map((c) => {
+            const copyText = c.getCopyText?.(fieldArgs);
+            return (
+              <div className={cls.detailsRow} key={c.key}>
+                <div className={cls.detailsLabel}>{c.getLabel()}</div>
+                <div className={cls.detailsValue}>
+                  <c.valueComponent {...fieldArgs} />
+                  {copyText && (
+                    <span className={cls.copyButton} data-copy-button>
+                      <CopyTextButton
+                        textToCopy={copyText}
+                        aria-label={`Copy ${c.getLabel()}`}
+                        kind={KIND.tertiary}
+                        overrides={overrides.copyButton}
+                      />
+                    </span>
+                  )}
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
       </div>
     </div>
   );

--- a/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.types.ts
+++ b/src/views/workflow-summary/workflow-summary-details/workflow-summary-details.types.ts
@@ -36,4 +36,5 @@ export type WorkflowSummaryDetailsConfig = {
   getLabel: () => string;
   valueComponent: React.ComponentType<WorkflowSummaryFieldArgs>;
   hide?: (args: WorkflowSummaryFieldArgs) => boolean;
+  getCopyText?: (args: WorkflowSummaryFieldArgs) => string | undefined;
 };


### PR DESCRIPTION
## Summary

Adds a copy icon next to Workflow ID, Run ID, and Workflow type on the workflow summary page. The icon stays space-reserved and appears on row hover or keyboard focus, then copies the value with the existing "Copied" tooltip.

## Changes

- Optional `getCopyText` on summary row config for those three fields.
- `WorkflowSummaryDetails` renders the shared `CopyTextButton` when copy text is present, sized to the value line height so rows do not grow.

## Screen Recordings

Hover each of Workflow ID, Workflow type, and Run ID, then click copy. The icon appears without shifting the row, and the "Copied" tooltip shows.

**Recording** — hover and copy on Workflow ID, Workflow type, and Run ID.

https://github.com/user-attachments/assets/16192c78-a86f-4c11-a6d6-b2cfde7b0d90

