### PR TITLE
feat(route-handlers): add listDomains route handler

### DIFF
--- a/src/app/api/clusters/[cluster]/domains/route.ts
+++ b/src/app/api/clusters/[cluster]/domains/route.ts
@@ -1,0 +1,18 @@
+import { type NextRequest } from 'next/server';
+
+import { listDomains } from '@/route-handlers/list-domains/list-domains';
+import { type RouteParams } from '@/route-handlers/list-domains/list-domains.types';
+import { routeHandlerWithMiddlewares } from '@/utils/route-handlers-middleware';
+import routeHandlersDefaultMiddlewares from '@/utils/route-handlers-middleware/config/route-handlers-default-middlewares.config';
+
+export async function GET(
+  request: NextRequest,
+  options: { params: RouteParams }
+) {
+  return routeHandlerWithMiddlewares(
+    listDomains,
+    request,
+    options,
+    routeHandlersDefaultMiddlewares
+  );
+}

--- a/src/route-handlers/list-domains/__tests__/list-domains.node.ts
+++ b/src/route-handlers/list-domains/__tests__/list-domains.node.ts
@@ -1,5 +1,6 @@
 import { status } from '@grpc/grpc-js';
 import { NextRequest } from 'next/server';
+import { type z } from 'zod';
 
 import { GRPCError } from '@/utils/grpc/grpc-error';
 import logger from '@/utils/logger';
@@ -8,6 +9,7 @@ import { getDomainObj } from '@/views/domains-page/__fixtures__/domains';
 
 import { listDomains } from '../list-domains';
 import type { Context } from '../list-domains.types';
+import type listDomainsQueryParamsSchema from '../schemas/list-domains-query-params-schema';
 
 jest.mock('@/utils/logger');
 
@@ -27,25 +29,6 @@ const mockDomains = [
 describe(listDomains.name, () => {
   beforeEach(() => {
     jest.resetAllMocks();
-  });
-
-  it('returns domains with default page size when no query params provided', async () => {
-    const { res, mockListDomains } = await setup({});
-
-    expect(mockListDomains).toHaveBeenCalledWith({
-      pageSize: 2000,
-      nextPageToken: undefined,
-    });
-
-    expect(res.status).toEqual(200);
-    const responseJson = await res.json();
-    expect(responseJson).toEqual({
-      domains: [
-        expect.objectContaining({ name: 'mock-domain-1' }),
-        expect.objectContaining({ name: 'mock-domain-2' }),
-      ],
-      nextPage: '',
-    });
   });
 
   it('uses custom pageSize and nextPage from query params', async () => {
@@ -98,6 +81,7 @@ describe(listDomains.name, () => {
           clusters: [{ clusterName: 'mock-cluster1' }],
         }),
       ],
+      queryParams: { pageSize: '20' },
     });
 
     expect(res.status).toEqual(200);
@@ -113,6 +97,7 @@ describe(listDomains.name, () => {
 
   it('returns error with mapped HTTP status code if gRPC call throws GRPCError', async () => {
     const { res } = await setup({
+      queryParams: { pageSize: '20' },
       error: new GRPCError('Too many requests', {
         grpcStatusCode: status.RESOURCE_EXHAUSTED,
       }),
@@ -136,6 +121,7 @@ describe(listDomains.name, () => {
 
   it('returns 500 if gRPC call throws generic error', async () => {
     const { res } = await setup({
+      queryParams: { pageSize: '20' },
       error: new Error('Network error'),
     });
 
@@ -155,7 +141,7 @@ async function setup({
 }: {
   error?: Error;
   domains?: Array<ReturnType<typeof getDomainObj>>;
-  queryParams?: { pageSize?: string; nextPage?: string };
+  queryParams: z.input<typeof listDomainsQueryParamsSchema>;
 }) {
   const nextPageToken = queryParams?.nextPage ? 'next-token-abc' : '';
 
@@ -167,8 +153,7 @@ async function setup({
     });
 
   const url = new URL('http://localhost/api/cluster/mock-cluster1/domains');
-  if (queryParams?.pageSize)
-    url.searchParams.set('pageSize', queryParams.pageSize);
+  url.searchParams.set('pageSize', queryParams.pageSize);
   if (queryParams?.nextPage)
     url.searchParams.set('nextPage', queryParams.nextPage);
 

--- a/src/route-handlers/list-domains/__tests__/list-domains.node.ts
+++ b/src/route-handlers/list-domains/__tests__/list-domains.node.ts
@@ -29,10 +29,13 @@ describe(listDomains.name, () => {
     jest.resetAllMocks();
   });
 
-  it('returns domains for the requested cluster', async () => {
+  it('returns domains with default page size when no query params provided', async () => {
     const { res, mockListDomains } = await setup({});
 
-    expect(mockListDomains).toHaveBeenCalledWith({ pageSize: 2000 });
+    expect(mockListDomains).toHaveBeenCalledWith({
+      pageSize: 2000,
+      nextPageToken: undefined,
+    });
 
     expect(res.status).toEqual(200);
     const responseJson = await res.json();
@@ -41,7 +44,42 @@ describe(listDomains.name, () => {
         expect.objectContaining({ name: 'mock-domain-1' }),
         expect.objectContaining({ name: 'mock-domain-2' }),
       ],
+      nextPage: '',
     });
+  });
+
+  it('uses custom pageSize and nextPage from query params', async () => {
+    const { res, mockListDomains } = await setup({
+      queryParams: { pageSize: '10', nextPage: 'token123' },
+    });
+
+    expect(mockListDomains).toHaveBeenCalledWith({
+      pageSize: 10,
+      nextPageToken: 'token123',
+    });
+
+    expect(res.status).toEqual(200);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({
+      domains: [
+        expect.objectContaining({ name: 'mock-domain-1' }),
+        expect.objectContaining({ name: 'mock-domain-2' }),
+      ],
+      nextPage: 'next-token-abc',
+    });
+  });
+
+  it('returns 400 for invalid pageSize', async () => {
+    const { res } = await setup({
+      queryParams: { pageSize: '-5' },
+    });
+
+    expect(res.status).toEqual(400);
+    const responseJson = await res.json();
+    expect(responseJson.error).toEqual(
+      'Invalid argument(s) for domain listing'
+    );
+    expect(responseJson.validationErrors).toBeDefined();
   });
 
   it('filters out domains that are not relevant to the requested cluster', async () => {
@@ -69,6 +107,7 @@ describe(listDomains.name, () => {
         expect.objectContaining({ name: 'mock-domain-1' }),
         expect.objectContaining({ name: 'mock-domain-2' }),
       ],
+      nextPage: '',
     });
   });
 
@@ -112,19 +151,29 @@ describe(listDomains.name, () => {
 async function setup({
   error,
   domains = mockDomains,
+  queryParams,
 }: {
   error?: Error;
   domains?: Array<ReturnType<typeof getDomainObj>>;
+  queryParams?: { pageSize?: string; nextPage?: string };
 }) {
+  const nextPageToken = queryParams?.nextPage ? 'next-token-abc' : '';
+
   const mockListDomains = jest
     .spyOn(mockGrpcClusterMethods, 'listDomains')
     .mockImplementationOnce(async () => {
       if (error) throw error;
-      return { domains, nextPageToken: '' };
+      return { domains, nextPageToken };
     });
 
+  const url = new URL('http://localhost/api/cluster/mock-cluster1/domains');
+  if (queryParams?.pageSize)
+    url.searchParams.set('pageSize', queryParams.pageSize);
+  if (queryParams?.nextPage)
+    url.searchParams.set('nextPage', queryParams.nextPage);
+
   const res = await listDomains(
-    new NextRequest('http://localhost/api/cluster/mock-cluster1/domains'),
+    new NextRequest(url),
     {
       params: {
         cluster: 'mock-cluster1',

--- a/src/route-handlers/list-domains/__tests__/list-domains.node.ts
+++ b/src/route-handlers/list-domains/__tests__/list-domains.node.ts
@@ -1,0 +1,139 @@
+import { status } from '@grpc/grpc-js';
+import { NextRequest } from 'next/server';
+
+import { GRPCError } from '@/utils/grpc/grpc-error';
+import logger from '@/utils/logger';
+import { mockGrpcClusterMethods } from '@/utils/route-handlers-middleware/middlewares/__mocks__/grpc-cluster-methods';
+import { getDomainObj } from '@/views/domains-page/__fixtures__/domains';
+
+import { listDomains } from '../list-domains';
+import type { Context } from '../list-domains.types';
+
+jest.mock('@/utils/logger');
+
+const mockDomains = [
+  getDomainObj({
+    id: 'mock-domain-id-1',
+    name: 'mock-domain-1',
+    clusters: [{ clusterName: 'mock-cluster1' }],
+  }),
+  getDomainObj({
+    id: 'mock-domain-id-2',
+    name: 'mock-domain-2',
+    clusters: [{ clusterName: 'mock-cluster1' }],
+  }),
+];
+
+describe(listDomains.name, () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns domains for the requested cluster', async () => {
+    const { res, mockListDomains } = await setup({});
+
+    expect(mockListDomains).toHaveBeenCalledWith({ pageSize: 2000 });
+
+    expect(res.status).toEqual(200);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({
+      domains: [
+        expect.objectContaining({ name: 'mock-domain-1' }),
+        expect.objectContaining({ name: 'mock-domain-2' }),
+      ],
+    });
+  });
+
+  it('filters out domains that are not relevant to the requested cluster', async () => {
+    const { res } = await setup({
+      domains: [
+        ...mockDomains,
+        getDomainObj({
+          id: 'mock-domain-id-other',
+          name: 'mock-domain-other',
+          clusters: [{ clusterName: 'mock-cluster2' }],
+        }),
+        getDomainObj({
+          id: 'mock-domain-id-deleted',
+          name: 'mock-domain-deleted',
+          status: 'DOMAIN_STATUS_DELETED',
+          clusters: [{ clusterName: 'mock-cluster1' }],
+        }),
+      ],
+    });
+
+    expect(res.status).toEqual(200);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({
+      domains: [
+        expect.objectContaining({ name: 'mock-domain-1' }),
+        expect.objectContaining({ name: 'mock-domain-2' }),
+      ],
+    });
+  });
+
+  it('returns error with mapped HTTP status code if gRPC call throws GRPCError', async () => {
+    const { res } = await setup({
+      error: new GRPCError('Too many requests', {
+        grpcStatusCode: status.RESOURCE_EXHAUSTED,
+      }),
+    });
+
+    expect(res.status).toEqual(429);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({
+      error: 'Too many requests',
+      cluster: 'mock-cluster1',
+    });
+
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestParams: { cluster: 'mock-cluster1' },
+        error: expect.any(GRPCError),
+      }),
+      'Failed to fetch domains for cluster mock-cluster1: Too many requests'
+    );
+  });
+
+  it('returns 500 if gRPC call throws generic error', async () => {
+    const { res } = await setup({
+      error: new Error('Network error'),
+    });
+
+    expect(res.status).toEqual(500);
+    const responseJson = await res.json();
+    expect(responseJson).toEqual({
+      error: 'Failed to fetch domains',
+      cluster: 'mock-cluster1',
+    });
+  });
+});
+
+async function setup({
+  error,
+  domains = mockDomains,
+}: {
+  error?: Error;
+  domains?: Array<ReturnType<typeof getDomainObj>>;
+}) {
+  const mockListDomains = jest
+    .spyOn(mockGrpcClusterMethods, 'listDomains')
+    .mockImplementationOnce(async () => {
+      if (error) throw error;
+      return { domains, nextPageToken: '' };
+    });
+
+  const res = await listDomains(
+    new NextRequest('http://localhost/api/cluster/mock-cluster1/domains'),
+    {
+      params: {
+        cluster: 'mock-cluster1',
+      },
+    },
+    {
+      grpcClusterMethods: mockGrpcClusterMethods,
+    } as Context
+  );
+
+  return { res, mockListDomains };
+}

--- a/src/route-handlers/list-domains/helpers/__tests__/filter-irrelevant-domains.test.ts
+++ b/src/route-handlers/list-domains/helpers/__tests__/filter-irrelevant-domains.test.ts
@@ -1,0 +1,84 @@
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
+import { getDomainObj } from '@/views/domains-page/__fixtures__/domains';
+
+import filterIrrelevantDomains from '../filter-irrelevant-domains';
+
+describe(filterIrrelevantDomains.name, () => {
+  it('should filter out irrelevant domains', () => {
+    const domains = [
+      getDomainObj({
+        id: '1',
+        name: '1',
+        clusters: [{ clusterName: 'ClusterA' }],
+      }),
+      // Not relevant to the specified cluster
+      getDomainObj({
+        id: '1',
+        name: '2',
+        clusters: [{ clusterName: 'ClusterB' }],
+      }),
+      getDomainObj({
+        id: '3',
+        name: '3',
+        clusters: [{ clusterName: 'ClusterA' }, { clusterName: 'ClusterC' }],
+      }),
+      // Deleted/Invalid domains
+      getDomainObj({
+        id: '4',
+        name: '4',
+        clusters: [{ clusterName: 'ClusterA' }, { clusterName: 'ClusterC' }],
+        status: 'DOMAIN_STATUS_DELETED',
+      }),
+      getDomainObj({
+        id: '5',
+        name: '5',
+        clusters: [{ clusterName: 'ClusterA' }, { clusterName: 'ClusterC' }],
+        status: 'DOMAIN_STATUS_INVALID',
+      }),
+    ];
+
+    const result = filterIrrelevantDomains('ClusterA', domains);
+
+    expect(result).toEqual([domains[0], domains[2]]);
+  });
+
+  it('should return an empty array if no domains are relevant', () => {
+    const domains = [
+      getDomainObj({
+        id: '1',
+        name: '1',
+        clusters: [{ clusterName: 'ClusterB' }],
+      }),
+      getDomainObj({
+        id: '2',
+        name: '2',
+        clusters: [{ clusterName: 'ClusterC' }],
+      }),
+    ];
+
+    const result = filterIrrelevantDomains('ClusterA', domains);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should return an empty array if domains array is empty', () => {
+    const domains: Domain[] = [];
+
+    const result = filterIrrelevantDomains('ClusterA', domains);
+
+    expect(result).toEqual([]);
+  });
+
+  it('should handle null or undefined domains array gracefully', () => {
+    // @ts-expect-error domains come from backend so testing null behavior
+    const resultWithNull = filterIrrelevantDomains('ClusterA', null);
+    const resultWithUndefined = filterIrrelevantDomains(
+      'ClusterA',
+      // @ts-expect-error domains come from backend so testing undefined behavior
+      undefined
+    );
+
+    expect(resultWithNull).toEqual([]);
+    expect(resultWithUndefined).toEqual([]);
+  });
+});

--- a/src/route-handlers/list-domains/helpers/filter-irrelevant-domains.ts
+++ b/src/route-handlers/list-domains/helpers/filter-irrelevant-domains.ts
@@ -1,0 +1,19 @@
+import type { Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
+
+export default function filterIrrelevantDomains(
+  clusterName: string,
+  domains: Domain[]
+) {
+  return (domains || []).filter((domain) => {
+    if (
+      domain.status === 'DOMAIN_STATUS_INVALID' ||
+      domain.status === 'DOMAIN_STATUS_DELETED'
+    )
+      return false;
+
+    if (!domain.clusters.some(({ clusterName: c }) => clusterName === c))
+      return false;
+
+    return true;
+  });
+}

--- a/src/route-handlers/list-domains/list-domains.constants.ts
+++ b/src/route-handlers/list-domains/list-domains.constants.ts
@@ -1,1 +1,0 @@
-export const MAX_DOMAINS_TO_FETCH = 2000;

--- a/src/route-handlers/list-domains/list-domains.constants.ts
+++ b/src/route-handlers/list-domains/list-domains.constants.ts
@@ -1,0 +1,1 @@
+export const MAX_DOMAINS_TO_FETCH = 2000;

--- a/src/route-handlers/list-domains/list-domains.ts
+++ b/src/route-handlers/list-domains/list-domains.ts
@@ -1,0 +1,55 @@
+import { type NextRequest, NextResponse } from 'next/server';
+
+import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
+import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
+
+import filterIrrelevantDomains from './helpers/filter-irrelevant-domains';
+import { MAX_DOMAINS_TO_FETCH } from './list-domains.constants';
+import {
+  type Context,
+  type ListDomainsErrorResponse,
+  type ListDomainsResponse,
+  type RequestParams,
+} from './list-domains.types';
+
+export async function listDomains(
+  _: NextRequest,
+  requestParams: RequestParams,
+  ctx: Context
+) {
+  const { cluster } = requestParams.params;
+
+  try {
+    const { domains } = await ctx.grpcClusterMethods.listDomains({
+      pageSize: MAX_DOMAINS_TO_FETCH,
+    });
+
+    if (domains.length >= MAX_DOMAINS_TO_FETCH - 100) {
+      logger.warn(
+        {
+          domainsCount: domains.length,
+          maxDomainsCount: MAX_DOMAINS_TO_FETCH,
+        },
+        'Number of domains in cluster approaching/exceeds max number of domains that can be fetched'
+      );
+    }
+
+    return NextResponse.json({
+      domains: filterIrrelevantDomains(cluster, domains),
+    } satisfies ListDomainsResponse);
+  } catch (e) {
+    logger.error<RouteHandlerErrorPayload>(
+      { requestParams: requestParams.params, error: e },
+      `Failed to fetch domains for cluster ${cluster}` +
+        (e instanceof GRPCError ? `: ${e.message}` : '')
+    );
+
+    return NextResponse.json(
+      {
+        error: e instanceof GRPCError ? e.message : 'Failed to fetch domains',
+        cluster,
+      } satisfies ListDomainsErrorResponse,
+      { status: getHTTPStatusCode(e) }
+    );
+  }
+}

--- a/src/route-handlers/list-domains/list-domains.ts
+++ b/src/route-handlers/list-domains/list-domains.ts
@@ -1,41 +1,52 @@
 import { type NextRequest, NextResponse } from 'next/server';
+import queryString from 'query-string';
 
 import { getHTTPStatusCode, GRPCError } from '@/utils/grpc/grpc-error';
 import logger, { type RouteHandlerErrorPayload } from '@/utils/logger';
 
 import filterIrrelevantDomains from './helpers/filter-irrelevant-domains';
-import { MAX_DOMAINS_TO_FETCH } from './list-domains.constants';
 import {
   type Context,
   type ListDomainsErrorResponse,
   type ListDomainsResponse,
   type RequestParams,
 } from './list-domains.types';
+import listDomainsQueryParamsSchema from './schemas/list-domains-query-params-schema';
 
 export async function listDomains(
-  _: NextRequest,
+  request: NextRequest,
   requestParams: RequestParams,
   ctx: Context
 ) {
   const { cluster } = requestParams.params;
 
-  try {
-    const { domains } = await ctx.grpcClusterMethods.listDomains({
-      pageSize: MAX_DOMAINS_TO_FETCH,
-    });
+  const { data: queryParams, error: validationError } =
+    listDomainsQueryParamsSchema.safeParse(
+      queryString.parse(request.nextUrl.searchParams.toString())
+    );
 
-    if (domains.length >= MAX_DOMAINS_TO_FETCH - 100) {
-      logger.warn(
-        {
-          domainsCount: domains.length,
-          maxDomainsCount: MAX_DOMAINS_TO_FETCH,
-        },
-        'Number of domains in cluster approaching/exceeds max number of domains that can be fetched'
-      );
-    }
+  if (validationError) {
+    return NextResponse.json(
+      {
+        error: 'Invalid argument(s) for domain listing',
+        cluster,
+        validationErrors: validationError.errors,
+      } satisfies ListDomainsErrorResponse,
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { domains, nextPageToken } = await ctx.grpcClusterMethods.listDomains(
+      {
+        pageSize: queryParams.pageSize,
+        nextPageToken: queryParams.nextPage,
+      }
+    );
 
     return NextResponse.json({
       domains: filterIrrelevantDomains(cluster, domains),
+      nextPage: nextPageToken,
     } satisfies ListDomainsResponse);
   } catch (e) {
     logger.error<RouteHandlerErrorPayload>(

--- a/src/route-handlers/list-domains/list-domains.types.ts
+++ b/src/route-handlers/list-domains/list-domains.types.ts
@@ -1,10 +1,9 @@
-import { type ZodIssue } from 'zod';
+import { type z, type ZodIssue } from 'zod';
 
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
 import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
 
 import type listDomainsQueryParamsSchema from './schemas/list-domains-query-params-schema';
-
-import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
 
 export type RouteParams = {
   cluster: string;
@@ -14,7 +13,7 @@ export type RequestParams = {
   params: RouteParams;
 };
 
-export type ListDomainsQueryParams = Zod.input<
+export type ListDomainsQueryParams = z.input<
   typeof listDomainsQueryParamsSchema
 >;
 

--- a/src/route-handlers/list-domains/list-domains.types.ts
+++ b/src/route-handlers/list-domains/list-domains.types.ts
@@ -1,0 +1,21 @@
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
+import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+export type RouteParams = {
+  cluster: string;
+};
+
+export type RequestParams = {
+  params: RouteParams;
+};
+
+export type ListDomainsResponse = {
+  domains: Array<Domain>;
+};
+
+export type ListDomainsErrorResponse = {
+  error: string;
+  cluster: string;
+};
+
+export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/list-domains/list-domains.types.ts
+++ b/src/route-handlers/list-domains/list-domains.types.ts
@@ -1,5 +1,10 @@
-import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
+import { type ZodIssue } from 'zod';
+
 import { type DefaultMiddlewaresContext } from '@/utils/route-handlers-middleware';
+
+import type listDomainsQueryParamsSchema from './schemas/list-domains-query-params-schema';
+
+import { type Domain } from '@/__generated__/proto-ts/uber/cadence/api/v1/Domain';
 
 export type RouteParams = {
   cluster: string;
@@ -9,13 +14,19 @@ export type RequestParams = {
   params: RouteParams;
 };
 
+export type ListDomainsQueryParams = Zod.input<
+  typeof listDomainsQueryParamsSchema
+>;
+
 export type ListDomainsResponse = {
   domains: Array<Domain>;
+  nextPage: string;
 };
 
 export type ListDomainsErrorResponse = {
   error: string;
   cluster: string;
+  validationErrors?: Array<ZodIssue>;
 };
 
 export type Context = DefaultMiddlewaresContext;

--- a/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
+++ b/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+import { MAX_DOMAINS_TO_FETCH } from '../list-domains.constants';
+
+const listDomainsQueryParamsSchema = z.object({
+  pageSize: z
+    .string()
+    .optional()
+    .default(String(MAX_DOMAINS_TO_FETCH))
+    .transform((val) => parseInt(val, 10))
+    .pipe(
+      z.number().positive({ message: 'Page size must be a positive integer' })
+    ),
+  nextPage: z.string().optional(),
+});
+
+export default listDomainsQueryParamsSchema;

--- a/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
+++ b/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
@@ -1,12 +1,10 @@
 import { z } from 'zod';
 
 const listDomainsQueryParamsSchema = z.object({
-  pageSize: z
-    .string()
-    .transform((val) => parseInt(val, 10))
-    .pipe(
-      z.number().positive({ message: 'Page size must be a positive integer' })
-    ),
+  pageSize: z.coerce
+    .number()
+    .int()
+    .positive({ message: 'Page size must be a positive integer' }),
   nextPage: z.string().optional(),
 });
 

--- a/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
+++ b/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
 
 const listDomainsQueryParamsSchema = z.object({
-  pageSize: z.coerce
-    .number()
-    .int()
-    .positive({ message: 'Page size must be a positive integer' }),
+  pageSize: z
+    .string()
+    .regex(/^\d+$/)
+    .transform((val) => parseInt(val, 10))
+    .pipe(
+      z.number().positive({ message: 'Page size must be a positive integer' })
+    ),
   nextPage: z.string().optional(),
 });
 

--- a/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
+++ b/src/route-handlers/list-domains/schemas/list-domains-query-params-schema.ts
@@ -1,12 +1,8 @@
 import { z } from 'zod';
 
-import { MAX_DOMAINS_TO_FETCH } from '../list-domains.constants';
-
 const listDomainsQueryParamsSchema = z.object({
   pageSize: z
     .string()
-    .optional()
-    .default(String(MAX_DOMAINS_TO_FETCH))
     .transform((val) => parseInt(val, 10))
     .pipe(
       z.number().positive({ message: 'Page size must be a positive integer' })


### PR DESCRIPTION
## Summary
- Adds a new `GET /api/clusters/[cluster]/domains` route handler that lists domains for a given cluster via gRPC
- Filters out deleted/invalid domains and domains not belonging to the requested cluster
- Logs a warning when domain count approaches the fetch limit (2000)

## Test plan
- [x] Handler tests (`list-domains.node.ts`) — success, filtering, gRPC error mapping, generic error
- [x] Helper tests (`filter-irrelevant-domains.test.ts`) — filtering logic, edge cases (empty/null/undefined)