### PR TITLE
feat: new feature flag for Workflow Diagnostics in the history view

### DIFF
--- a/.agents/skills/add-feature-flag/SKILL.md
+++ b/.agents/skills/add-feature-flag/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: add-feature-flag
+description: Add a new boolean feature flag (dynamic config key) to cadence-web. Use when asked to add, create, or set up a feature flag, config flag, or `*_ENABLED` toggle.
+---
+
+# Add a feature flag
+
+Feature flags are dynamic config entries whose resolver returns `boolean`. Completeness is enforced by TypeScript — the fixture and the Zod schema map are typed against `dynamicConfigs`, so a missing entry fails `npm run typecheck`.
+
+Reference example: `WORKFLOW_DIAGNOSTICS_ENABLED` (added in the same 4 files below).
+
+## Naming
+
+- Key: `UPPER_SNAKE_CASE`, ending in `_ENABLED` — e.g. `WORKFLOW_DIAGNOSTICS_ENABLED`
+- Env var: `CADENCE_` + key — e.g. `CADENCE_WORKFLOW_DIAGNOSTICS_ENABLED`
+- Resolver file: kebab-case of the key — e.g. `workflow-diagnostics-enabled.ts`
+- Resolver function: camelCase of the key — e.g. `workflowDiagnosticsEnabled`
+
+## Files to touch
+
+Add the new entry directly after a related existing flag in each file (not alphabetically).
+
+### 1. Resolver — `src/config/dynamic/resolvers/<flag-name>.ts`
+
+```ts
+/**
+ * Returns whether <feature> is enabled.
+ *
+ * To enable, set the CADENCE_<FLAG_NAME> env variable to `true`.
+ * For further customization, override the implementation of this resolver.
+ *
+ * @returns {Promise<boolean>} Whether <feature> is enabled.
+ */
+export default async function <flagName>(): Promise<boolean> {
+  return process.env.CADENCE_<FLAG_NAME> === 'true';
+}
+```
+
+- Default export, `async`, returns `Promise<boolean>`.
+- Off by default; forks override the resolver.
+- If the flag depends on another flag, import and call that resolver rather than re-reading its env var (see `workflow-diagnostics-in-history-enabled.ts`). Check the cheap env var first.
+- If the flag needs args (e.g. `{ cluster, domain }`), add `<flag-name>.types.ts` with a `<FlagName>ResolverParams` type (see `cron-list-enabled.types.ts`).
+
+### 2. Register — `src/config/dynamic/dynamic.config.ts`
+
+Three edits:
+
+```ts
+// import (alphabetical by file path)
+import <flagName> from './resolvers/<flag-name>';
+
+// type block
+<FLAG_NAME>: ConfigAsyncResolverDefinition<undefined, boolean, 'request', true>;
+
+// runtime block
+<FLAG_NAME>: {
+  resolver: <flagName>,
+  evaluateOn: 'request',
+  isPublic: true,
+},
+```
+
+Replace `undefined` with the args type if the resolver takes args. `isPublic: true` is what exposes the key to the client via `/api/config`.
+
+### 3. Zod schema — `src/config/dynamic/resolvers/schemas/resolver-schemas.ts`
+
+```ts
+<FLAG_NAME>: {
+  args: z.undefined(), // or z.object({ cluster: z.string(), domain: z.string() })
+  returnType: z.boolean(),
+},
+```
+
+### 4. Test fixture — `src/utils/config/__fixtures__/resolved-config-values.ts`
+
+```ts
+<FLAG_NAME>: false,
+```
+
+The `getConfigValue` auto-mock reads from this, so server-side tests see the new key automatically.
+
+### 5. Resolver test (only if the resolver has logic)
+
+Skip for a plain env-var check. If the resolver combines conditions, calls another resolver, or takes args, add `src/config/dynamic/resolvers/__tests__/<flag-name>.node.ts`. Mirror `batch-actions-ui-enabled.node.ts`: `jest.mock` the imported resolvers, save/restore the env var in `beforeEach`/`afterEach`.
+
+## Consuming the flag
+
+Client:
+
+```ts
+const { data: isEnabled } = useSuspenseConfigValue('<FLAG_NAME>');
+// or non-suspense: useConfigValue('<FLAG_NAME>', args?)
+```
+
+Server (route handlers): `await getConfigValue('<FLAG_NAME>')`.
+
+Client tests mock the endpoint:
+
+```ts
+render(<Component />, {
+  endpointsMocks: [
+    {
+      path: '/api/config',
+      httpMethod: 'GET',
+      mockOnce: false,
+      httpResolver: async () => HttpResponse.json(true),
+    },
+  ],
+});
+```
+
+## When the feature ships
+
+Once the UI lands:
+
+- Add a row to the **Feature flags** table in `README.md`
+- Add a commented `# CADENCE_<FLAG_NAME>=true` under `### Feature flags` in `.env`
+
+## Verify
+
+```bash
+npm run typecheck                                  # proves fixture + schema are complete
+npm run test:unit:node <flag-name>.node.ts         # if you added a resolver test
+npm run test:unit:node -- src/route-handlers/get-config src/utils/config src/config/dynamic
+npm run lint
+```
+
+Optional live check: `npm run dev`, then `curl 'http://localhost:8088/api/config?configKey=<FLAG_NAME>'` → `false`; rerun with `CADENCE_<FLAG_NAME>=true npm run dev` → `true`.

--- a/src/config/dynamic/dynamic.config.ts
+++ b/src/config/dynamic/dynamic.config.ts
@@ -39,6 +39,7 @@ import {
   type WorkflowActionsEnabledConfig,
 } from './resolvers/workflow-actions-enabled.types';
 import workflowDiagnosticsEnabled from './resolvers/workflow-diagnostics-enabled';
+import workflowDiagnosticsInHistoryEnabled from './resolvers/workflow-diagnostics-in-history-enabled';
 import workflowsListEnabled from './resolvers/workflows-list-enabled';
 
 const dynamicConfigs: {
@@ -85,6 +86,12 @@ const dynamicConfigs: {
     true
   >;
   WORKFLOW_DIAGNOSTICS_ENABLED: ConfigAsyncResolverDefinition<
+    undefined,
+    boolean,
+    'request',
+    true
+  >;
+  WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED: ConfigAsyncResolverDefinition<
     undefined,
     boolean,
     'request',
@@ -177,6 +184,11 @@ const dynamicConfigs: {
   },
   WORKFLOW_DIAGNOSTICS_ENABLED: {
     resolver: workflowDiagnosticsEnabled,
+    evaluateOn: 'request',
+    isPublic: true,
+  },
+  WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED: {
+    resolver: workflowDiagnosticsInHistoryEnabled,
     evaluateOn: 'request',
     isPublic: true,
   },

--- a/src/config/dynamic/resolvers/__tests__/workflow-diagnostics-in-history-enabled.node.ts
+++ b/src/config/dynamic/resolvers/__tests__/workflow-diagnostics-in-history-enabled.node.ts
@@ -1,0 +1,48 @@
+import workflowDiagnosticsEnabled from '../workflow-diagnostics-enabled';
+import workflowDiagnosticsInHistoryEnabled from '../workflow-diagnostics-in-history-enabled';
+
+jest.mock('../workflow-diagnostics-enabled', () => jest.fn());
+
+const mockWorkflowDiagnosticsEnabled = jest.mocked(workflowDiagnosticsEnabled);
+
+describe(workflowDiagnosticsInHistoryEnabled.name, () => {
+  const originalValue =
+    process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED = originalValue;
+  });
+
+  it('returns true when the env variable is set and workflow diagnostics are enabled', async () => {
+    process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED = 'true';
+    mockWorkflowDiagnosticsEnabled.mockResolvedValue(true);
+
+    expect(await workflowDiagnosticsInHistoryEnabled()).toBe(true);
+    expect(mockWorkflowDiagnosticsEnabled).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when the env variable is unset', async () => {
+    delete process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED;
+
+    expect(await workflowDiagnosticsInHistoryEnabled()).toBe(false);
+    expect(mockWorkflowDiagnosticsEnabled).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the env variable is not "true"', async () => {
+    process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED = 'false';
+
+    expect(await workflowDiagnosticsInHistoryEnabled()).toBe(false);
+    expect(mockWorkflowDiagnosticsEnabled).not.toHaveBeenCalled();
+  });
+
+  it('returns false when workflow diagnostics are disabled', async () => {
+    process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED = 'true';
+    mockWorkflowDiagnosticsEnabled.mockResolvedValue(false);
+
+    expect(await workflowDiagnosticsInHistoryEnabled()).toBe(false);
+  });
+});

--- a/src/config/dynamic/resolvers/__tests__/workflow-diagnostics-in-history-enabled.node.ts
+++ b/src/config/dynamic/resolvers/__tests__/workflow-diagnostics-in-history-enabled.node.ts
@@ -14,7 +14,12 @@ describe(workflowDiagnosticsInHistoryEnabled.name, () => {
   });
 
   afterEach(() => {
-    process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED = originalValue;
+    if (originalValue === undefined) {
+      delete process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED;
+    } else {
+      process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED =
+        originalValue;
+    }
   });
 
   it('returns true when the env variable is set and workflow diagnostics are enabled', async () => {

--- a/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
+++ b/src/config/dynamic/resolvers/schemas/resolver-schemas.ts
@@ -97,6 +97,10 @@ const resolverSchemas: ResolverSchemas = {
     args: z.undefined(),
     returnType: z.boolean(),
   },
+  WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED: {
+    args: z.undefined(),
+    returnType: z.boolean(),
+  },
   ARCHIVAL_DEFAULT_SEARCH_ENABLED: {
     args: z.undefined(),
     returnType: z.boolean(),

--- a/src/config/dynamic/resolvers/workflow-diagnostics-in-history-enabled.ts
+++ b/src/config/dynamic/resolvers/workflow-diagnostics-in-history-enabled.ts
@@ -1,0 +1,17 @@
+import workflowDiagnosticsEnabled from './workflow-diagnostics-enabled';
+
+/**
+ * Returns whether workflow diagnostics are shown in the workflow history view.
+ *
+ * To enable, set the CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED env variable to `true`.
+ * Workflow diagnostics must also be enabled (see workflow-diagnostics-enabled.ts).
+ * For further customization, override the implementation of this resolver.
+ *
+ * @returns {Promise<boolean>} Whether workflow diagnostics are enabled in the history view.
+ */
+export default async function workflowDiagnosticsInHistoryEnabled(): Promise<boolean> {
+  return (
+    process.env.CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED === 'true' &&
+    (await workflowDiagnosticsEnabled())
+  );
+}

--- a/src/utils/config/__fixtures__/resolved-config-values.ts
+++ b/src/utils/config/__fixtures__/resolved-config-values.ts
@@ -46,6 +46,7 @@ const mockResolvedConfigValues: LoadedConfigResolvedValues = {
     issues: false,
   },
   WORKFLOW_DIAGNOSTICS_ENABLED: false,
+  WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED: false,
   ARCHIVAL_DEFAULT_SEARCH_ENABLED: false,
   BATCH_ACTIONS_UI_ENABLED: false,
   FAILOVER_HISTORY_ENABLED: false,


### PR DESCRIPTION
## Summary
New dynamic config flag `WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED` to gate the upcoming diagnostics-in-history UI. The feature itself isn't ready yet.

The resolver returns `true` only when `CADENCE_WORKFLOW_DIAGNOSTICS_IN_HISTORY_ENABLED=true` and the base `WORKFLOW_DIAGNOSTICS_ENABLED` resolver is also enabled, so it can't be on while diagnostics is off.

Also adds an `add-feature-flag` skill under `.agents/skills/` documenting the steps for adding a flag.

## Test plan
- Added unit tests for the new resolver
- `npm run typecheck`, `npm run lint`, and existing config tests pass