### PR TITLE
fix(schedules): Default decision task timeout on create and edit

### DIFF
--- a/src/route-handlers/create-schedule/helpers/__tests__/transform-create-schedule-body-to-grpc-input.node.ts
+++ b/src/route-handlers/create-schedule/helpers/__tests__/transform-create-schedule-body-to-grpc-input.node.ts
@@ -2,7 +2,6 @@ import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 
 import { DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_SECONDS } from '../../../start-workflow/start-workflow.constants';
-
 import { type CreateScheduleRequestBody } from '../../create-schedule.types';
 import transformCreateScheduleBodyToGrpcInput from '../transform-create-schedule-body-to-grpc-input';
 

--- a/src/route-handlers/create-schedule/helpers/__tests__/transform-create-schedule-body-to-grpc-input.node.ts
+++ b/src/route-handlers/create-schedule/helpers/__tests__/transform-create-schedule-body-to-grpc-input.node.ts
@@ -1,6 +1,8 @@
 import { ScheduleCatchUpPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleCatchUpPolicy';
 import { ScheduleOverlapPolicy } from '@/__generated__/proto-ts/uber/cadence/api/v1/ScheduleOverlapPolicy';
 
+import { DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_SECONDS } from '../../../start-workflow/start-workflow.constants';
+
 import { type CreateScheduleRequestBody } from '../../create-schedule.types';
 import transformCreateScheduleBodyToGrpcInput from '../transform-create-schedule-body-to-grpc-input';
 
@@ -55,6 +57,34 @@ describe(transformCreateScheduleBodyToGrpcInput.name, () => {
         input: undefined,
       })
     );
+  });
+
+  it('defaults the task start-to-close timeout when the body omits it', () => {
+    const grpc = transformCreateScheduleBodyToGrpcInput({
+      domain: 'd',
+      body: minimalBody(),
+    });
+
+    expect(grpc.action?.startWorkflow?.taskStartToCloseTimeout).toEqual({
+      seconds: DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_SECONDS,
+      nanos: 0,
+    });
+  });
+
+  it('maps the task start-to-close timeout when the body provides it', () => {
+    const grpc = transformCreateScheduleBodyToGrpcInput({
+      domain: 'd',
+      body: minimalBody({
+        startWorkflow: minimalStartWorkflow({
+          taskStartToCloseTimeoutSeconds: 30,
+        }),
+      }),
+    });
+
+    expect(grpc.action?.startWorkflow?.taskStartToCloseTimeout).toEqual({
+      seconds: 30,
+      nanos: 0,
+    });
   });
 
   it('maps ISO schedule bounds and jitter to spec timestamps and duration', () => {

--- a/src/route-handlers/create-schedule/helpers/transform-create-schedule-body-to-grpc-input.ts
+++ b/src/route-handlers/create-schedule/helpers/transform-create-schedule-body-to-grpc-input.ts
@@ -6,6 +6,7 @@ import getGrpcDurationFromSeconds from '@/utils/datetime/get-grpc-duration-from-
 import getGrpcTimestampFromIso from '@/utils/datetime/get-grpc-timestamp-from-iso';
 
 import processWorkflowInput from '../../start-workflow/helpers/process-workflow-input';
+import { DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_SECONDS } from '../../start-workflow/start-workflow.constants';
 import { type CreateScheduleRequestBody } from '../create-schedule.types';
 
 export default function transformCreateScheduleBodyToGrpcInput({
@@ -60,6 +61,12 @@ export default function transformCreateScheduleBodyToGrpcInput({
     workflowIdPrefix: startWorkflow.workflowIdPrefix?.trim() ?? '',
     executionStartToCloseTimeout: getGrpcDurationFromSeconds(
       startWorkflow.executionStartToCloseTimeoutSeconds
+    ),
+    // Cadence rejects a scheduled start with no decision task timeout, so send
+    // the same default the start-workflow route handler applies.
+    taskStartToCloseTimeout: getGrpcDurationFromSeconds(
+      startWorkflow.taskStartToCloseTimeoutSeconds ??
+        DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_SECONDS
     ),
     retryPolicy: grpcRetryPolicy,
     memo: startWorkflow.memo

--- a/src/route-handlers/create-schedule/schemas/create-schedule-request-body-schema.ts
+++ b/src/route-handlers/create-schedule/schemas/create-schedule-request-body-schema.ts
@@ -29,6 +29,7 @@ const scheduleStartWorkflowBodySchema = z.object({
   input: z.array(jsonValueSchema).optional(),
   workflowIdPrefix: z.string().optional(),
   executionStartToCloseTimeoutSeconds: z.number().positive(),
+  taskStartToCloseTimeoutSeconds: z.number().positive().optional(),
   retryPolicy: retryPolicySchema,
   memo: z.record(z.any()).optional(),
   searchAttributes: z

--- a/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/__tests__/transform-domain-schedules-create-form-to-body.test.ts
@@ -38,8 +38,26 @@ describe(transformDomainSchedulesCreateFormToBody.name, () => {
         taskList: { name: 'demo-tl' },
         workerSDKLanguage: 'GO',
         executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: undefined,
       },
     });
+  });
+
+  it('includes a task start-to-close timeout when the form has one', () => {
+    const result = transformDomainSchedulesCreateFormToBody({
+      ...mockDomainSchedulesCreateFormData,
+      taskStartToCloseTimeoutSeconds: 30,
+    });
+
+    expect(result.startWorkflow.taskStartToCloseTimeoutSeconds).toBe(30);
+  });
+
+  it('omits the task start-to-close timeout when the form has none', () => {
+    const result = transformDomainSchedulesCreateFormToBody(
+      mockDomainSchedulesCreateFormData
+    );
+
+    expect(result.startWorkflow.taskStartToCloseTimeoutSeconds).toBeUndefined();
   });
 
   it('includes parsed JSON inputs when provided', () => {

--- a/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/helpers/transform-domain-schedules-create-form-to-body.ts
@@ -39,6 +39,7 @@ export default function transformDomainSchedulesCreateFormToBody(
       workerSDKLanguage: formData.workerSDKLanguage,
       executionStartToCloseTimeoutSeconds:
         formData.executionStartToCloseTimeoutSeconds,
+      taskStartToCloseTimeoutSeconds: formData.taskStartToCloseTimeoutSeconds,
       ...(parsedInput && parsedInput.length > 0 ? { input: parsedInput } : {}),
       ...(mappedRetryPolicy ? { retryPolicy: mappedRetryPolicy } : {}),
       ...(parsedMemo ? { memo: parsedMemo } : {}),

--- a/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
+++ b/src/views/domain-schedules/domain-schedules-create-modal/schemas/create-schedule-form-schema.ts
@@ -82,6 +82,9 @@ export const createScheduleFormFieldsSchema = z.object({
       required_error: 'Execution timeout is required',
     })
     .positive('Execution timeout must be positive'),
+  // Hidden on create/edit: Cadence requires a decision-task timeout, and edit
+  // must round-trip the existing value so a full-replace update does not clobber it.
+  taskStartToCloseTimeoutSeconds: z.number().positive().optional(),
   // TODO(refactor): WORKER_SDK_LANGUAGES imported from start-workflow — extract to shared constants
   workerSDKLanguage: z.enum(WORKER_SDK_LANGUAGES, {
     required_error: 'Worker SDK is required',

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-describe-schedule-response-to-form-data.test.ts
@@ -65,6 +65,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
         workflowType: { name: 'DemoWorkflow' },
         taskList: { name: 'demo-task-list' },
         executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: 30,
         workflowIdPrefix: 'scheduled-demo-',
         workerSDKLanguage: undefined,
       })
@@ -191,6 +192,7 @@ describe(transformDescribeScheduleResponseToFormData.name, () => {
       workflowType: { name: '' },
       taskList: { name: '' },
       executionStartToCloseTimeoutSeconds: undefined,
+      taskStartToCloseTimeoutSeconds: undefined,
       workerSDKLanguage: undefined,
       input: [''],
       workflowIdPrefix: undefined,

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/__tests__/transform-edit-schedule-form-to-submission.test.ts
@@ -15,8 +15,18 @@ describe(transformEditScheduleFormToSubmission.name, () => {
         taskList: { name: 'demo-task-list' },
         workerSDKLanguage: 'GO',
         executionStartToCloseTimeoutSeconds: 3600,
+        taskStartToCloseTimeoutSeconds: undefined,
       },
     });
     expect(result).not.toHaveProperty('scheduleId');
+  });
+
+  it('keeps a prefilled task start-to-close timeout on the update body', () => {
+    const result = transformEditScheduleFormToSubmission({
+      ...mockEditScheduleFormData,
+      taskStartToCloseTimeoutSeconds: 30,
+    });
+
+    expect(result.startWorkflow.taskStartToCloseTimeoutSeconds).toBe(30);
   });
 });

--- a/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
+++ b/src/views/schedule-actions/schedule-action-edit-form/helpers/transform-describe-schedule-response-to-form-data.ts
@@ -42,6 +42,9 @@ export default function transformDescribeScheduleResponseToFormData(
     executionStartToCloseTimeoutSeconds:
       formatDurationToSeconds(startWorkflow?.executionStartToCloseTimeout) ??
       undefined,
+    taskStartToCloseTimeoutSeconds:
+      formatDurationToSeconds(startWorkflow?.taskStartToCloseTimeout) ??
+      undefined,
     // Cadence stores encoded input bytes only; the worker SDK is not persisted.
     workerSDKLanguage: undefined,
     input: parsedInput?.length


### PR DESCRIPTION
## Summary

Cadence rejects a scheduled workflow start when `taskStartToCloseTimeout` is missing. This restores that timeout on the create/update path without bringing back a visible form field: create uses the same default as start-workflow, and edit round-trips the existing value so a full-replace update does not clobber it.

## Changes

- Accept optional `taskStartToCloseTimeoutSeconds` on the create-schedule request body and form schema (still hidden in the UI).
- Default omitted values to `DEFAULT_TASK_START_TO_CLOSE_TIMEOUT_SECONDS` (10s) when mapping to gRPC.
- Prefill the hidden field from `DescribeSchedule` so edit submissions keep the current decision-task timeout.

## Testing
- Checked creation is not send by the create form
- Confirmed value was added correctly from API and reflects in the schedule describe
- Check Update keeps sending this value to backend as is


https://github.com/user-attachments/assets/186a2eff-e3dd-47bd-854f-a3140cc482e8

- Scheduler workflow is able to run workflows
<img width="1844" height="1121" alt="Screenshot 2026-09-07 at 15 29 30" src="https://github.com/user-attachments/assets/da1aeccf-aea5-4011-a1e4-af99cc5b0982" />
<img width="1718" height="1038" alt="Screenshot 2026-09-07 at 15 29 42" src="https://github.com/user-attachments/assets/0a1c7c42-6946-4ae6-bf73-f62093592733" />


